### PR TITLE
Added @Produces annotations (fixes an issue in Wildfly 8b1)

### DIFF
--- a/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/AndroidVariantEndpoint.java
+++ b/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/AndroidVariantEndpoint.java
@@ -46,6 +46,7 @@ public class AndroidVariantEndpoint extends AbstractVariantEndpoint {
     // new Android
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
     public Response registerAndroidVariant(
             AndroidVariant androidVariant,
             @PathParam("pushAppID") String pushApplicationID,
@@ -91,6 +92,7 @@ public class AndroidVariantEndpoint extends AbstractVariantEndpoint {
     @PUT
     @Path("/{androidID}")
     @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
     public Response updateAndroidVariation(
             @PathParam("pushAppID") String id,
             @PathParam("androidID") String androidID,

--- a/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/ChromePackagedAppEndpoint.java
+++ b/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/ChromePackagedAppEndpoint.java
@@ -48,6 +48,7 @@ public class ChromePackagedAppEndpoint extends AbstractVariantEndpoint {
     // new Chrome Packaged App
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
     public Response registerChromePackagedAppVariant(
             ChromePackagedAppVariant chromePackagedAppVariant,
             @PathParam("pushAppID") String pushApplicationID,

--- a/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/InstallationManagementEndpoint.java
+++ b/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/InstallationManagementEndpoint.java
@@ -84,6 +84,7 @@ public class InstallationManagementEndpoint {
     @PUT
     @Path("/{installationID}")
     @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
     public Response updateInstallation(InstallationImpl entity, @PathParam("variantID") String variantId, @PathParam("installationID") String installationId) {
 
         InstallationImpl installation = clientInstallationService.findById(installationId);
@@ -100,6 +101,7 @@ public class InstallationManagementEndpoint {
 
     @DELETE
     @Path("/{installationID}")
+    @Produces(MediaType.APPLICATION_JSON)
     public Response removeInstallation(@PathParam("variantID") String variantId, @PathParam("installationID") String installationId) {
 
         InstallationImpl installation = clientInstallationService.findById(installationId);

--- a/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/PushApplicationEndpoint.java
+++ b/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/PushApplicationEndpoint.java
@@ -59,6 +59,7 @@ public class PushApplicationEndpoint extends AbstractBaseEndpoint {
     // CREATE
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
     public Response registerPushApplication(PushApplication pushApp) {
 
         // some validation
@@ -105,6 +106,7 @@ public class PushApplicationEndpoint extends AbstractBaseEndpoint {
     @PUT
     @Path("/{pushAppID}")
     @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
     public Response updatePushApplication(@PathParam("pushAppID") String pushApplicationID, PushApplication updatedPushApp) {
 
         PushApplication pushApp = pushAppService.findByPushApplicationIDForDeveloper(pushApplicationID, loginName.get());
@@ -137,6 +139,7 @@ public class PushApplicationEndpoint extends AbstractBaseEndpoint {
     @PUT
     @Path("/{pushAppID}/reset")
     @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
     public Response resetMasterSecret(@PathParam("pushAppID") String pushApplicationID) {
 
         PushApplication pushApp = pushAppService.findByPushApplicationIDForDeveloper(pushApplicationID, loginName.get());
@@ -156,6 +159,7 @@ public class PushApplicationEndpoint extends AbstractBaseEndpoint {
     // DELETE
     @DELETE
     @Path("/{pushAppID}")
+    @Produces(MediaType.APPLICATION_JSON)
     public Response deletePushApplication(@PathParam("pushAppID") String pushApplicationID) {
 
         PushApplication pushApp = pushAppService.findByPushApplicationIDForDeveloper(pushApplicationID, loginName.get());

--- a/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/SimplePushVariantEndpoint.java
+++ b/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/SimplePushVariantEndpoint.java
@@ -46,6 +46,7 @@ public class SimplePushVariantEndpoint extends AbstractVariantEndpoint {
     // new SimplePush
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
     public Response registerSimplePushVariant(
             SimplePushVariant simplePushVariant,
             @PathParam("pushAppID") String pushApplicationID,
@@ -92,6 +93,7 @@ public class SimplePushVariantEndpoint extends AbstractVariantEndpoint {
     @PUT
     @Path("/{simplePushID}")
     @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
     public Response updateSimplePushVariation(
             @PathParam("pushAppID") String id,
             @PathParam("simplePushID") String simplePushID,


### PR DESCRIPTION
This works around the following exceptions:

21:37:17,547 WARN  [org.jboss.resteasy.core.ExceptionHandler](default task-17) Failed executing POST /applications/2086d764-a9c9-4bb1-ac98-94265c65ba3c/android: org.jboss.resteasy.core.NoMessageBodyWriterFoundFailure: Could not find MessageBodyWriter for response object of type: org.jboss.aerogear.unifiedpush.model.AndroidVariant of media type: application/octet-stream
    at org.jboss.resteasy.core.ServerResponseWriter.writeNomapResponse(ServerResponseWriter.java:67) [resteasy-jaxrs-3.0.4.Final.jar:]
    at org.jboss.resteasy.core.SynchronousDispatcher.writeResponse(SynchronousDispatcher.java:411) [resteasy-jaxrs-3.0.4.Final.jar:]
    at org.jboss.resteasy.core.SynchronousDispatcher.invoke(SynchronousDispatcher.java:376) [resteasy-jaxrs-3.0.4.Final.jar:]
    at org.jboss.resteasy.core.SynchronousDispatcher.invoke(SynchronousDispatcher.java:179) [resteasy-jaxrs-3.0.4.Final.jar:]
    at org.jboss.resteasy.plugins.server.servlet.ServletContainerDispatcher.service(ServletContainerDispatcher.java:220) [resteasy-jaxrs-3.0.4.Final.jar:]
    at org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher.service(HttpServletDispatcher.java:56) [resteasy-jaxrs-3.0.4.Final.jar:]
    at org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher.service(HttpServletDispatcher.java:51) [resteasy-jaxrs-3.0.4.Final.jar:]
    at javax.servlet.http.HttpServlet.service(HttpServlet.java:790) [jboss-servlet-api_3.1_spec-1.0.0.Beta1.jar:1.0.0.Beta1]
    at io.undertow.servlet.handlers.ServletHandler.handleRequest(ServletHandler.java:87) [undertow-servlet-1.0.0.Beta17.jar:1.0.0.Beta17]
    at io.undertow.servlet.handlers.security.ServletSecurityRoleHandler.handleRequest(ServletSecurityRoleHandler.java:59) [undertow-servlet-1.0.0.Beta17.jar:1.0.0.Beta17]
    at io.undertow.servlet.handlers.ServletDispatchingHandler.handleRequest(ServletDispatchingHandler.java:36) [undertow-servlet-1.0.0.Beta17.jar:1.0.0.Beta17]
    at org.wildfly.extension.undertow.security.SecurityContextAssociationHandler.handleRequest(SecurityContextAssociationHandler.java:81)
    at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:25) [undertow-core-1.0.0.Beta17.jar:1.0.0.Beta17]
    at io.undertow.servlet.handlers.security.SSLInformationAssociationHandler.handleRequest(SSLInformationAssociationHandler.java:113) [undertow-servlet-1.0.0.Beta17.jar:1.0.0.Beta17]
    at io.undertow.security.handlers.AuthenticationCallHandler.handleRequest(AuthenticationCallHandler.java:52) [undertow-core-1.0.0.Beta17.jar:1.0.0.Beta17]
    at io.undertow.security.handlers.AbstractConfidentialityHandler.handleRequest(AbstractConfidentialityHandler.java:45) [undertow-core-1.0.0.Beta17.jar:1.0.0.Beta17]
    at io.undertow.servlet.handlers.security.CachedAuthenticatedSessionHandler.handleRequest(CachedAuthenticatedSessionHandler.java:65) [undertow-servlet-1.0.0.Beta17.jar:1.0.0.Beta17]
    at io.undertow.security.handlers.SecurityInitialHandler.handleRequest(SecurityInitialHandler.java:70) [undertow-core-1.0.0.Beta17.jar:1.0.0.Beta17]
    at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:25) [undertow-core-1.0.0.Beta17.jar:1.0.0.Beta17]
    at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:25) [undertow-core-1.0.0.Beta17.jar:1.0.0.Beta17]
    at io.undertow.servlet.handlers.ServletInitialHandler.handleFirstRequest(ServletInitialHandler.java:218) [undertow-servlet-1.0.0.Beta17.jar:1.0.0.Beta17]
    at io.undertow.servlet.handlers.ServletInitialHandler.dispatchRequest(ServletInitialHandler.java:205) [undertow-servlet-1.0.0.Beta17.jar:1.0.0.Beta17]
    at io.undertow.servlet.handlers.ServletInitialHandler.access$000(ServletInitialHandler.java:69) [undertow-servlet-1.0.0.Beta17.jar:1.0.0.Beta17]
    at io.undertow.servlet.handlers.ServletInitialHandler$1.handleRequest(ServletInitialHandler.java:134) [undertow-servlet-1.0.0.Beta17.jar:1.0.0.Beta17]
    at io.undertow.server.HttpHandlers.executeRootHandler(HttpHandlers.java:36) [undertow-core-1.0.0.Beta17.jar:1.0.0.Beta17]
    at io.undertow.server.HttpServerExchange$1.run(HttpServerExchange.java:619) [undertow-core-1.0.0.Beta17.jar:1.0.0.Beta17]
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145) [rt.jar:1.7.0_45]
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615) [rt.jar:1.7.0_45]
    at java.lang.Thread.run(Thread.java:744) [rt.jar:1.7.0_45]
