### PR TITLE
Apns cleanup

### DIFF
--- a/push/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/APNsPushNotificationSender.java
+++ b/push/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/APNsPushNotificationSender.java
@@ -158,7 +158,8 @@ public class APNsPushNotificationSender implements PushNotificationSender {
             builder.withDelegate(new ApnsDelegateAdapter() {
                 @Override
                 public void messageSent(ApnsNotification message, boolean resent) {
-                    logger.fine("Sending APNs message: " + message.getDeviceToken());
+                    // Invoked for EVERY devicetoken:
+                    logger.finest("Sending APNs message: " + message.getDeviceToken());
                 }
 
                 @Override


### PR DESCRIPTION
Removing the `.withNoErrorDection()`, since that was a work-around for https://github.com/notnoop/java-apns/pull/144

This fixes the root of https://issues.jboss.org/browse/AGPUSH-1087 

Besides that, I am also lowering the logging on the `messageSent` of the anonymous `ApnsDelegateAdapter` implementation.

This needs to go to our `master` and `1.0.x` branches
