### PR TITLE
ui: App tile actions. Change entry points to Activity and Send Push

### DIFF
--- a/admin-ui/app/directives/variant-details.html
+++ b/admin-ui/app/directives/variant-details.html
@@ -19,9 +19,9 @@
             <a data-toggle="dropdown" class="dropdown-toggle" href="#"><i class="fa fa-cog"></i> <i class="fa fa-caret-down"></i></a>
             <ul class="dropdown-menu">
                 <li><a role="menuitem" ng-click="editVariant(variant, type)">Edit...</a></li>
+                <li><a role="menuitem" href="#/activity/{{applicationId}}/{{variant.variantID}}">Activity</a></li>
                 <li role="presentation" class="divider"></li>
                 <li><a role="menuitem" ng-click="removeVariant(variant, type)">Remove...</a></li>
-                <li><a role="menuitem" href="#/activity/{{applicationId}}/{{variant.variantID}}">Metrics</a></li>
             </ul>
         </div>
         <div class="ups-toggle-box" collapse="isCollapsed(variant)">
@@ -39,6 +39,7 @@
                     <tr><td>Client Secret:</td><td>{{ variant.clientSecret }}</td></tr>
                     <tr><td>Refresh Token:</td><td>{{ variant.refreshToken }}</td></tr>
                 </table>
+                <p ng-show="variant.type == 'SIMPLE_PUSH'">This server's <em>SimplePush</em> implementation will be used.</p>
             </div>
             <br><br>
             <div class="ups-tip-panel">

--- a/admin-ui/app/views/applications.html
+++ b/admin-ui/app/views/applications.html
@@ -5,7 +5,7 @@
 
             <div class="lo-page-info">
                 <p>
-                    You have <ups-pluralize count="applications.length" zero="no" noun="application"></ups-pluralize>.
+                    You have <ups-pluralize noun="application" count="applications.length"></ups-pluralize>.
                 </p>
 
                 <div class="pull-right">
@@ -14,7 +14,7 @@
             </div>
             <div class="panel panel-default lo-panel lo-panel-storage" ng-repeat="application in applications">
                 <div class="panel-heading">
-                    <a href="#/detail/{{application.pushApplicationID}}">{{ application.name }}</a>
+                    <h3 class="panel-title"><a href="#/detail/{{application.pushApplicationID}}">{{ application.name }}</a></h3>
                     <div class="dropdown">
                         <a class="dropdown-toggle">
                             <i class="fa fa-cog"></i> <i class="fa fa-caret-down"></i></b>
@@ -23,16 +23,17 @@
                             <li><a role="menuitem" tabindex="-1" ng-click="edit(application)">Edit...</a></li>
                             <li class="divider"></li>
                             <li><a role="menuitem" tabindex="-1" ng-click="remove(application)">Remove...</a></li>
-                            <li><a role="menuitem" tabindex="-1" href="#/activity/{{application.pushApplicationID}}">Metrics</a></li>
                         </ul>
                     </div>
                 </div>
                 <div class="panel-body">
-                    <p ng-show="application.description.length"><em>&ldquo;{{ application.description }}&rdquo;</em></p>
-                    <p>
-                        <ups-pluralize noun="variant" count="application.androidVariants.length + application.simplePushVariants.length +
-                            application.iosvariants.length + application.chromePackagedAppVariants.length"></ups-pluralize>
-                    </p>
+                    <p ng-show="application.description.length"><em>&ldquo;{{ application.description }}&rdquo;</em><br><br></p>
+                    <ul class="lo-app-opts">
+                      <li><i class="fa fa-cubes"></i><a href="#/detail/{{application.pushApplicationID}}"><ups-pluralize noun="variant" count="application.androidVariants.length + application.simplePushVariants.length +
+                            application.iosvariants.length + application.chromePackagedAppVariants.length"></ups-pluralize></a></li>
+                      <li><i class="fa fa-tachometer"></i><a href="#/activity/{{application.pushApplicationID}}">Activity</a></li>
+                      <li><i class="fa fa-send"></i><a href="#/compose/{{ application.pushApplicationID }}">Send Push</a></li>
+                    </ul>
                 </div>
             </div>
         </div>

--- a/admin-ui/app/views/detail.html
+++ b/admin-ui/app/views/detail.html
@@ -5,11 +5,6 @@
 
             <div class="lo-page-info">
                 <p ng-show="application.description.length"><em>&ldquo;{{ application.description }}&rdquo;</em></p>
-                <div class="pull-right">
-                    <a href="#/compose/{{ application.pushApplicationID }}" class="btn btn-default btn-lg" type="button">Send Push...</a>
-                    <button class="btn btn-primary btn-lg" type="button" ng-click="addVariant()">Add Variant...</button>
-                </div>
-
                 <div style="clear: both;"></div>
             </div>
 
@@ -23,7 +18,6 @@
                             <a data-toggle="dropdown" class="dropdown-toggle" href="#"><i class="fa fa-cog"></i> <i class="fa fa-caret-down"></i></a>
                             <ul class="dropdown-menu">
                                 <li><a role="menuitem" ng-click="renewMasterSecret()">Renew Master Secret...</a></li>
-                                <li><a role="menuitem" href="#/activity/{{application.pushApplicationID}}">Metrics</a></li>
                             </ul>
                         </div>
                     </h2>
@@ -45,10 +39,19 @@
                 <div style="clear: both;"></div>
             </div>
 
-            <h3>Variants</h3>
-            <div class="lo-panel ups-panel-variants" ng-if="application.androidVariants.length == 0 && application.iosvariants.length == 0 && application.chromePackagedAppVariants.length == 0 && application.simplePushVariants.length == 0">
-              <button class="btn btn-primary btn-lg" type="button" ng-click="addVariant()">Add Variant...</button>
+            <h2>Variants</h2>
+
+            <div class="lo-page-info">
+                <p>
+                    You have <ups-pluralize noun="variant" count="application.androidVariants.length + application.iosvariants.length + application.chromePackagedAppVariants.length + application.simplePushVariants.length"></ups-pluralize>.
+                </p>
+                <div class="pull-right">
+                    <button class="btn btn-primary btn-lg" type="button" ng-click="addVariant()">Add Variant</button>
+                </div>
+
+                <div style="clear: both;"></div>
             </div>
+
             <div class="panel lo-panel ups-panel-variants android" ng-if="application.androidVariants.length != 0">
                 <div class="panel-heading">
                     <div class="pull-left"><h2>Android</h2></div>


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/AGPUSH-741
- adds app tile icons to apps page and Push Network Details for SimplePush variants on details page.
- removes Send Push button from details page to reduce noise since this feature can now be accessed from the apps page.
- Minor visual tweaks
