### PR TITLE
AGPUSH-1031 : always show totalReceivers

### DIFF
--- a/admin-ui/app/views/notification.html
+++ b/admin-ui/app/views/notification.html
@@ -28,7 +28,7 @@
                 </a>
               </td>
               <td>
-                <strong>{{ metric.totalReceivers ? metric.totalReceivers : 'All'  }}</strong> installations
+                <strong>{{ metric.totalReceivers }}</strong> installations
               </td>
               <td>
                 <strong>


### PR DESCRIPTION
TotalReceivers is always returned so let's always show it to avoid weird behavior such as showing "all" when it has been sent to 0 receivers.
note : "all" will now never been showed if we still want this , more has to change on the backend but IMO this has low prio. 
