### PR TITLE
fixing the name of the simplepush endpoint

### DIFF
--- a/admin-ui/app/scripts/controllers/ExampleController.js
+++ b/admin-ui/app/scripts/controllers/ExampleController.js
@@ -75,6 +75,6 @@ angular.module('upsConsole').controller('ExampleController',
     var parser = document.createElement('a');
     parser.href = ContextProvider.contextPath();
 
-    return parser.protocol + '//' + parser.hostname + ':8443/simplePush';
+    return parser.protocol + '//' + parser.hostname + ':8443/simplepush';
   };
 });


### PR DESCRIPTION
The SimplePush URL is `simplepush`, and _not_ `simplePush`
