### PR TITLE
compile angular templates to one file + optimize assets

### DIFF
--- a/admin-ui/Gruntfile.js
+++ b/admin-ui/Gruntfile.js
@@ -30,6 +30,7 @@ module.exports = function (grunt) {
 
   grunt.initConfig({
     yeoman: yeomanConfig,
+    local: {},
     less: {
       main: {
         options: {
@@ -124,27 +125,18 @@ module.exports = function (grunt) {
         '<%= yeoman.app %>/scripts/{,*/}*.js'
       ]
     },
-    // not used since Uglify task does concat,
-    // but still available if needed
-    /*concat: {
-     dist: {}
-     },*/
-    rev: {
+    filerev: {
       dist: {
-        files: {
-          src: [
-            '<%= yeoman.dist %>/scripts/{,*/}*.js',
-            '<%= yeoman.dist %>/styles/{,*/}*.css',
-            '<%= yeoman.dist %>/img/{,*/}*.{png,jpg,jpeg,gif,webp,svg}'
-          ]
-        }
+        src: [
+          '<%= yeoman.dist %>/scripts/{,*/}*.js',
+          '<%= yeoman.dist %>/styles/{,*/}*.css',
+          '<%= yeoman.dist %>/img/{,*/}*.{png,jpg,jpeg,gif,webp,svg}'
+        ]
       }
     },
     useminPrepare: {
       html: [
-        '<%= yeoman.app %>/index.html',
-        '<%= yeoman.app %>/directives/{,*/}*.html',
-        '<%= yeoman.app %>/views/{,*/}*.html'
+        '<%= yeoman.app %>/index.html'
       ],
       options: {
         dest: '<%= yeoman.dist %>'
@@ -244,9 +236,7 @@ module.exports = function (grunt) {
               '*.{ico,txt}',
               '.htaccess',
               'keycloak.json',
-              'img/{,*/}*.{webp,gif,png,svg}',
-              'directives/**',
-              'views/**'
+              'img/{,*/}*.{webp,gif,png,svg}'
             ]
           },
           {
@@ -349,6 +339,33 @@ module.exports = function (grunt) {
         ]
       }
     },
+    uglify: {
+      options: {
+        mangle: false,
+        compress: true,
+        report: true
+      }
+    },
+    cssmin: {
+      options: {
+        report: 'min'
+      }
+    },
+    ngtemplates:  {
+      upsConsole: {
+        src: [
+          'directives/**.html',
+          'views/**.html',
+          'views/dialogs/**.html',
+          'views/include/**.html'
+        ],
+        cwd: '<%= yeoman.app %>',
+        dest: '<%= yeoman.tmp %>/ngtemplates/templates.js',
+        options:    {
+          usemin: 'scripts/templates.js'
+        }
+      }
+    },
     bower: {
       install: {
         options: {
@@ -387,13 +404,15 @@ module.exports = function (grunt) {
     'less',
     'copy:fonts',
     'useminPrepare',
+    'ngtemplates',
     'imagemin',
     'htmlmin',
     'concat',
-//    'ngmin:dist',
-//    'uglify',
+    'cssmin',
+    'ngmin:dist',
+    'uglify',
     'copy:dist',
-    'rev',
+    'filerev',
     'usemin'
   ]);
 
@@ -411,6 +430,7 @@ module.exports = function (grunt) {
   ]);
 
   grunt.registerTask('jbosswebDist', [
+    'initLocalConfig',
     'dist',
     'clean:jbosswebDist',
     'copy:jbosswebDist'

--- a/admin-ui/app/index.html
+++ b/admin-ui/app/index.html
@@ -137,5 +137,8 @@
 <script src="scripts/directives.js"></script>
 <!-- endbuild -->
 
+<!-- build:js scripts/templates.js -->
+<!-- endbuild -->
+
 </body>
 </html>

--- a/admin-ui/package.json
+++ b/admin-ui/package.json
@@ -7,7 +7,7 @@
     "grunt-contrib-copy": "~0.4.1",
     "grunt-contrib-less": "~0.11.3",
     "grunt-contrib-concat": "~0.3.0",
-    "grunt-contrib-uglify": "~0.2.0",
+    "grunt-contrib-uglify": "~0.5.0",
     "grunt-contrib-jshint": "~0.6.0",
     "grunt-contrib-cssmin": "~0.6.0",
     "grunt-contrib-clean": "~0.5.0",
@@ -15,9 +15,9 @@
     "grunt-contrib-imagemin": "~0.2.0",
     "grunt-contrib-watch": "~0.5.2",
     "grunt-autoprefixer": "~0.2.0",
-    "grunt-usemin": "~0.1.11",
+    "grunt-usemin": "~2.0.0",
     "grunt-svgmin": "~0.2.0",
-    "grunt-rev": "~0.1.0",
+    "grunt-filerev": "^0.2.1",
     "grunt-concurrent": "~0.3.0",
     "load-grunt-tasks": "~0.1.0",
     "grunt-google-cdn": "~0.2.0",
@@ -30,7 +30,8 @@
     "grunt-karma": "~0.8.2",
     "grunt-newer": "~0.7.0",
     "grunt-bower-task": "^0.3.4",
-    "grunt-cli": "^0.1.13"
+    "grunt-cli": "^0.1.13",
+    "grunt-angular-templates": "^0.5.5"
   },
   "engines": {
     "node": ">=0.8.0"


### PR DESCRIPTION
https://issues.jboss.org/browse/AGPUSH-718
- we are compiling angular directives and views to 'templates.js' file
- additionally I have added support for minification + uglification of JS and CSS assets (this was required in order to bundle link from index.html to templates.js so I did it at once)
