### PR TITLE
Using normal PersistenceContext

### DIFF
--- a/model/jpa/src/main/java/org/jboss/aerogear/unifiedpush/jpa/cdi/Factory.java
+++ b/model/jpa/src/main/java/org/jboss/aerogear/unifiedpush/jpa/cdi/Factory.java
@@ -19,13 +19,12 @@ package org.jboss.aerogear.unifiedpush.jpa.cdi;
 import javax.enterprise.inject.Produces;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
-import javax.persistence.PersistenceContextType;
 
 /**
  * CDI Utility class, which contains various producer / factory methods.
  */
 public final class Factory {
     @Produces
-    @PersistenceContext(unitName = "unifiedpush-default", type = PersistenceContextType.EXTENDED)
+    @PersistenceContext(unitName = "unifiedpush-default")
     private EntityManager entityManager;
 }


### PR DESCRIPTION
No need for extended PersistenceContext

Tested the server (creating app/variant, registering tokens and sending).

@edewit @sebastienblanc can you review?

Needs to be merged to 1.0.x and master branches
