### PR TITLE
fixes logout. AGPUSH-140

### DIFF
--- a/src/main/java/org/jboss/aerogear/connectivity/rest/security/AuthenticationEndpoint.java
+++ b/src/main/java/org/jboss/aerogear/connectivity/rest/security/AuthenticationEndpoint.java
@@ -76,6 +76,7 @@ public class AuthenticationEndpoint {
         return Response.ok().build();
     }
 
+    @POST
     @Path("/logout")
     public Response logout() {
         try {


### PR DESCRIPTION
The logout endpoint method didn't have a @POST so on a "successful" logout,  the error callback on the client would receive the response instead of the success callback
