### PR TITLE
fix broken Openshfit profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,33 @@
                 <scope>test</scope>
             </dependency>
 
+            <!-- Some test dependencies -->
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>${mockito.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>${assertj.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.h2database</groupId>
+                <artifactId>h2</artifactId>
+                <version>${h2.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.openejb</groupId>
+                <artifactId>openejb-core-hibernate</artifactId>
+                <version>${openejb.version}</version>
+                <type>pom</type>
+                <scope>test</scope>
+            </dependency>
+
             <!-- JBoss distributes a complete set of Java EE 6 APIs including a Bill of Materials (BOM). A BOM specifies the versions
                 of a "stack" (or a collection) of artifacts. We use this here so that we always get the correct versions of artifacts.
                 Here we use
@@ -141,6 +168,11 @@
         <jboss-as-maven-plugin.version>7.4.Final</jboss-as-maven-plugin.version>
 
         <aerogear.bom.version>0.2.3</aerogear.bom.version>
+
+        <assertj.version>1.5.0</assertj.version>
+        <mockito.version>1.9.5</mockito.version>
+        <h2.version>1.3.172</h2.version>
+        <openejb.version>4.6.0</openejb.version>
 
         <!-- Override versions of AeroGear BOMs-->
         <junit.version>4.11</junit.version>


### PR DESCRIPTION
Today, running `mvn clean install -Popenshift` fails w/ maven dependency/version errors.

I _think_ this was introduced w/ https://github.com/aerogear/aerogear-unifiedpush-server/commit/d0b9d70bb16d4568631e905a27c28944bd35f513 

@kpiwko please review this.

Question: Long term.... should this be moved to the aerogear-bom ? ATM theses versions are only on the `test` BOM file 
