### PR TITLE
Adding REST spec docs for HTTP Basic endpoints

### DIFF
--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -97,6 +97,44 @@
         </dependency>
 
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>jax-rs-docs</id>
+                        <phase>generate-resources</phase>
+                        <configuration>
+                            <doclet>com.lunatech.doclets.jax.jaxrs.JAXRSDoclet</doclet>
+                            <docletArtifacts>
+                                <docletArtifact>
+                                    <groupId>com.lunatech.jax-doclets</groupId>
+                                    <artifactId>doclets</artifactId>
+                                    <version>0.10.0</version>
+                                </docletArtifact>
+                            </docletArtifacts>
+                            <detectOfflineLinks>false</detectOfflineLinks>
+                            <offlineLinks>
+                                <offlineLink>
+                                    <url>../javadocs</url>
+                                    <location>${project.basedir}/../target/site/apidocs</location>
+                                </offlineLink>
+                            </offlineLinks>
+                            <additionalparam>-disablehttpexample -disablejavascriptexample</additionalparam>
+                            <!-- only document the BASIC protected URIs for sender and (un)registration -->
+                            <excludePackageNames>org.jboss.aerogear.unifiedpush.rest.metrics:org.jboss.aerogear.unifiedpush.rest.registry.applications:*.util.*</excludePackageNames>
+                        </configuration>
+                        <goals>
+                            <goal>javadoc</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
     
     <profiles>
         <profile>

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/installations/InstallationRegistrationEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/installations/InstallationRegistrationEndpoint.java
@@ -68,6 +68,33 @@ public class InstallationRegistrationEndpoint {
         return appendPreflightResponseHeaders(headers, Response.ok()).build();
     }
 
+    /**
+     * RESTful API for Device registration.
+     * The Endpoint is protected using <code>HTTP Basic</code> (credentials <code>VariantID:secret</code>).
+     *
+     * <pre>
+     * curl -3 -u "variantID:secret"
+     *   -v -H "Accept: application/json" -H "Content-type: application/json"
+     *   -X POST
+     *   -d '{
+     *     "deviceToken" : "someTokenString",
+     *     "deviceType" : "iPad",
+     *     "operatingSystem" : "iOS",
+     *     "osVersion" : "6.1.2",
+     *     "alias" : "someUsername or email adress...",
+     *     "categories" : ["football", "sport"],
+     *     "simplePushEndpoint" : "http://server.com/someEndpoint"
+     *   }'
+     *   https://SERVER:PORT/context/rest/registry/device
+     * </pre>
+     *
+     * Details about JSON format can be found HERE!
+     *
+     * @HTTP 200 (OK) Successful storage of the device metadata.
+     * @HTTP 400 (Bad Request) The format of the client request was incorrect (e.g. missing required values).
+     * @HTTP 401 (Unauthorized) The request requires authentication.
+     * @HTTP 404 (Not Found) The requested Variant resource does not exist.
+     */
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
@@ -119,6 +146,21 @@ public class InstallationRegistrationEndpoint {
         return appendAllowOriginHeader(Response.ok(entity), request);
     }
 
+    /**
+     * RESTful API for Device unregistration.
+     * The Endpoint is protected using <code>HTTP Basic</code> (credentials <code>VariantID:secret</code>).
+     *
+     * <pre>
+     * curl -3 -u "variantID:secret"
+     *   -v -H "Accept: application/json" -H "Content-type: application/json"
+     *   -X DELETE
+     *   https://SERVER:PORT/context/rest/registry/device/{token}
+     * </pre>
+     *
+     * @HTTP 204 (OK) Successful unregistration.
+     * @HTTP 401 (Unauthorized) The request requires authentication.
+     * @HTTP 404 (Not Found) The requested device metadata does not exist.
+     */
     @DELETE
     @Path("{token}")
     public Response unregisterInstallations(

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/sender/PushNotificationSenderEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/sender/PushNotificationSenderEndpoint.java
@@ -48,6 +48,44 @@ public class PushNotificationSenderEndpoint {
     @Inject
     private SenderService senderService;
 
+    /**
+     * RESTful API for sending Push Notifications.
+     * The Endpoint is protected using <code>HTTP Basic</code> (credentials <code>PushApplicationID:masterSecret</code>).
+     * <p/><p/>
+     *
+     * Messages are submitted as flexible JSON maps, like:
+     * <pre>
+     * curl -3 -u "PushApplicationID:MasterSecret"
+     *   -v -H "Accept: application/json" -H "Content-type: application/json"
+     *   -X POST
+     *   -d '{
+     *     "alias" : ["someUsername"],
+     *     "deviceType" : ["someDevice"],
+     *     "categories" : ["someCategories"],
+     *     "variants" : ["someVariantIDs"],
+     *     "ttl" : 3600,
+     *     "message":
+     *     {
+     *       "key":"value",
+     *       "key2":"other value",
+     *       "alert":"HELLO!",
+     *       "action-category":"some value",
+     *       "sound":"default",
+     *       "badge":2,
+     *       "content-available" : true
+     *     },
+     *     "simple-push":"version=123"
+     *   }'
+     *   https://SERVER:PORT/CONTEXT/rest/sender
+     * </pre>
+     *
+     * Details about the Message Format can be found HERE!
+     *
+     * @HTTP 200 (OK) Indicates the Job has been accepted and is being process by the AeroGear UnifiedPush Server.
+     * @HTTP 401 (Unauthorized) The request requires authentication.
+     * @HTTP 404 (Not Found) The requested PushApplication resource does not exist.
+     * @RequestHeader aerogear-sender The header to identify the used client. If the header is not present, the standard "user-agent" header is used.
+     */
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     public Response send(final Map<String, Object> message, @Context HttpServletRequest request) {


### PR DESCRIPTION
Done for [AGPUSH-859](https://issues.jboss.org/browse/AGPUSH-859)

Using jax-doclets, like Keycloak does.

Example deployment: http://people.apache.org/~matzew/UPS_REST_API/overview-index.html 
