### PR TITLE
Adding KC migration script

### DIFF
--- a/databases/keycloak-migration-mysql.sql
+++ b/databases/keycloak-migration-mysql.sql
@@ -1,0 +1,8 @@
+use unifiedpush;
+
+--
+-- Migrate KC refactorings done between 1.0-beta-4 and 1.0.Final
+--
+rename table REALM_AUDIT_LISTENERS to REALM_EVENTS_LISTENERS;
+alter table REALM change AUDIT_ENABLED EVENTS_ENABLED bit(1);
+alter table REALM change AUDIT_EXPIRATION EVENTS_EXPIRATION bigint(20);

--- a/databases/keycloak-migration-postgresql.sql
+++ b/databases/keycloak-migration-postgresql.sql
@@ -1,0 +1,6 @@
+--
+-- Migrate KC refactorings done between 1.0-beta-4 and 1.0.Final
+--
+alter table REALM_AUDIT_LISTENERS rename to REALM_EVENTS_LISTENERS;
+alter table REALM rename column AUDIT_ENABLED to EVENTS_ENABLED;
+alter table REALM rename column AUDIT_EXPIRATION to EVENTS_EXPIRATION;


### PR DESCRIPTION
See [AGPUSH-1136](https://issues.jboss.org/browse/AGPUSH-1136) for details/background on this PR.

How to test ? 
1. setup WF with MySQL (see https://aerogear.org/docs/unifiedpush/ups_userguide/server-installation/#_mysql_database)
2. deploy (`copy`) the 'auth-server' from 1.0.0.Final (only the auth-server). Get it [here](https://repository.jboss.org/nexus/content/repositories/public/org/jboss/aerogear/unifiedpush/unifiedpush-auth-server/1.0.0.Final/unifiedpush-auth-server-1.0.0.Final.war)
3. Login to http://localhost:8080/auth/admin/aerogear/console/index.html and change the default password
4. Shutdown WF
5. Open a MySQL client of your choice
6. execute the script of this PR
7. copy the auth-server.war file from 1.0.2 release to the `standalone/deployments` folder. Get it [here](https://repository.jboss.org/nexus/content/repositories/public/org/jboss/aerogear/unifiedpush/unifiedpush-auth-server/1.0.2/unifiedpush-auth-server-1.0.2.war)
__Alternative__ you can build the `1.0.x` or `master` branch - all have the same bug :-) 
8. start up the WF
9. Login to http://localhost:8080/auth/admin/aerogear/console/index.html 

If that worked, the migration worked for you too 
