### PR TITLE
removing SSLv3 usage example from docs

### DIFF
--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/installations/InstallationRegistrationEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/installations/InstallationRegistrationEndpoint.java
@@ -81,7 +81,7 @@ public class InstallationRegistrationEndpoint {
      * The Endpoint is protected using <code>HTTP Basic</code> (credentials <code>VariantID:secret</code>).
      *
      * <pre>
-     * curl -3 -u "variantID:secret"
+     * curl -u "variantID:secret"
      *   -v -H "Accept: application/json" -H "Content-type: application/json"
      *   -X POST
      *   -d '{
@@ -140,7 +140,7 @@ public class InstallationRegistrationEndpoint {
      * The Endpoint is protected using <code>HTTP Basic</code> (credentials <code>VariantID:secret</code>).
      *
      * <pre>
-     * curl -3 -u "variantID:secret"
+     * curl -u "variantID:secret"
      *   -v -H "Accept: application/json" -H "Content-type: application/json"
      *   -X DELETE
      *   https://SERVER:PORT/context/rest/registry/device/{token}
@@ -186,7 +186,7 @@ public class InstallationRegistrationEndpoint {
      * The Endpoint is protected using <code>HTTP Basic</code> (credentials <code>VariantID:secret</code>).
      *
      * <pre>
-     * curl -3 -u "variantID:secret"
+     * curl -u "variantID:secret"
      *   -v -H "Accept: application/json" -H "Content-type: multipart/form-data"
      *   -F "file=@/path/to/my-devices-for-import.json"
      *   -X POST

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/sender/PushNotificationSenderEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/sender/PushNotificationSenderEndpoint.java
@@ -55,7 +55,7 @@ public class PushNotificationSenderEndpoint {
      *
      * Messages are submitted as flexible JSON maps, like:
      * <pre>
-     * curl -3 -u "PushApplicationID:MasterSecret"
+     * curl -u "PushApplicationID:MasterSecret"
      *   -v -H "Accept: application/json" -H "Content-type: application/json"
      *   -X POST
      *   -d '{


### PR DESCRIPTION
Done for https://issues.jboss.org/browse/AGPUSH-1071

Needs to go to `MASTER` and `1.0.x` branches
