### PR TITLE
Upgrade push server to AG sec 1.3.1-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -277,8 +277,8 @@
         -->
         <maven.compiler.argument.target>${maven.compiler.target}</maven.compiler.argument.target>
         <maven.compiler.argument.source>${maven.compiler.source}</maven.compiler.argument.source>
-        <aerogear.security.version>1.2.1</aerogear.security.version>
-        <aerogear.security.picketlink.version>1.2.2</aerogear.security.picketlink.version>
+        <aerogear.security.version>1.3.1-SNAPSHOT</aerogear.security.version>
+        <aerogear.security.picketlink.version>1.3.1-SNAPSHOT</aerogear.security.picketlink.version>
 
     </properties>
 


### PR DESCRIPTION
This is the fix to https://issues.jboss.org/browse/AGSEC-164. After we test it against the push server we might be good to release 1.3.1 this week.

Is not necessary to build ag-sec, ag-sec-plink once it was released on nexus under snapshot repositories.
