### PR TITLE
Removal of annoying warning

### DIFF
--- a/admin-ui/package.json
+++ b/admin-ui/package.json
@@ -1,6 +1,10 @@
 {
   "name": "ups-admin-ui",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/aerogear/aerogear-unifiedpush-server/"
+  },
   "dependencies": {},
   "devDependencies": {
     "bower": "1.3.9",


### PR DESCRIPTION
To reproduce the issue run npm install inside admin-ui folder, the expected result is:

```
npm WARN package.json ups-admin-ui@0.0.0 No repository field.
```

`master` and `1.0.x` please.
