### PR TITLE
fix pgsql lob behavior

### DIFF
--- a/model/api/pom.xml
+++ b/model/api/pom.xml
@@ -39,14 +39,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jboss.aerogear</groupId>
-            <artifactId>aerogear-crypto</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>bouncycastle</groupId>
-            <artifactId>bcprov-jdk16</artifactId>
-            <version>140</version>
+            <groupId>net.iharder</groupId>
+            <artifactId>base64</artifactId>
         </dependency>
 
     </dependencies>

--- a/model/api/pom.xml
+++ b/model/api/pom.xml
@@ -37,6 +37,18 @@
             <groupId>org.codehaus.jackson</groupId>
             <artifactId>jackson-core-asl</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.jboss.aerogear</groupId>
+            <artifactId>aerogear-crypto</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>bouncycastle</groupId>
+            <artifactId>bcprov-jdk16</artifactId>
+            <version>140</version>
+        </dependency>
+
     </dependencies>
     
     <profiles>

--- a/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/iOSVariant.java
+++ b/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/iOSVariant.java
@@ -21,11 +21,13 @@ import javax.validation.constraints.Size;
 
 import org.codehaus.jackson.annotate.JsonIgnore;
 import org.codehaus.jackson.annotate.JsonProperty;
+import org.jboss.aerogear.crypto.encoders.Base64;
 
 /**
  * The iOS variant class encapsulates APNs specific behavior.
  */
 public class iOSVariant extends Variant {
+    private static final Base64 encoder = new Base64();
     private static final long serialVersionUID = -889367404039436329L;
 
     private boolean production;
@@ -37,7 +39,7 @@ public class iOSVariant extends Variant {
 
     @NotNull(message = "Certificate must be provided")
     @JsonIgnore
-    private byte[] certificate;
+    private String certificateData;
 
     /**
      * If <code>true</code> a connection to Apple's Production APNs server
@@ -75,12 +77,12 @@ public class iOSVariant extends Variant {
      */
     @JsonIgnore
     public byte[] getCertificate() {
-        return certificate;
+        return encoder.decode(certificateData);
     }
 
     @JsonProperty
     public void setCertificate(byte[] cert) {
-        this.certificate = cert;
+        this.certificateData = encoder.encode(cert);
     }
 
     @Override

--- a/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/iOSVariant.java
+++ b/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/iOSVariant.java
@@ -19,15 +19,16 @@ package org.jboss.aerogear.unifiedpush.api;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
+import net.iharder.Base64;
 import org.codehaus.jackson.annotate.JsonIgnore;
 import org.codehaus.jackson.annotate.JsonProperty;
-import org.jboss.aerogear.crypto.encoders.Base64;
+
+import java.io.IOException;
 
 /**
  * The iOS variant class encapsulates APNs specific behavior.
  */
 public class iOSVariant extends Variant {
-    private static final Base64 encoder = new Base64();
     private static final long serialVersionUID = -889367404039436329L;
 
     private boolean production;
@@ -77,12 +78,16 @@ public class iOSVariant extends Variant {
      */
     @JsonIgnore
     public byte[] getCertificate() {
-        return encoder.decode(certificateData);
+        try {
+            return Base64.decode(certificateData);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @JsonProperty
     public void setCertificate(byte[] cert) {
-        this.certificateData = encoder.encode(cert);
+        this.certificateData = Base64.encodeBytes(cert);
     }
 
     @Override

--- a/model/jpa/src/main/resources/META-INF/orm.xml
+++ b/model/jpa/src/main/resources/META-INF/orm.xml
@@ -63,8 +63,8 @@ http://java.sun.com/xml/ns/persistence/orm_2_0.xsd"
     <entity class="iOSVariant" access="FIELD">
         <discriminator-value>ios</discriminator-value>
         <attributes>
-            <basic name="certificate">
-                <lob/>
+            <basic name="certificateData">
+                <column length="100000"/>
             </basic>
         </attributes>
     </entity>

--- a/model/jpa/src/main/resources/META-INF/orm.xml
+++ b/model/jpa/src/main/resources/META-INF/orm.xml
@@ -64,7 +64,7 @@ http://java.sun.com/xml/ns/persistence/orm_2_0.xsd"
         <discriminator-value>ios</discriminator-value>
         <attributes>
             <basic name="certificateData">
-                <column length="100000"/>
+                <column name="cert_data" length="100000"/>
             </basic>
         </attributes>
     </entity>


### PR DESCRIPTION
PostgreSQL may use more than one row for storing *LOB fields, hence a
transaction is always needed for ensuring consistency.

By extracting the certificate storage to its own entity, access to variants
becomes more lightweight, and cert lookup can be made lazy.

AGPUSH-1144