### PR TITLE
Update for Keycloak final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -225,7 +225,7 @@
         <aerogear.bom.version>0.2.6</aerogear.bom.version>
 
         <!-- Keycloak version override from AeroGear BOMs -->
-        <keycloak.ups.version>1.0-rc-2</keycloak.ups.version>
+        <keycloak.ups.version>1.0-final</keycloak.ups.version>
 
         <!-- Override versions of AeroGear BOMs-->
         <junit.version>4.11</junit.version>


### PR DESCRIPTION
Keycloak 1.0 was officially released http://bill.burkecentral.com/2014/09/10/keycloak-1-0-final-released/. Also a heads up on the mailing list was sent for testing http://aerogear-dev.1069024.n5.nabble.com/aerogear-dev-Keycloak-call-for-arms-td9169.html.

While testing, keep in mind that the artifact is not available at Maven Central yet, but only at JBoss Nexus. Probably later today or tomorrow, everything will be all set.

This PR must be merged on `1.0.x` and also cherry-picked on `master`
