### PR TITLE
Explicit declaration of codehaus.jackson dependencies

### DIFF
--- a/model/api/pom.xml
+++ b/model/api/pom.xml
@@ -47,7 +47,6 @@
         <dependency>
             <groupId>org.codehaus.jackson</groupId>
             <artifactId>jackson-core-asl</artifactId>
-            <version>1.9.13</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,23 @@
                 <version>${hibernate.version}</version>
             </dependency>
 
+            <dependency>
+                <groupId>org.codehaus.jackson</groupId>
+                <artifactId>jackson-core-asl</artifactId>
+                <version>${codehaus.jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.codehaus.jackson</groupId>
+                <artifactId>jackson-mapper-asl</artifactId>
+                <version>${codehaus.jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.codehaus.jackson</groupId>
+                <artifactId>jackson-xc</artifactId>
+                <version>${codehaus.jackson.version}</version>
+            </dependency>
+
+
             <!-- Has to be added in aerogear-bom-->
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>
@@ -358,6 +375,7 @@
         <org.bouncycastle.version>1.46</org.bouncycastle.version>
         <freemarker.version>2.3.19</freemarker.version>
         <zxing.version>2.2</zxing.version>
+        <codehaus.jackson.version>1.9.9</codehaus.jackson.version>
 
         <!-- Code coverage -->
         <org.jacoco.ant.version>0.6.3.201306030806</org.jacoco.ant.version>


### PR DESCRIPTION
Explicit declaration of codehaus.jackson dependencies, as they will be shipped. Use of version 1.9.9 of codehaus.jackson for better dependency alignment
