### PR TITLE
Removal of the payload which violates user's privacy

### DIFF
--- a/admin-ui/app/scripts/controllers/ActivityController.js
+++ b/admin-ui/app/scripts/controllers/ActivityController.js
@@ -87,31 +87,4 @@ angular.module('upsConsole').controller('ActivityController',
       return !metric.expand;
     };
 
-    $scope.parse = function (metric) {
-      try {
-        return JSON.parse(metric.rawJsonMessage);
-      } catch (err) {
-        return {};
-      }
-    };
-
-    $scope.showFullRequest = function (rawJsonMessage) {
-      $modal.open({
-        templateUrl: 'views/dialogs/request.html',
-        controller: function ($scope, $modalInstance, request) {
-          $scope.request = request;
-
-          $scope.cancel = function () {
-            $modalInstance.dismiss('cancel');
-          };
-        },
-        resolve: {
-          request: function () {
-            //nasty way to get formatted json
-            return JSON.stringify(JSON.parse(rawJsonMessage), null, 4);
-          }
-        }
-      });
-    };
-
   });

--- a/admin-ui/app/views/notification.html
+++ b/admin-ui/app/views/notification.html
@@ -20,13 +20,6 @@
               </tr>
             </th>
             <tr style="border-top: 1px #eee solid" ng-repeat-start="metric in activityCtrl.pushMetrics">
-              <td style="padding: 8px 0;">
-                <a href ng-click="activityCtrl.expand(metric)">
-                  <i class="fa"
-                     ng-class="{'fa-plus-square-o': activityCtrl.isCollapsed(metric), 'fa-minus-square-o': !activityCtrl.isCollapsed(metric)}"></i>
-                  {{ metric.rawJsonMessage | limitTo : 50 }}...
-                </a>
-              </td>
               <td>
                 <strong>{{ metric.totalReceivers }}</strong> installations
               </td>
@@ -48,8 +41,6 @@
                     <tr>
                       <td>Request IP:</td>
                       <td><strong>{{ metric.ipAddress }}</strong>
-                      </td>
-                      <td><a href ng-click="activityCtrl.showFullRequest(metric.rawJsonMessage)">Full Request</a>
                       </td>
                     </tr>
                     <tr>

--- a/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/PushMessageInformation.java
+++ b/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/PushMessageInformation.java
@@ -29,7 +29,6 @@ public class PushMessageInformation extends BaseModel {
     @NotNull
     private String pushApplicationId;
 
-    private String rawJsonMessage;
     private String ipAddress;
     private String clientIdentifier;
 
@@ -37,17 +36,6 @@ public class PushMessageInformation extends BaseModel {
     private long totalReceivers;
 
     private Set<VariantMetricInformation> variantInformations = new HashSet<VariantMetricInformation>();
-
-    /**
-     * The raw JSON payload of the push message request
-     */
-    public String getRawJsonMessage() {
-        return rawJsonMessage;
-    }
-
-    public void setRawJsonMessage(String rawJsonMessage) {
-        this.rawJsonMessage = rawJsonMessage;
-    }
 
     /**
      * The IP from the submitter of the push message request

--- a/model/api/src/test/java/org/jboss/aerogear/unifiedpush/api/PushMessageInformationTest.java
+++ b/model/api/src/test/java/org/jboss/aerogear/unifiedpush/api/PushMessageInformationTest.java
@@ -32,7 +32,6 @@ public class PushMessageInformationTest {
         // general job data
         pushMessageInformation = new PushMessageInformation();
         pushMessageInformation.setPushApplicationId("123");
-        pushMessageInformation.setRawJsonMessage("{\"data\" : \"something\"}");
         pushMessageInformation.setIpAddress("127.0.0.1");
         pushMessageInformation.setClientIdentifier("Java Sender Client");
 
@@ -62,7 +61,6 @@ public class PushMessageInformationTest {
                         tuple(100L, Boolean.TRUE)
                 );
 
-        assertThat(pushMessageInformation.getRawJsonMessage()).isEqualTo("{\"data\" : \"something\"}");
         assertThat(pushMessageInformation.getSubmitDate()).isNotNull();
         assertThat(pushMessageInformation.getId()).isNotNull();
         assertThat(pushMessageInformation.getIpAddress()).isEqualTo("127.0.0.1");

--- a/model/jpa/src/main/resources/META-INF/orm.xml
+++ b/model/jpa/src/main/resources/META-INF/orm.xml
@@ -98,9 +98,6 @@ http://java.sun.com/xml/ns/persistence/orm_2_0.xsd"
             <basic name="submitDate">
                 <temporal>TIMESTAMP</temporal>
             </basic>
-            <basic name="rawJsonMessage">
-                <column length="4500" />
-            </basic>
             <one-to-many name="variantInformations" fetch="EAGER">
                 <join-column />
                 <cascade>

--- a/model/jpa/src/test/java/org/jboss/aerogear/unifiedpush/jpa/PushMessageInformationDaoTest.java
+++ b/model/jpa/src/test/java/org/jboss/aerogear/unifiedpush/jpa/PushMessageInformationDaoTest.java
@@ -521,21 +521,6 @@ public class PushMessageInformationDaoTest {
     }
 
     @Test
-    public void testLongRawJsonPayload() {
-        PushMessageInformation largePushMessageInformation = new PushMessageInformation();
-        largePushMessageInformation.setPushApplicationId("231231231");
-        pushMessageInformationDao.create(largePushMessageInformation);
-    }
-
-    @Test(expected = PersistenceException.class)
-    public void testTooLongRawJsonPayload() {
-        PushMessageInformation largePushMessageInformation = new PushMessageInformation();
-        largePushMessageInformation.setPushApplicationId("231231231");
-        pushMessageInformationDao.create(largePushMessageInformation);
-        flushAndClear();
-    }
-
-    @Test
     public void deleteOldPushMessageInformations() {
 
         List<PushMessageInformation> messageInformations = pushMessageInformationDao.findAllForPushApplication("231231231", Boolean.TRUE);

--- a/model/jpa/src/test/java/org/jboss/aerogear/unifiedpush/jpa/PushMessageInformationDaoTest.java
+++ b/model/jpa/src/test/java/org/jboss/aerogear/unifiedpush/jpa/PushMessageInformationDaoTest.java
@@ -23,7 +23,6 @@ import org.jboss.aerogear.unifiedpush.api.VariantMetricInformation;
 import org.jboss.aerogear.unifiedpush.dao.PageResult;
 import org.jboss.aerogear.unifiedpush.jpa.dao.impl.JPAPushMessageInformationDao;
 import org.jboss.aerogear.unifiedpush.utils.DateUtils;
-import org.jboss.aerogear.unifiedpush.utils.TestUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -106,14 +105,12 @@ public class PushMessageInformationDaoTest {
     @Test
     public void addJsonToPushMessageInformation() {
         pushMessageInformation = pushMessageInformationDao.find(pushMessageInformationID);
-        pushMessageInformation.setRawJsonMessage("{\"alert\" : \"hello\"}");
         pushMessageInformationDao.update(pushMessageInformation);
 
         flushAndClear();
 
         pushMessageInformation = pushMessageInformationDao.find(pushMessageInformationID);
 
-        assertThat(pushMessageInformation.getRawJsonMessage()).isEqualTo("{\"alert\" : \"hello\"}");
         assertThat(pushMessageInformation.getSubmitDate()).isNotNull();
     }
 
@@ -527,7 +524,6 @@ public class PushMessageInformationDaoTest {
     public void testLongRawJsonPayload() {
         PushMessageInformation largePushMessageInformation = new PushMessageInformation();
         largePushMessageInformation.setPushApplicationId("231231231");
-        largePushMessageInformation.setRawJsonMessage(TestUtils.longString(4500));
         pushMessageInformationDao.create(largePushMessageInformation);
     }
 
@@ -535,7 +531,6 @@ public class PushMessageInformationDaoTest {
     public void testTooLongRawJsonPayload() {
         PushMessageInformation largePushMessageInformation = new PushMessageInformation();
         largePushMessageInformation.setPushApplicationId("231231231");
-        largePushMessageInformation.setRawJsonMessage(TestUtils.longString(4501));
         pushMessageInformationDao.create(largePushMessageInformation);
         flushAndClear();
     }

--- a/service/src/main/java/org/jboss/aerogear/unifiedpush/service/metrics/PushMessageMetricsService.java
+++ b/service/src/main/java/org/jboss/aerogear/unifiedpush/service/metrics/PushMessageMetricsService.java
@@ -50,7 +50,6 @@ public class PushMessageMetricsService {
     public PushMessageInformation storeNewRequestFrom(String pushAppId, String json, String ipAddress, String clientIdentifier) {
         final PushMessageInformation information = new PushMessageInformation();
 
-        information.setRawJsonMessage(json);
         information.setIpAddress(ipAddress);
         information.setPushApplicationId(pushAppId);
         information.setClientIdentifier(clientIdentifier);


### PR DESCRIPTION
Must go on `master` and `1.0.x`, please.

During our discussions on aerogear-dev we agreed on storing `metadata` for metrics, not the content of the messages. Today @qmx and @lholmquist caught my attention about it.

I think it's an easy fix. Would you mind to review @qmx @lholmquist @matzew @sebastienblanc ?