### PR TITLE
disable default developer

### DIFF
--- a/servers/auth-server/src/main/webapp/WEB-INF/ups-realm.json
+++ b/servers/auth-server/src/main/webapp/WEB-INF/ups-realm.json
@@ -33,7 +33,7 @@
         },
         {
             "username" : "developer",
-            "enabled": true,
+            "enabled": false,
             "credentials" : [
                 { "type" : "password",
                     "value" : "developer" }


### PR DESCRIPTION
The main reason for this is, that after initial installation we do not leave the default `developer` open, for usage.

Now, with this change the admin does explicitly need to activate the account before it can be used

_Note:_ Another option is to not even create the developer user/account upon installation. We just have the role defined in the `ups-realm.json` file.

Once this has been merged to master/1.0.x, I will go ahead and update the documentation
