### PR TITLE
Fix url pattern for device unregistration.

### DIFF
--- a/server/src/main/webapp/WEB-INF/web.xml
+++ b/server/src/main/webapp/WEB-INF/web.xml
@@ -47,7 +47,7 @@
         <web-resource-collection>
             <web-resource-name>HttpBasic</web-resource-name>
             <description>Matches a few special URLs.</description>
-            <url-pattern>/rest/registry/device</url-pattern>
+            <url-pattern>/rest/registry/device/*</url-pattern>
             <url-pattern>/rest/sender</url-pattern>
         </web-resource-collection>
         <!-- No auth-constraint does the exclude! -->


### PR DESCRIPTION
Without this fix, registration was working, but when unregistration was tried, it sent 302 redirect to keycloak.
