### PR TITLE
Adding parent, containing latest KC 1.1.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.jboss.aerogear</groupId>
         <artifactId>aerogear-parent</artifactId>
-        <version>0.2.11</version>
+        <version>0.2.12-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jboss.aerogear.unifiedpush</groupId>
@@ -188,7 +188,7 @@
         <jboss-as-maven-plugin.version>7.5.Final</jboss-as-maven-plugin.version>
         <wildfly-maven-plugin.version>1.0.2.Final</wildfly-maven-plugin.version>
 
-        <aerogear.bom.version>0.2.11</aerogear.bom.version>
+        <aerogear.bom.version>0.2.12-SNAPSHOT</aerogear.bom.version>
 
         <!-- Override versions of AeroGear BOMs-->
         <junit.version>4.11</junit.version>


### PR DESCRIPTION
You need https://github.com/aerogear/aerogear-parent/pull/40 for testing this

Tested and deployed on WF 8.2 -> works fine

NOTE: before merging this, I'd think we should get the parent 0.2.12 released to maven central