### PR TITLE
Adding database configuration scripts for WildFly

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,20 @@ The H2 database is included in the JBoss AS and is pretty easy to install. First
 ./standalone.sh
 ```
 
-and afterwards issue the following command:
+and afterwards issue one of the follwing command line interface script depending on if your are using JBoss AS 7.x or WildFly:
+
+For JBoss AS 7.x:
 
 ```
 /Path/to/JBossAS/bin/jboss-cli.sh --file=./databases/h2-database-config.cli
 ```
+
+For WildFly:
+
+```
+/Path/to/WildFly/bin/jboss-cli.sh --file=./databases/h2-database-config-wildfly.cli
+```
+
 
 The above script will add the _UnifiedPushDS datasource_, inside of the application server (```${jboss.server.data.dir}/unifiedpush```).
 
@@ -82,10 +91,19 @@ Next, start your server:
 ```
 ./standalone.sh
 ```
-Finally, run the follwing command line interface script:
+
+Finally, run one of the follwing command line interface script depending on if your are using JBoss AS 7.x or WildFly:
+
+For JBoss AS 7.x:
 
 ```
 /Path/to/JBossAS/bin/jboss-cli.sh --file=./databases/mysql-database-config.cli
+```
+
+For WildFly:
+
+```
+/Path/to/WildFly/bin/jboss-cli.sh --file=./databases/mysql-database-config-wildfly.cli
 ```
 
 The above script will add the mysql driver and a datasource.
@@ -130,10 +148,19 @@ Next, start your server:
 ```
 ./standalone.sh
 ```
-Finally, run the follwing command line interface script:
+
+Finally, run one of the follwing command line interface script depending on if your are using JBoss AS 7.x or WildFly:
+
+For JBoss AS 7.x:
 
 ```
 /Path/to/JBossAS/bin/jboss-cli.sh --file=./databases/postgresql-database-config.cli
+```
+
+For WildFly:
+
+```
+/Path/to/WildFly/bin/jboss-cli.sh --file=./databases/postgresql-database-config-wildfly.cli
 ```
 
 The above script will add the postgresql driver and a datasource.

--- a/databases/h2-database-config-wildfly.cli
+++ b/databases/h2-database-config-wildfly.cli
@@ -1,0 +1,9 @@
+# $WILDFLY_HOME/bin/jboss-cli.sh --file=/path/to/this/file.
+connect
+batch
+
+## Add SimplePush Datasource
+data-source add --name=UnifiedPushDS --driver-name=h2 --jndi-name=java:jboss/datasources/UnifiedPushDS --connection-url="jdbc:h2:${jboss.server.data.dir}/unifiedpush;DB_CLOSE_DELAY=-1" --user-name=sa --password=sa --use-ccm=true --enabled=true
+
+run-batch
+#:reload

--- a/databases/mysql-database-config-wildfly.cli
+++ b/databases/mysql-database-config-wildfly.cli
@@ -1,0 +1,12 @@
+# $WILDFLY_HOME/bin/jboss-cli.sh --file=/path/to/this/file.
+connect
+batch
+
+## Add Mysql driver
+/subsystem=datasources/jdbc-driver=mysqlup:add(driver-name=mysqlup,driver-module-name=com.mysql.jdbc,driver-xa-datasource-class-name=com.mysql.jdbc.jdbc2.optional.MysqlXADataSource)
+
+## Add PushEE Mysql Datasource
+data-source add --name=UnifiedPushDS --driver-name=mysqlup --jndi-name=java:jboss/datasources/UnifiedPushDS --connection-url=jdbc:mysql://localhost:3306/unifiedpush?useUnicode=true&amp;characterEncoding=UTF-8 --user-name=unifiedpush --password=unifiedpush --use-ccm=false --max-pool-size=25 --blocking-timeout-wait-millis=5000 --enabled=true
+
+run-batch
+#:reload

--- a/databases/postgresql-database-config-wildfly.cli
+++ b/databases/postgresql-database-config-wildfly.cli
@@ -1,0 +1,12 @@
+# $WILDFLY_HOME/bin/jboss-cli.sh --file=/path/to/this/file.
+connect
+batch
+
+## Add Postgresql driver
+/subsystem=datasources/jdbc-driver=psqlup:add(driver-name=psqlup,driver-module-name=org.postgresql,driver-xa-datasource-class-name=org.postgresql.xa.PGXADataSource)
+
+## Add PushEE Postgresql Datasource
+data-source add --name=UnifiedPushDS --driver-name=psqlup --jndi-name=java:jboss/datasources/UnifiedPushDS --connection-url=jdbc:postgresql://localhost:5432/unifiedpush --user-name=unifiedpush --password=unifiedpush --use-ccm=false --max-pool-size=25 --blocking-timeout-wait-millis=5000 --enabled=true
+
+run-batch
+#:reload


### PR DESCRIPTION
The current database configuration scripts don't work with WildFly and
only with AS 7.x. Adding separate configurations for WildFly will
simplify setup for our users.
