### PR TITLE
updating to use latest parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.jboss.aerogear</groupId>
         <artifactId>aerogear-parent</artifactId>
-        <version>0.2.3</version>
+        <version>0.2.5</version>
     </parent>
 
     <groupId>org.jboss.aerogear.unifiedpush</groupId>
@@ -140,7 +140,7 @@
 
         <jboss-as-maven-plugin.version>7.4.Final</jboss-as-maven-plugin.version>
 
-        <aerogear.bom.version>0.2.3</aerogear.bom.version>
+        <aerogear.bom.version>0.2.5</aerogear.bom.version>
 
         <!-- Override versions of AeroGear BOMs-->
         <junit.version>4.11</junit.version>


### PR DESCRIPTION
Mainly updating to latest APNs version (1.0.0.Beta4). Contains patch from @kpiwko to remove spring dependencies and a fix for `content-available`

@cvasilak @djcoleman and @kpiwko please review!
