### PR TITLE
No need to generate JavaDocs for internal server bits

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,22 @@
         </dependencies>
     </dependencyManagement>
 
+    <build>
+        <plugins>
+            <!-- we really do not need javadocs for the server, there are no Java APIs exposed -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <phase>none</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -251,18 +251,6 @@
                 <artifactId>jboss-as-maven-plugin</artifactId>
                 <version>7.4.Final</version>
             </plugin>
-
-            <!-- we really do not need javadocs for the server, there are no Java APIs exposed -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <phase>none</phase>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Since for the server do not publish JavaDocs (as the JARs are not used on 3rd party applications to be programmed against (they are basically no API)), I have overridden the default from aerogear-parent and explicitly disabled the JavaDoc generation; 
