### PR TITLE
Removing duplicated call

### DIFF
--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/installations/InstallationRegistrationEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/installations/InstallationRegistrationEndpoint.java
@@ -107,8 +107,6 @@ public class InstallationRegistrationEndpoint {
             logger.log(Level.FINEST, "Performing new device/client registration");
             // store the installation:
             clientInstallationService.addInstallation(variant, entity);
-            // add installation to the matching variant
-            genericVariantService.addInstallation(variant, entity);
         } else {
             // We only update the metadata, if the device is enabled: 
             if (installation.isEnabled()) {

--- a/service/src/main/java/org/jboss/aerogear/unifiedpush/service/GenericVariantService.java
+++ b/service/src/main/java/org/jboss/aerogear/unifiedpush/service/GenericVariantService.java
@@ -16,7 +16,6 @@
  */
 package org.jboss.aerogear.unifiedpush.service;
 
-import org.jboss.aerogear.unifiedpush.api.Installation;
 import org.jboss.aerogear.unifiedpush.api.Variant;
 
 /**
@@ -48,14 +47,6 @@ public interface GenericVariantService {
      * See that variant exists for developer
      */
     boolean existsVariantIDForDeveloper(String variantID, String loginName);
-
-    /**
-     * Adds a installation (device/client) to the given variant
-     *
-     * @param variant the container/owner the installation belongs to
-     * @param installation the device/client to be registered
-     */
-    void addInstallation(Variant variant, Installation installation);
 
     /**
      * Removes the given variant entity.

--- a/service/src/main/java/org/jboss/aerogear/unifiedpush/service/impl/GenericVariantServiceImpl.java
+++ b/service/src/main/java/org/jboss/aerogear/unifiedpush/service/impl/GenericVariantServiceImpl.java
@@ -16,7 +16,6 @@
  */
 package org.jboss.aerogear.unifiedpush.service.impl;
 
-import org.jboss.aerogear.unifiedpush.api.Installation;
 import org.jboss.aerogear.unifiedpush.api.Variant;
 import org.jboss.aerogear.unifiedpush.dao.VariantDao;
 import org.jboss.aerogear.unifiedpush.service.GenericVariantService;
@@ -46,13 +45,6 @@ public class GenericVariantServiceImpl implements GenericVariantService {
     @Override
     public boolean existsVariantIDForDeveloper(String variantID, String loginName) {
         return variantDao.existsVariantIDForDeveloper(variantID, loginName);
-    }
-
-    @Override
-    public void addInstallation(Variant variant, Installation installation) {
-
-        installation.setVariant(variant);
-        variantDao.update(variant);
     }
 
     @Override


### PR DESCRIPTION
The `clientInstallationService.addInstallation` above now performs the same code than the removed line in the endpoint.

Getting entirely rid of that `genericVariantService.addInstallation` "API"
