### PR TITLE
Adding 'Access-Control-Max-Age' CORS header

### DIFF
--- a/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/installations/InstallationRegistrationEndpoint.java
+++ b/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/installations/InstallationRegistrationEndpoint.java
@@ -152,7 +152,9 @@ public class InstallationRegistrationEndpoint {
         response.header("Access-Control-Allow-Origin", headers.getRequestHeader("Origin").get(0)) // return submitted origin
                 .header("Access-Control-Allow-Methods", "POST, DELETE") // only POST/DELETE are allowed
                 .header("Access-Control-Allow-Headers", "accept, origin, content-type, authorization") // explicit Headers!
-                .header("Access-Control-Allow-Credentials", "true");
+                .header("Access-Control-Allow-Credentials", "true")
+                // indicates how long the results of a preflight request can be cached (in seconds)
+                .header("Access-Control-Max-Age", "604800"); // for now, we keep it for seven days
 
         return response;
     }


### PR DESCRIPTION
Header added for caching of the preflight request. Currently using a cache of seven days.

For more details, take a look at [AGPUSH-343](https://issues.jboss.org/browse/AGPUSH-343)
