### PR TITLE
Moving query criterias into its own class

### DIFF
--- a/src/main/java/org/jboss/aerogear/connectivity/service/sender/message/SelectiveSendCriterias.java
+++ b/src/main/java/org/jboss/aerogear/connectivity/service/sender/message/SelectiveSendCriterias.java
@@ -1,0 +1,45 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright Red Hat, Inc., and individual contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.aerogear.connectivity.service.sender.message;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Simple class, containing all "query criteria" options for a message,
+ * that has been sent to the "Selective Send" HTTP endpoint.
+ */
+public class SelectiveSendCriterias {
+
+    private final List<String> aliases;
+    private final List<String> deviceTypes;
+
+    @SuppressWarnings("unchecked")
+    public SelectiveSendCriterias(Map<String, Object> data) {
+        this.aliases = (List<String>) data.remove("alias");
+        this.deviceTypes = (List<String>) data.remove("deviceType");
+    }
+
+    public List<String> getAliases() {
+        return aliases;
+    }
+    
+    public List<String> getDeviceTypes() {
+        return deviceTypes;
+    }
+}

--- a/src/main/java/org/jboss/aerogear/connectivity/service/sender/message/SelectiveSendMessage.java
+++ b/src/main/java/org/jboss/aerogear/connectivity/service/sender/message/SelectiveSendMessage.java
@@ -17,13 +17,11 @@
 
 package org.jboss.aerogear.connectivity.service.sender.message;
 
-import java.util.List;
 import java.util.Map;
 
 public class SelectiveSendMessage implements UnifiedPushMessage {
 
-    private final List<String> aliases;
-    private final List<String> deviceTypes;
+    private final SelectiveSendCriterias criterias;
 
     private final Map<String, String> simplePush;
     private final String alert;
@@ -58,9 +56,9 @@ public class SelectiveSendMessage implements UnifiedPushMessage {
      */
     @SuppressWarnings("unchecked")
     public SelectiveSendMessage(Map<String, Object> data) {
-        this.aliases = (List<String>) data.remove("alias");
-        this.deviceTypes = (List<String>) data.remove("deviceType");
-        
+        // extract all the different criterias
+        this.criterias = new SelectiveSendCriterias(data);
+
         // ======= Payload ====
         // the Android/iOS payload of the actual message:
         this.data = (Map<String, Object>) data.remove("message");
@@ -82,15 +80,10 @@ public class SelectiveSendMessage implements UnifiedPushMessage {
 
     }
 
-    public List<String> getAliases() {
-        return aliases;
+    public SelectiveSendCriterias getSendCriterias() {
+        return criterias;
     }
-    
-    public List<String> getDeviceTypes() {
-        return deviceTypes;
-    }
-    
-    
+
     public Map<String, String> getSimplePush() {
         return simplePush;
     }


### PR DESCRIPTION
refactorings, before we can/should add new criterias to the HTTP endpoint for "sending"
