### PR TITLE
Make use of a separate datasource for Keycloak

### DIFF
--- a/databases/h2-database-config-wildfly.cli
+++ b/databases/h2-database-config-wildfly.cli
@@ -5,5 +5,8 @@ batch
 ## Add UnifiedPush Datasource
 data-source add --name=UnifiedPushDS --driver-name=h2 --jndi-name=java:jboss/datasources/UnifiedPushDS --connection-url="jdbc:h2:${jboss.server.data.dir}/unifiedpush;DB_CLOSE_DELAY=-1" --user-name=sa --password=sa --use-ccm=true --enabled=true
 
+## Add Keycloak Datasource
+data-source add --name=KeycloakDS --driver-name=h2 --jndi-name=java:jboss/datasources/KeycloakDS --connection-url="jdbc:h2:${jboss.server.data.dir}/keycloak;DB_CLOSE_DELAY=-1" --user-name=sa --password=sa --use-ccm=true --enabled=true
+
 run-batch
 #:reload

--- a/databases/h2-database-config.cli
+++ b/databases/h2-database-config.cli
@@ -6,5 +6,11 @@ batch
 data-source add --name=UnifiedPushDS --driver-name=h2 --jndi-name=java:jboss/datasources/UnifiedPushDS --connection-url="jdbc:h2:${jboss.server.data.dir}/unifiedpush;DB_CLOSE_DELAY=-1" --user-name=sa --password=sa --use-ccm=true
 data-source enable --name=UnifiedPushDS
 
+## Add Keycloak Datasource
+data-source add --name=KeycloakDS --driver-name=h2 --jndi-name=java:jboss/datasources/KeycloakDS --connection-url="jdbc:h2:${jboss.server.data.dir}/keycloak;DB_CLOSE_DELAY=-1" --user-name=sa --password=sa --use-ccm=true
+data-source enable --name=KeycloakDS
+
+
+
 run-batch
 #:reload

--- a/databases/mysql-database-config-wildfly.cli
+++ b/databases/mysql-database-config-wildfly.cli
@@ -8,5 +8,8 @@ batch
 ## Add UnifiedPush Datasource
 data-source add --name=UnifiedPushDS --driver-name=mysqlup --jndi-name=java:jboss/datasources/UnifiedPushDS --connection-url="jdbc:mysql://localhost:3306/unifiedpush?useUnicode=true&amp;characterEncoding=UTF-8" --user-name=unifiedpush --password=unifiedpush --use-ccm=false --max-pool-size=25 --blocking-timeout-wait-millis=5000 --enabled=true
 
+## Add Keycloak Datasource
+data-source add --name=KeycloakDS --driver-name=mysqlup --jndi-name=java:jboss/datasources/KeycloakDS --connection-url="jdbc:mysql://localhost:3306/keycloak?useUnicode=true&amp;characterEncoding=UTF-8" --user-name=unifiedpush --password=unifiedpush --use-ccm=false --max-pool-size=25 --blocking-timeout-wait-millis=5000 --enabled=true
+
 run-batch
 #:reload

--- a/databases/mysql-database-config.cli
+++ b/databases/mysql-database-config.cli
@@ -9,5 +9,9 @@ batch
 data-source add --name=UnifiedPushDS --driver-name=mysqlup --jndi-name=java:jboss/datasources/UnifiedPushDS --connection-url="jdbc:mysql://localhost:3306/unifiedpush?useUnicode=true&amp;characterEncoding=UTF-8" --user-name=unifiedpush --password=unifiedpush --use-ccm=false --max-pool-size=25 --blocking-timeout-wait-millis=5000
 data-source enable --name=UnifiedPushDS
 
+## Add Keycloak Datasource
+data-source add --name=KeycloakDS --driver-name=mysqlup --jndi-name=java:jboss/datasources/KeycloakDS --connection-url="jdbc:mysql://localhost:3306/keycloak?useUnicode=true&amp;characterEncoding=UTF-8" --user-name=unifiedpush --password=unifiedpush --use-ccm=false --max-pool-size=25 --blocking-timeout-wait-millis=5000
+data-source enable --name=KeycloakDS
+
 run-batch
 #:reload

--- a/databases/postgresql-database-config-wildfly.cli
+++ b/databases/postgresql-database-config-wildfly.cli
@@ -8,5 +8,8 @@ batch
 ## Add UnifiedPush Datasource
 data-source add --name=UnifiedPushDS --driver-name=psqlup --jndi-name=java:jboss/datasources/UnifiedPushDS --connection-url=jdbc:postgresql://localhost:5432/unifiedpush --user-name=unifiedpush --password=unifiedpush --use-ccm=false --max-pool-size=25 --blocking-timeout-wait-millis=5000 --enabled=true
 
+## Add Keycloak Datasource
+data-source add --name=KeycloakDS --driver-name=psqlup --jndi-name=java:jboss/datasources/KeycloakDS --connection-url=jdbc:postgresql://localhost:5432/keycloak --user-name=unifiedpush --password=unifiedpush --use-ccm=false --max-pool-size=25 --blocking-timeout-wait-millis=5000 --enabled=true
+
 run-batch
 #:reload

--- a/databases/postgresql-database-config.cli
+++ b/databases/postgresql-database-config.cli
@@ -9,5 +9,10 @@ batch
 data-source add --name=UnifiedPushDS --driver-name=psqlup --jndi-name=java:jboss/datasources/UnifiedPushDS --connection-url=jdbc:postgresql://localhost:5432/unifiedpush --user-name=unifiedpush --password=unifiedpush --use-ccm=false --max-pool-size=25 --blocking-timeout-wait-millis=5000
 data-source enable --name=UnifiedPushDS
 
+## Add Keycloak Datasource
+data-source add --name=KeycloakDS --driver-name=psqlup --jndi-name=java:jboss/datasources/KeycloakDS --connection-url=jdbc:postgresql://localhost:5432/keycloak --user-name=unifiedpush --password=unifiedpush --use-ccm=false --max-pool-size=25 --blocking-timeout-wait-millis=5000
+data-source enable --name=KeycloakDS
+
+
 run-batch
 #:reload

--- a/databases/unifiedpush-h2-ds.xml
+++ b/databases/unifiedpush-h2-ds.xml
@@ -23,5 +23,14 @@
             <user-name>sa</user-name>
             <password>sa</password>
         </security>
+      </datasource>
+    <datasource jndi-name="java:jboss/datasources/KeycloakDS"
+                  pool-name="KeycloakDS" enabled="true" use-java-context="true">
+        <connection-url>jdbc:h2:${jboss.server.data.dir}/keycloak;AUTO_SERVER=TRUE</connection-url>
+        <driver>h2</driver>
+        <security>
+            <user-name>sa</user-name>
+            <password>sa</password>
+        </security>
     </datasource>
 </datasources>

--- a/servers/auth-server/src/main/resources/META-INF/keycloak-server.json
+++ b/servers/auth-server/src/main/resources/META-INF/keycloak-server.json
@@ -65,7 +65,7 @@
 
     "connectionsJpa": {
         "default": {
-            "dataSource": "java:jboss/datasources/UnifiedPushDS",
+            "dataSource": "java:jboss/datasources/KeycloakDS",
             "user": "${keycloak.connectionsJpa.user:sa}",
             "password": "${keycloak.connectionsJpa.password:sa}",
             "databaseSchema": "update"


### PR DESCRIPTION
Like [reported](http://lists.jboss.org/pipermail/keycloak-dev/2015-February/003682.html) by @sebastienblanc at keycloak-dev, there's an issue after the deployment of Keycloak 1.1.0.Final and UPS pointing to the same database.

Marek [suggested](http://lists.jboss.org/pipermail/keycloak-dev/2015-February/003685.html) to split the datasources, which makes perfect sense.

That said @matzew @edewit @qmx @sebastienblanc would you mind to review?

It must go on `master` and `1.0.x` branch.