### PR TITLE
AGPUSH-833

### DIFF
--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/installations/InstallationRegistrationEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/installations/InstallationRegistrationEndpoint.java
@@ -54,7 +54,7 @@ public class InstallationRegistrationEndpoint {
     private GenericVariantService genericVariantService;
 
     @OPTIONS
-    @Path("{token}")
+    @Path("{token: .*}")
     public Response crossOriginForInstallations(
             @Context HttpHeaders headers,
             @PathParam("token") String token) {


### PR DESCRIPTION
deviceToken can be an url, make sure every slash is regarded as part of the token, this way we don't need to use any kind of encoding tested with curl and js
