### PR TITLE
Override apns version from parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,13 @@
                 <scope>import</scope>
             </dependency>
 
+            <!-- overriding apns from base -->
+            <dependency>
+                <groupId>com.notnoop.apns</groupId>
+                <artifactId>apns</artifactId>
+                <version>1.0.0.Beta5</version>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
@cvasilak @sebastienblanc can you review ? 

NOTE: Only goes to 1.0.x branch - the master will be updated via a proper release of the parent pom file