### PR TITLE
Fix withFeedbackDestination to obtain host and not port.

### DIFF
--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/APNsPushNotificationSender.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/APNsPushNotificationSender.java
@@ -40,6 +40,7 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
 import static org.jboss.aerogear.unifiedpush.message.util.ConfigurationUtils.tryGetProperty;
+import static org.jboss.aerogear.unifiedpush.message.util.ConfigurationUtils.tryGetIntegerProperty;
 
 @SenderType(iOSVariant.class)
 public class APNsPushNotificationSender implements PushNotificationSender {
@@ -50,9 +51,9 @@ public class APNsPushNotificationSender implements PushNotificationSender {
     private static final String CUSTOM_AEROGEAR_APNS_FEEDBACK_PORT = "custom.aerogear.apns.feedback.port";
     
     private static final String customAerogearApnsPushHost = tryGetProperty(CUSTOM_AEROGEAR_APNS_PUSH_HOST);
-    private static final String customAerogearApnsPushPort = tryGetProperty(CUSTOM_AEROGEAR_APNS_PUSH_PORT);
+    private static final Integer customAerogearApnsPushPort = tryGetIntegerProperty(CUSTOM_AEROGEAR_APNS_PUSH_PORT);
     private static final String customAerogearApnsFeedbackHost = tryGetProperty(CUSTOM_AEROGEAR_APNS_FEEDBACK_HOST);
-    private static final String customAerogearApnsFeedbackPort  = tryGetProperty(CUSTOM_AEROGEAR_APNS_FEEDBACK_PORT);
+    private static final Integer customAerogearApnsFeedbackPort  = tryGetIntegerProperty(CUSTOM_AEROGEAR_APNS_FEEDBACK_PORT);
 
     private final AeroGearLogger logger = AeroGearLogger.getInstance(APNsPushNotificationSender.class);
 
@@ -223,12 +224,12 @@ public class APNsPushNotificationSender implements PushNotificationSender {
     /**
      * Configure the Gateway to the Apns servers.
      * Default gateway and port can be override with respectively :
-     *  - aerogear.apns.push.host
-     *  - aerogear.apns.push.port
+     *  - custom.aerogear.apns.push.host
+     *  - custom.aerogear.apns.push.port
      *
      * Feedback gateway and port can be override with  respectively :
-     *  - aerogear.apns.feedback.host
-     *  - aerogear.apns.feedback.port
+     *  - custom.aerogear.apns.feedback.host
+     *  - custom.aerogear.apns.feedback.port
      * @param iOSVariant
      * @param builder
      */
@@ -240,18 +241,18 @@ public class APNsPushNotificationSender implements PushNotificationSender {
         if(customAerogearApnsPushHost != null){
             int port = Utilities.SANDBOX_GATEWAY_PORT;
             if(customAerogearApnsPushPort != null) {
-                port = Integer.parseInt(customAerogearApnsPushPort);
+                port = customAerogearApnsPushPort;
             }
-            builder.withGatewayDestination(customAerogearApnsPushHost,port);
+            builder.withGatewayDestination(customAerogearApnsPushHost, port);
         }
 
         //Is the feedback gateway provided by a system property, for tests ?
         if(customAerogearApnsFeedbackHost != null){
             int port = Utilities.SANDBOX_FEEDBACK_PORT;
-            if(customAerogearApnsFeedbackPort!= null) {
-                port = Integer.parseInt(customAerogearApnsFeedbackPort);
+            if(customAerogearApnsFeedbackPort != null) {
+                port = customAerogearApnsFeedbackPort;
             }
-            builder.withFeedbackDestination(customAerogearApnsFeedbackPort,port);
+            builder.withFeedbackDestination(customAerogearApnsFeedbackHost, port);
         }
     }
 }

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/util/ConfigurationUtils.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/util/ConfigurationUtils.java
@@ -41,4 +41,34 @@ public final class ConfigurationUtils {
             return null;
         }
     }
+
+    /**
+     * Try to retrieve a system property and returns null if SecurityManager blocks it.
+     *
+     * @param key Name of the system property to get the integer for.
+     * @return the value of the System property
+     */
+    public static Integer tryGetIntegerProperty(String key) {
+        return tryGetIntegerProperty(key, null);
+    }
+
+    /**
+     * Try to retrieve a system property and returns the defaultValue if SecurityManager blocks it.
+     *
+     * @param key Name of the system property to get the integer for.
+     * @param defaultValue Value to be returned on unsuccessful operation or if the propety is not set.
+     *
+     * @return the value of the System property
+     */
+    public static Integer tryGetIntegerProperty(String key, Integer defaultValue) {
+        try {
+            return Integer.getInteger(key, defaultValue);
+        } catch (SecurityException e) {
+            logger.severe("Could not get value of property " + key + " due to SecurityManager. Using null value.");
+            return defaultValue;
+        }
+    }
+
+
+
 }

--- a/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/message/util/ConfigurationUtilsTest.java
+++ b/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/message/util/ConfigurationUtilsTest.java
@@ -17,22 +17,46 @@
 package org.jboss.aerogear.unifiedpush.message.util;
 
 
+import org.junit.After;
 import org.junit.Test;
 import static org.assertj.core.api.Assertions.*;
 import java.util.Properties;
 
 public class ConfigurationUtilsTest {
 
+    private static final String TEST_PROPERTY_NAME = "ConfigurationUtilsTestProperty";
+
+    @After
+    public void cleanupTestProperty() {
+        Properties properties = System.getProperties();
+        properties.remove(TEST_PROPERTY_NAME);
+    }
+
     @Test
     public void testExistingTryGetProperty(){
-        Properties properties = System.getProperties();
-        properties.setProperty("MyNiceProp","MyNiceValue");
-        assertThat(ConfigurationUtils.tryGetProperty("MyNiceProp")).isEqualTo("MyNiceValue");
+        System.setProperty(TEST_PROPERTY_NAME, "MyNiceValue");
+        assertThat(ConfigurationUtils.tryGetProperty(TEST_PROPERTY_NAME)).isEqualTo("MyNiceValue");
     }
 
     @Test
     public void testNonExistingTryGetProperty(){
-        assertThat(ConfigurationUtils.tryGetProperty("MyNiceOtherProp")).isNull();
+        assertThat(ConfigurationUtils.tryGetProperty(TEST_PROPERTY_NAME)).isNull();
+    }
+
+    @Test
+    public void testExistingTryGetIntegerProperty() {
+        System.setProperty(TEST_PROPERTY_NAME, "123456");
+        assertThat(ConfigurationUtils.tryGetIntegerProperty(TEST_PROPERTY_NAME)).isEqualTo(123456);
+    }
+
+    @Test
+    public void testNonExistingTryGetIntegerProperty() {
+        assertThat(ConfigurationUtils.tryGetIntegerProperty(TEST_PROPERTY_NAME)).isNull();
+    }
+
+    @Test
+    public void testNonExistingTryGetIntegerPropertyWithDefaultValue() {
+        assertThat(ConfigurationUtils.tryGetIntegerProperty(TEST_PROPERTY_NAME, 123)).isEqualTo(123);
     }
 
 }


### PR DESCRIPTION
There was a typo and the `withFeedbackDestination` was getting the port instead of host resulting in push using custom mock APNS server not working. I've fixed that and added a two new methods into ConfigurationUtils to obtain Integer properties. That way it should not happen to accidentally give something that wants a `String` an `Integer`.