### PR TITLE
OpenEJB clean up

### DIFF
--- a/service/src/test/java/org/jboss/aerogear/unifiedpush/service/AbstractBaseServiceTest.java
+++ b/service/src/test/java/org/jboss/aerogear/unifiedpush/service/AbstractBaseServiceTest.java
@@ -16,27 +16,124 @@
  */
 package org.jboss.aerogear.unifiedpush.service;
 
+import org.apache.openejb.jee.Beans;
+import org.apache.openejb.junit.ApplicationComposer;
+import org.apache.openejb.mockito.MockitoInjector;
+import org.apache.openejb.testing.MockInjector;
 import org.apache.openejb.testing.Module;
+import org.jboss.aerogear.unifiedpush.jpa.dao.impl.JPACategoryDao;
+import org.jboss.aerogear.unifiedpush.jpa.dao.impl.JPAInstallationDao;
+import org.jboss.aerogear.unifiedpush.jpa.dao.impl.JPAPushApplicationDao;
+import org.jboss.aerogear.unifiedpush.jpa.dao.impl.JPAPushMessageInformationDao;
+import org.jboss.aerogear.unifiedpush.jpa.dao.impl.JPAVariantDao;
+import org.jboss.aerogear.unifiedpush.service.impl.ClientInstallationServiceImpl;
+import org.jboss.aerogear.unifiedpush.service.impl.GenericVariantServiceImpl;
+import org.jboss.aerogear.unifiedpush.service.impl.PushApplicationServiceImpl;
+import org.jboss.aerogear.unifiedpush.service.impl.PushSearchByDeveloperServiceImpl;
+import org.jboss.aerogear.unifiedpush.service.impl.PushSearchServiceImpl;
 import org.jboss.aerogear.unifiedpush.service.impl.SearchManager;
+import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.keycloak.KeycloakPrincipal;
+import org.keycloak.KeycloakSecurityContext;
+import org.keycloak.representations.AccessToken;
+import org.mockito.Mock;
 
 import javax.annotation.PreDestroy;
 import javax.ejb.Stateful;
 import javax.enterprise.context.SessionScoped;
 import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.Persistence;
+import javax.servlet.http.HttpServletRequest;
 import java.io.Serializable;
 
+import static org.mockito.Mockito.when;
+
+@RunWith(ApplicationComposer.class)
 public abstract class AbstractBaseServiceTest {
 
-    @Module
-    public Class<?>[] app() throws Exception {
-        return new Class<?>[] { EntityManagerProducer.class, SearchManager.class};
+    @Mock
+    protected HttpServletRequest httpServletRequest;
+
+    @Mock
+    protected KeycloakSecurityContext context;
+
+    @Mock
+    protected KeycloakPrincipal keycloakPrincipal;
+
+    @Inject
+    protected SearchManager searchManager;
+
+    @Inject
+    protected PushApplicationServiceImpl pushApplicationService;
+
+    @Inject
+    protected PushSearchByDeveloperServiceImpl searchApplicationService;
+
+    // ===================== JUnit hooks =====================
+
+    /**
+     * Basic setup stuff, needed for all the UPS related service classes
+     */
+    @Before
+    public void setUp(){
+        // Keycloak test environment
+        AccessToken token = new AccessToken();
+        //The current developer will always be the admin in this testing scenario
+        token.setPreferredUsername("admin");
+        when(context.getToken()).thenReturn(token);
+        when(keycloakPrincipal.getKeycloakSecurityContext()).thenReturn(context);
+        when(httpServletRequest.getUserPrincipal()).thenReturn(keycloakPrincipal);
+
+        // glue it to serach mgr
+        searchManager.setHttpServletRequest(httpServletRequest);
+
+        // more to setup ?
+        specificSetup();
     }
 
-    // test-ware: EM producer:
+    /**
+     * Enforced to override to make sure test-case specific
+     * setup is done inside here!
+     */
+    protected abstract void specificSetup();
 
+    // ===================== OpenEJB hooks and base methods =====================
+
+    @MockInjector
+    public Class<?> mockitoInjector() {
+        return MockitoInjector.class;
+    }
+
+    @Module
+    public Beans getBeans() {
+        final Beans beans = new Beans();
+        beans.addManagedClass(ClientInstallationServiceImpl.class);
+        beans.addManagedClass(JPAPushMessageInformationDao.class);
+        beans.addManagedClass(JPAInstallationDao.class);
+        beans.addManagedClass(GenericVariantServiceImpl.class);
+        beans.addManagedClass(JPAVariantDao.class);
+        beans.addManagedClass(JPACategoryDao.class);
+        beans.addManagedClass(PushSearchByDeveloperServiceImpl.class);
+        beans.addManagedClass(PushApplicationServiceImpl.class);
+        beans.addManagedClass(JPAPushApplicationDao.class);
+        beans.addManagedClass(PushSearchServiceImpl.class);
+        beans.addManagedClass(SearchManager.class);
+
+        return beans;
+    }
+
+    @Module
+    public Class<?>[] produceTestEntityManager() throws Exception {
+        return new Class<?>[] { EntityManagerProducer.class};
+    }
+
+    /**
+     * Static class to have OpenEJB produce/lookup a test EntityManager.
+     */
     @SessionScoped
     @Stateful
     public static class EntityManagerProducer implements Serializable {

--- a/service/src/test/java/org/jboss/aerogear/unifiedpush/service/ClientInstallationServiceTest.java
+++ b/service/src/test/java/org/jboss/aerogear/unifiedpush/service/ClientInstallationServiceTest.java
@@ -16,44 +16,18 @@
  */
 package org.jboss.aerogear.unifiedpush.service;
 
-import org.apache.openejb.jee.Beans;
-import org.apache.openejb.junit.ApplicationComposer;
-import org.apache.openejb.mockito.MockitoInjector;
-import org.apache.openejb.testing.MockInjector;
-import org.apache.openejb.testing.Module;
 import org.jboss.aerogear.unifiedpush.api.AndroidVariant;
 import org.jboss.aerogear.unifiedpush.api.Installation;
-import org.jboss.aerogear.unifiedpush.jpa.dao.impl.JPACategoryDao;
-import org.jboss.aerogear.unifiedpush.jpa.dao.impl.JPAInstallationDao;
-import org.jboss.aerogear.unifiedpush.jpa.dao.impl.JPAPushApplicationDao;
-import org.jboss.aerogear.unifiedpush.jpa.dao.impl.JPAPushMessageInformationDao;
-import org.jboss.aerogear.unifiedpush.jpa.dao.impl.JPAVariantDao;
-import org.jboss.aerogear.unifiedpush.service.impl.ClientInstallationServiceImpl;
-import org.jboss.aerogear.unifiedpush.service.impl.GenericVariantServiceImpl;
-import org.jboss.aerogear.unifiedpush.service.impl.PushApplicationServiceImpl;
-import org.jboss.aerogear.unifiedpush.service.impl.PushSearchByDeveloperServiceImpl;
-import org.jboss.aerogear.unifiedpush.service.impl.PushSearchServiceImpl;
-import org.jboss.aerogear.unifiedpush.service.impl.SearchManager;
-import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.keycloak.KeycloakPrincipal;
-import org.keycloak.KeycloakSecurityContext;
-import org.keycloak.representations.AccessToken;
-import org.mockito.Mock;
 
 import javax.inject.Inject;
-import javax.servlet.http.HttpServletRequest;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
 
-@RunWith(ApplicationComposer.class)
 public class ClientInstallationServiceTest extends AbstractBaseServiceTest {
-
 
     @Inject
     private ClientInstallationService clientInstallationService;
@@ -61,60 +35,10 @@ public class ClientInstallationServiceTest extends AbstractBaseServiceTest {
     @Inject
     private GenericVariantService variantService;
 
-    @Inject
-    private SearchManager searchManager;
-
-    @Inject
-    private PushApplicationServiceImpl pushApplicationService;
-
-    @Inject
-    private PushSearchByDeveloperServiceImpl searchApplicationService;
-
     private AndroidVariant androidVariant;
 
-    @Mock
-    private HttpServletRequest httpServletRequest;
-
-    @Mock
-    private KeycloakSecurityContext context;
-
-    @Mock
-    private KeycloakPrincipal keycloakPrincipal;
-
-    @MockInjector
-    public Class<?> mockitoInjector() {
-        return MockitoInjector.class;
-    }
-
-    @Module
-    public Beans getBeans() {
-        final Beans beans = new Beans();
-        beans.addManagedClass(ClientInstallationServiceImpl.class);
-        beans.addManagedClass(JPAPushMessageInformationDao.class);
-        beans.addManagedClass(JPAInstallationDao.class);
-        beans.addManagedClass(JPACategoryDao.class);
-        beans.addManagedClass(GenericVariantServiceImpl.class);
-        beans.addManagedClass(JPAVariantDao.class);
-        beans.addManagedClass(PushSearchByDeveloperServiceImpl.class);
-        beans.addManagedClass(PushApplicationServiceImpl.class);
-        beans.addManagedClass(JPAPushApplicationDao.class);
-        beans.addManagedClass(PushSearchServiceImpl.class);
-        beans.addManagedClass(SearchManager.class);
-
-        return beans;
-    }
-
-    @Before
-    public void setup() {
-
-        AccessToken token = new AccessToken();
-        token.setPreferredUsername("admin");
-        when(context.getToken()).thenReturn(token);
-        when(keycloakPrincipal.getKeycloakSecurityContext()).thenReturn(context);
-        when(httpServletRequest.getUserPrincipal()).thenReturn(keycloakPrincipal);
-
-        searchManager.setHttpServletRequest(httpServletRequest);
-
+    @Override
+    protected void specificSetup() {
         // setup a variant:
         androidVariant = new AndroidVariant();
         androidVariant.setGoogleKey("Key");

--- a/service/src/test/java/org/jboss/aerogear/unifiedpush/service/PushApplicationServiceTest.java
+++ b/service/src/test/java/org/jboss/aerogear/unifiedpush/service/PushApplicationServiceTest.java
@@ -16,89 +16,18 @@
  */
 package org.jboss.aerogear.unifiedpush.service;
 
-import org.apache.openejb.jee.Beans;
-import org.apache.openejb.junit.ApplicationComposer;
-import org.apache.openejb.mockito.MockitoInjector;
-import org.apache.openejb.testing.MockInjector;
-import org.apache.openejb.testing.Module;
 import org.jboss.aerogear.unifiedpush.api.PushApplication;
-import org.jboss.aerogear.unifiedpush.dao.InstallationDao;
-import org.jboss.aerogear.unifiedpush.jpa.dao.impl.JPAInstallationDao;
-import org.jboss.aerogear.unifiedpush.jpa.dao.impl.JPAPushApplicationDao;
-import org.jboss.aerogear.unifiedpush.jpa.dao.impl.JPAPushMessageInformationDao;
-import org.jboss.aerogear.unifiedpush.jpa.dao.impl.JPAVariantDao;
-import org.jboss.aerogear.unifiedpush.service.impl.PushApplicationServiceImpl;
-import org.jboss.aerogear.unifiedpush.service.impl.PushSearchByDeveloperServiceImpl;
-import org.jboss.aerogear.unifiedpush.service.impl.PushSearchServiceImpl;
-import org.jboss.aerogear.unifiedpush.service.impl.SearchManager;
-import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.keycloak.KeycloakPrincipal;
-import org.keycloak.KeycloakSecurityContext;
-import org.keycloak.representations.AccessToken;
-import org.mockito.Mock;
 
-import javax.inject.Inject;
-import javax.servlet.http.HttpServletRequest;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
 
-
-@RunWith(ApplicationComposer.class)
 public class PushApplicationServiceTest extends AbstractBaseServiceTest {
 
-    @Inject
-    private PushApplicationServiceImpl pushApplicationService;
-
-    @Inject
-    private PushSearchByDeveloperServiceImpl searchApplicationService;
-
-    @Inject
-    private SearchManager searchManager;
-
-    @Mock
-    private HttpServletRequest httpServletRequest;
-
-    @Mock
-    private KeycloakSecurityContext context;
-
-    @Mock
-    private KeycloakPrincipal keycloakPrincipal;
-
-    @MockInjector
-    public Class<?> mockitoInjector() {
-        return MockitoInjector.class;
-    }
-
-    @Before
-    public void setUp(){
-        AccessToken token = new AccessToken();
-        //The current developer will always be the admin in this testing scenario
-        token.setPreferredUsername("admin");
-        when(context.getToken()).thenReturn(token);
-        when(keycloakPrincipal.getKeycloakSecurityContext()).thenReturn(context);
-        when(httpServletRequest.getUserPrincipal()).thenReturn(keycloakPrincipal);
-        searchManager.setHttpServletRequest(httpServletRequest);
-    }
-
-    @Module
-    public Beans getBeans() {
-        final Beans beans = new Beans();
-        beans.addManagedClass(JPAVariantDao.class);
-        beans.addManagedClass(JPAInstallationDao.class);
-        beans.addManagedClass(JPAPushMessageInformationDao.class);
-        beans.addManagedClass(PushApplicationServiceImpl.class);
-        beans.addManagedClass(JPAPushApplicationDao.class);
-        beans.addManagedClass(PushSearchByDeveloperServiceImpl.class);
-        beans.addManagedClass(PushSearchServiceImpl.class);
-        beans.addManagedClass(SearchManager.class);
-        beans.addManagedClass(InstallationDao.class);
-
-
-        return beans;
+    @Override
+    protected void specificSetup() {
+        // noop
     }
 
     @Test


### PR DESCRIPTION
Service tests based on OpenEJB are a simpler with this. no more hooks to OpenEJB code, move that to base class
