### PR TITLE
Fixes the script for PostgreSQL

### DIFF
--- a/databases/postgresql-database-config.cli
+++ b/databases/postgresql-database-config.cli
@@ -3,11 +3,11 @@ connect
 batch
 
 ## Add Postgresql driver
-/subsystem=datasources/jdbc-driver=psqlup:add(driver-name=psqlup,driver-module-name=org.postgresql,driver-xa-datasource-class-name=org.postgresql.xa.PGXADataSource)
+/profile=default/subsystem=datasources/jdbc-driver=psqlup:add(driver-name=psqlup,driver-module-name=org.postgresql,driver-xa-datasource-class-name=org.postgresql.xa.PGXADataSource)
 
 ## Add UnifiedPush Datasource
-data-source add --name=UnifiedPushDS --driver-name=psqlup --jndi-name=java:jboss/datasources/UnifiedPushDS --connection-url=jdbc:postgresql://localhost:5432/unifiedpush --user-name=unifiedpush --password=unifiedpush --use-ccm=false --max-pool-size=25 --blocking-timeout-wait-millis=5000
-data-source enable --name=UnifiedPushDS
+data-source add --name=UnifiedPushDS --driver-name=psqlup --jndi-name=java:jboss/datasources/UnifiedPushDS --connection-url=jdbc:postgresql://localhost:5432/unifiedpush --user-name=unifiedpush --password=unifiedpush --use-ccm=false --max-pool-size=25 --blocking-timeout-wait-millis=5000 --profile=default
+data-source enable --name=UnifiedPushDS --profile=default
 
 run-batch
 #:reload


### PR DESCRIPTION
Currently we're not able to follow the tutorial with PostgreSQL: http://aerogear.org/docs/unifiedpush/ups_userguide/server-installation/#_postgresql_database. Because the script fails.

To reproduce the issue, on WildFly 8.1.0, run:

`jboss-cli.sh --file=databases/postgresql-database-config.cl`

This pull request must go on `master` and `1.0.x` branch
