### PR TITLE
APNs sender should support both iOS and Safari - AGPUSH-491

### DIFF
--- a/push/model/src/main/java/org/jboss/aerogear/unifiedpush/message/Message.java
+++ b/push/model/src/main/java/org/jboss/aerogear/unifiedpush/message/Message.java
@@ -32,7 +32,12 @@ public class Message {
     @JsonProperty("action-category")
     private String actionCategory;
     private String alert;
+    private String title;
+    private String action;
     private String sound;
+
+    @JsonProperty("url-args")
+    private String[] urlArgs;
 
     @JsonProperty("content-available")
     private boolean contentAvailable;
@@ -71,6 +76,26 @@ public class Message {
     public void setAlert(String alert) {
         this.alert = alert;
     }
+
+    /**
+     * Returns the value of the 'title' key from the submitted payload.
+     * This key is recognized in APNs for Safari, without any API invocation and
+     * on AeroGear's GCM offerings.
+     *
+     */
+    public String getTitle() { return title; }
+
+    public void setTitle(String title) { this.title = title; }
+
+    /**
+     * Returns the value of the 'action' key from the submitted payload.
+     * This key is recognized in APNs for Safari, without any API invocation and
+     * on AeroGear's GCM offerings.
+     *
+     */
+    public String getAction() { return action; }
+
+    public void setAction(String action) { this.action = action; }
 
     /**
      * Returns the value of the 'sound' key from the submitted payload.
@@ -132,6 +157,16 @@ public class Message {
     public void setUserData(Map<String, Object> userData) {
         this.userData = userData;
     }
+
+    /**
+     * Returns the value of the 'url-args' key from the submitted payload.
+     * This key is recognized in APNs for Safari, without any API invocation and
+     * on AeroGear's GCM offerings.
+     *
+     */
+    public String[] getUrlArgs() { return urlArgs; }
+
+    public void setUrlArgs(String[] urlArgs) { this.urlArgs = urlArgs; }
 
     /**
      * Returns the SimplePush specific version number.

--- a/push/model/src/main/java/org/jboss/aerogear/unifiedpush/message/UnifiedPushMessage.java
+++ b/push/model/src/main/java/org/jboss/aerogear/unifiedpush/message/UnifiedPushMessage.java
@@ -25,7 +25,7 @@ import java.io.IOException;
 /**
  * Contains the data of the JSON payload that has been sent to the
  * RESTful Sender endpoint.
- * 
+ *
  * <p>
  * For details have a look at the <a href="http://aerogear.org/docs/specs/aerogear-push-messages/">Message Format Specification</a>.
  *
@@ -33,7 +33,7 @@ import java.io.IOException;
  * <pre>
  *  "message": {
  *   "alert": "HELLO!",
- *   "title": "Safari Title",
+ *   "title": "Title",
  *   "action": "Safari Action",
  *   "url-args":[ "arg1", "arg2" ],
  *   "action-category": "some value",

--- a/push/model/src/main/java/org/jboss/aerogear/unifiedpush/message/UnifiedPushMessage.java
+++ b/push/model/src/main/java/org/jboss/aerogear/unifiedpush/message/UnifiedPushMessage.java
@@ -33,6 +33,9 @@ import java.io.IOException;
  * <pre>
  *  "message": {
  *   "alert": "HELLO!",
+ *   "title": "Safari Title",
+ *   "action": "Safari Action",
+ *   "url-args":[ "arg1", "arg2" ],
  *   "action-category": "some value",
  *   "sound": "default",
  *   "badge": 2,

--- a/push/model/src/test/java/org/jboss/aerogear/unifiedpush/message/UnifiedPushMessageTest.java
+++ b/push/model/src/test/java/org/jboss/aerogear/unifiedpush/message/UnifiedPushMessageTest.java
@@ -265,6 +265,41 @@ public class UnifiedPushMessageTest {
     }
 
     @Test
+    public void testAction() throws IOException{
+        final Map<String, Object> container = new LinkedHashMap<String, Object>();
+        final Map<String, Object> messageObject = new LinkedHashMap<String, Object>();
+
+        messageObject.put("alert", "howdy");
+        messageObject.put("action", "View");
+
+        container.put("message", messageObject);
+
+        // parse it:
+        final UnifiedPushMessage unifiedPushMessage = parsePushMessage(container);
+        assertEquals("View", unifiedPushMessage.getMessage().getAction());
+
+    }
+
+    @Test
+    public void testUrlArgs() throws IOException {
+        final Map<String, Object> container = new LinkedHashMap<String, Object>();
+        final Map<String, Object> messageObject = new LinkedHashMap<String, Object>();
+        final String[] urlArgs = { "Arg1", "Arg2" };
+
+
+
+        messageObject.put("alert", "howdy");
+        messageObject.put("title", "I'm a Title");
+        messageObject.put("url-args", urlArgs);
+
+        container.put("message", messageObject);
+
+        // parse it:
+        final UnifiedPushMessage unifiedPushMessage = parsePushMessage(container);
+        assertEquals("[Arg1, Arg2]", Arrays.toString(unifiedPushMessage.getMessage().getUrlArgs()));
+    }
+
+    @Test
     public void testActionCategory() throws IOException {
         final Map<String, Object> container = new LinkedHashMap<String, Object>();
         final Map<String, Object> messageObject = new LinkedHashMap<String, Object>();
@@ -532,9 +567,12 @@ public class UnifiedPushMessageTest {
                 "\"clientIdentifier\":null," +
                 "\"message\":{" +
                     "\"alert\":\"Howdy\"," +
+                    "\"title\":null," +
+                    "\"action\":null," +
                     "\"sound\":\"default\"," +
                     "\"badge\":2," +
                     "\"action-category\":null," +
+                    "\"url-args\":null," +
                     "\"content-available\":false," +
                     "\"user-data\":{" +
                     "\"someKey\":\"someValue\"" +

--- a/push/model/src/test/resources/message-format.json
+++ b/push/model/src/test/resources/message-format.json
@@ -3,6 +3,9 @@
   "clientIdentifier":null,
   "message":{
     "alert":"HELLO!",
+    "title": null,
+    "action": null,
+    "url-args": null,
     "sound":"default",
     "badge":2,
     "user-data":{

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/APNsPushNotificationSender.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/APNsPushNotificationSender.java
@@ -74,7 +74,10 @@ public class APNsPushNotificationSender implements PushNotificationSender {
         Message message = pushMessage.getMessage();
         PayloadBuilder builder = APNS.newPayload()
                 // adding recognized key values
-                .alertBody(message.getAlert()) // alert dialog, in iOS
+                .alertBody(message.getAlert()) // alert dialog, in iOS or Safari
+                .alertTitle(message.getTitle()) // The title of the notification in Safari
+                .alertAction(message.getAction()) // The label of the action button, if the user sets the notifications to appear as alerts in Safari.
+                .urlArgs(message.getUrlArgs())
                 .badge(message.getBadge()) // little badge icon update;
                 .sound(message.getSound()) // sound to be played by app
                 .category(message.getActionCategory()); // iOS8: User Action category


### PR DESCRIPTION
Putting the time in to create an APNsVariant to combine iOS and Safari is not really worth it anymore.  We can just re-user the iOS Variant similar to how we use the Android Variant for chrome apps.

However; the message format is slightly different for Safari,  so the APNs sender needs to be updated