### PR TITLE
AGPUSH-927: enforce Jackson1 as a JSON serialization provider for RestEasy

### DIFF
--- a/servers/ups-wildfly/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/servers/ups-wildfly/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -2,10 +2,10 @@
     <deployment>
         <dependencies>
             <module name="org.apache.httpcomponents"/>
-            <module name="org.codehaus.jackson.jackson-core-asl"/>
-            <module name="org.codehaus.jackson.jackson-mapper-asl"/>
+            <module name="org.jboss.resteasy.resteasy-jackson-provider"  services="import" />
         </dependencies>
         <exclusions>
+            <module name="org.jboss.resteasy.resteasy-jackson2-provider" />
         </exclusions>
     </deployment>
 </jboss-deployment-structure>


### PR DESCRIPTION
- makes WildFly 8.1 happy as it uses Jackson 2 provider by default
  https://community.jboss.org/wiki/WildFly810FinalReleaseNotes
- works on WildFly 8.0
- we use different jboss-deployment-structure.xml for AS7/EAP6

See details in https://issues.jboss.org/browse/AGPUSH-927
