### PR TITLE
AGPUSH-1305 : add an apns section to the push message API

### DIFF
--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/sender/PushNotificationSenderEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/sender/PushNotificationSenderEndpoint.java
@@ -74,8 +74,10 @@ public class PushNotificationSenderEndpoint {
      *          "title" : "someTitle",
      *          "action-category": "some value",
      *          "content-available": true,
-     *          "action" : "someAction"
-     *          "url-args" :["args1","arg2"]
+     *          "action" : "someAction",
+     *          "url-args" :["args1","arg2"],
+     *          "localized-title-key" : "some value",
+     *          "localized-title-arguments" : ["args1","arg2"]
      *      }
      *      "simple-push": "version=123"
      *     },

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/sender/PushNotificationSenderEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/sender/PushNotificationSenderEndpoint.java
@@ -56,10 +56,8 @@ public class PushNotificationSenderEndpoint {
      *   -d '{
      *     "message": {
      *      "alert": "HELLO!",
-     *      "action-category": "some value",
      *      "sound": "default",
      *      "badge": 2,
-     *      "content-available": true,
      *      "user-data": {
      *          "key": "value",
      *          "key2": "other value"
@@ -72,6 +70,13 @@ public class PushNotificationSenderEndpoint {
      *          "images": ["Assets/test.jpg", "Assets/background.png"],
      *          "textFields": ["foreground text"]
      *      },
+     *      "apns": {
+     *          "title" : "someTitle",
+     *          "action-category": "some value",
+     *          "content-available": true,
+     *          "action" : "someAction"
+     *          "url-args" :["args1","arg2"]
+     *      }
      *      "simple-push": "version=123"
      *     },
      *     "criteria": {

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/util/transform/UserParams.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/util/transform/UserParams.java
@@ -33,8 +33,8 @@ import static java.text.MessageFormat.format;
  * UserParams is a DynamicTransformer that moves all user parameters to a separate user-data section.
  */
 public class UserParams implements DynamicTransformer {
-    private static final List<String> KNOWN_KEYS = Arrays.asList("alert", "action-category", "sound", "badge",
-            "content-available","simple-push", "user-data");
+    private static final List<String> KNOWN_KEYS = Arrays.asList("alert", "apns", "sound", "badge",
+            "simple-push", "user-data");
     public static final String MOVE_OP = "['{'\"op\": \"move\",\"from\": \"/message/{0}\",\"path\": \"/message/user-data/{0}\"'}']";
 
     @Override

--- a/jaxrs/src/main/resources/rest/sender/100.json
+++ b/jaxrs/src/main/resources/rest/sender/100.json
@@ -16,6 +16,21 @@
       "value": {}
     },
     {
+      "op": "add",
+      "path": "/message/apns",
+      "value": {}
+    },
+    {
+      "op": "move",
+      "from": "/message/action-category",
+      "path": "/message/apns/action-category"
+    },
+    {
+      "op": "move",
+      "from": "/message/content-available",
+      "path": "/message/apns/content-available"
+    },
+    {
       "op": "move",
       "from": "/alias",
       "path": "/criteria/alias"

--- a/jaxrs/src/test/resources/new-message-format.json
+++ b/jaxrs/src/test/resources/new-message-format.json
@@ -1,13 +1,15 @@
 {
   "message": {
     "alert": "HELLO!",
-    "action-category": "some value",
     "sound": "default",
     "badge": 2,
-    "content-available": true,
     "user-data": {
       "key": "value",
       "key2": "other value"
+    },
+    "apns": {
+      "content-available": true,
+      "action-category": "some value"
     },
     "simple-push": "version=123"
   },

--- a/push/model/src/main/java/org/jboss/aerogear/unifiedpush/message/Message.java
+++ b/push/model/src/main/java/org/jboss/aerogear/unifiedpush/message/Message.java
@@ -18,6 +18,7 @@ package org.jboss.aerogear.unifiedpush.message;
 
 
 import org.codehaus.jackson.annotate.JsonProperty;
+import org.jboss.aerogear.unifiedpush.message.ios.APNs;
 import org.jboss.aerogear.unifiedpush.message.windows.Windows;
 
 import java.util.HashMap;
@@ -30,18 +31,9 @@ import java.util.Map;
  * For details have a look at the <a href="http://aerogear.org/docs/specs/aerogear-push-messages/">Message Format Specification</a>.
  */
 public class Message {
-    @JsonProperty("action-category")
-    private String actionCategory;
+
     private String alert;
-    private String title;
-    private String action;
     private String sound;
-
-    @JsonProperty("url-args")
-    private String[] urlArgs;
-
-    @JsonProperty("content-available")
-    private boolean contentAvailable;
     private int badge = -1;
 
     @JsonProperty("user-data")
@@ -55,18 +47,7 @@ public class Message {
     private String consolidationKey;
 
     private Windows windows = new Windows();
-
-    /**
-     * Returns the value of the 'action-category', which is used on the client (iOS for now),
-     * to invoke a certain "user action" on the device, based on the push message. Implemented for iOS8
-     */
-    public String getActionCategory() {
-        return actionCategory;
-    }
-
-    public void setActionCategory(String actionCategory) {
-        this.actionCategory = actionCategory;
-    }
+    private APNs apns = new APNs();
 
     /**
      * Returns the value of the 'alert' key from the submitted payload.
@@ -84,25 +65,6 @@ public class Message {
         this.alert = alert;
     }
 
-    /**
-     * Returns the value of the 'title' key from the submitted payload.
-     * This key is recognized in APNs for Safari, without any API invocation and
-     * on AeroGear's GCM offerings.
-     *
-     */
-    public String getTitle() { return title; }
-
-    public void setTitle(String title) { this.title = title; }
-
-    /**
-     * Returns the value of the 'action' key from the submitted payload.
-     * This key is recognized in APNs for Safari, without any API invocation and
-     * on AeroGear's GCM offerings.
-     *
-     */
-    public String getAction() { return action; }
-
-    public void setAction(String action) { this.action = action; }
 
     /**
      * Returns the value of the 'sound' key from the submitted payload.
@@ -117,20 +79,6 @@ public class Message {
 
     public void setSound(String sound) {
         this.sound = sound;
-    }
-
-    /**
-     * Used for in iOS specific feature, to indicate if content (for Newsstand or silent messages) has marked as
-     * being available
-     *
-     * Not supported on other platforms.
-     */
-    public boolean isContentAvailable() {
-        return contentAvailable;
-    }
-
-    public void setContentAvailable(boolean contentAvailable) {
-        this.contentAvailable = contentAvailable;
     }
 
     /**
@@ -165,15 +113,6 @@ public class Message {
         this.userData = userData;
     }
 
-    /**
-     * Returns the value of the 'url-args' key from the submitted payload.
-     * This key is recognized in APNs for Safari, without any API invocation and
-     * on AeroGear's GCM offerings.
-     *
-     */
-    public String[] getUrlArgs() { return urlArgs; }
-
-    public void setUrlArgs(String[] urlArgs) { this.urlArgs = urlArgs; }
 
     /**
      * Returns the SimplePush specific version number.
@@ -221,6 +160,17 @@ public class Message {
     }
 
     /**
+     * Apns specific parameters to configure how the message will be displayed.
+     */
+    public APNs getApns() {
+        return apns;
+    }
+
+    public void setApns(APNs apns) {
+        this.apns = apns;
+    }
+
+    /**
      * Windows specific parameters to configure how the message will be displayed.
      */
     public Windows getWindows() {
@@ -234,10 +184,8 @@ public class Message {
     @Override
     public String toString() {
         return "Message{" +
-                "action-category='" + actionCategory + '\'' +
                 ", alert='" + alert + '\'' +
                 ", sound='" + sound + '\'' +
-                ", contentAvailable=" + contentAvailable +
                 ", badge=" + badge +
                 ", consolidationKey=" + consolidationKey +
                 ", user-data=" + userData +

--- a/push/model/src/main/java/org/jboss/aerogear/unifiedpush/message/Message.java
+++ b/push/model/src/main/java/org/jboss/aerogear/unifiedpush/message/Message.java
@@ -18,7 +18,7 @@ package org.jboss.aerogear.unifiedpush.message;
 
 
 import org.codehaus.jackson.annotate.JsonProperty;
-import org.jboss.aerogear.unifiedpush.message.ios.APNs;
+import org.jboss.aerogear.unifiedpush.message.apns.APNs;
 import org.jboss.aerogear.unifiedpush.message.windows.Windows;
 
 import java.util.HashMap;

--- a/push/model/src/main/java/org/jboss/aerogear/unifiedpush/message/UnifiedPushMessage.java
+++ b/push/model/src/main/java/org/jboss/aerogear/unifiedpush/message/UnifiedPushMessage.java
@@ -33,30 +33,42 @@ import java.util.LinkedHashMap;
  *
  * Messages are submitted as follows:
  * <pre>
- *  "message": {
- *   "alert": "HELLO!",
- *   "title": "Title",
- *   "action": "Safari Action",
- *   "url-args":[ "arg1", "arg2" ],
- *   "action-category": "some value",
- *   "sound": "default",
- *   "badge": 2,
- *   "content-available": true,
- *   "user-data": {
- *       "key": "value",
- *       "key2": "other value"
- *   },
- *   "simple-push": "version=123"
- *  },
- *  "criteria": {
- *      "alias": [ "someUsername" ],
- *      "deviceType": [ "someDevice" ],
- *      "categories": [ "someCategories" ],
- *      "variants": [ "someVariantIDs" ]
- *  },
- *  "config": {
- *      "ttl": 3600
- *  }
+ * {    
+ *   "message": {
+ *       "alert": "HELLO!",
+ *       "sound": "default",
+ *       "badge": 2,
+ *       "user-data": {
+ *          "key": "value",
+ *          "key2": "other value"
+ *       },
+ *       "windows": {
+ *           "type": "tile",
+ *           "duration": "short",
+ *           "badge": "alert",
+ *           "tileType": "TileWideBlockAndText01",
+ *           "images": ["Assets/test.jpg", "Assets/background.png"],
+ *           "textFields": ["foreground text"]
+ *       },
+ *       "apns": {
+ *           "title" : "someTitle",
+ *           "action-category": "some value",
+ *           "content-available": true,
+ *           "action" : "someAction"
+ *           "url-args" :["args1","arg2"]
+ *       },
+ *       "simple-push": "version=123"
+ *    },
+ *    "criteria": {
+ *         "alias": [ "someUsername" ],
+ *         "deviceType": [ "someDevice" ],
+ *         "categories": [ "someCategories" ],
+ *         "variants": [ "someVariantIDs" ]
+ *     },
+ *    "config": {
+ *         "ttl": 3600
+ *     }
+ * }
  * </pre>
  */
 public class UnifiedPushMessage {

--- a/push/model/src/main/java/org/jboss/aerogear/unifiedpush/message/UnifiedPushMessage.java
+++ b/push/model/src/main/java/org/jboss/aerogear/unifiedpush/message/UnifiedPushMessage.java
@@ -54,8 +54,10 @@ import java.util.LinkedHashMap;
  *           "title" : "someTitle",
  *           "action-category": "some value",
  *           "content-available": true,
- *           "action" : "someAction"
- *           "url-args" :["args1","arg2"]
+ *           "action" : "someAction",
+ *           "url-args" :["args1","arg2"],
+ *           "localized-title-key" : "some value",
+ *           "localized-title-arguments" : ["args1","arg2"]
  *       },
  *       "simple-push": "version=123"
  *    },

--- a/push/model/src/main/java/org/jboss/aerogear/unifiedpush/message/UnifiedPushMessage.java
+++ b/push/model/src/main/java/org/jboss/aerogear/unifiedpush/message/UnifiedPushMessage.java
@@ -33,7 +33,7 @@ import java.util.LinkedHashMap;
  *
  * Messages are submitted as follows:
  * <pre>
- * {    
+ * {
  *   "message": {
  *       "alert": "HELLO!",
  *       "sound": "default",

--- a/push/model/src/main/java/org/jboss/aerogear/unifiedpush/message/apns/APNs.java
+++ b/push/model/src/main/java/org/jboss/aerogear/unifiedpush/message/apns/APNs.java
@@ -30,6 +30,12 @@ public class APNs {
     private String title;
     private String action;
 
+    @JsonProperty("localized-title-key")
+    private String localizedTitleKey;
+
+    @JsonProperty("localized-title-arguments")
+    private String[] localizedTitleArguments;
+
     @JsonProperty("url-args")
     private String[] urlArgs;
 
@@ -88,5 +94,21 @@ public class APNs {
     public String[] getUrlArgs() { return urlArgs; }
 
     public void setUrlArgs(String[] urlArgs) { this.urlArgs = urlArgs; }
+
+    /**
+     * The key to a title string in the Localizable.strings file for the current localization.
+     */
+    public String getLocalizedTitleKey() { return localizedTitleKey;}
+
+    public void setLocalizedTitleKey(String localizedTitleKey) {this.localizedTitleKey = localizedTitleKey;}
+
+    /**
+     * Sets the arguments for the localizable title key
+     */
+    public String[] getLocalizedTitleArguments() { return localizedTitleArguments;}
+
+    public void setLocalizedTitleArguments(String[] localizedTitleArguments) {this.localizedTitleArguments = localizedTitleArguments;}
+
+
 
 }

--- a/push/model/src/main/java/org/jboss/aerogear/unifiedpush/message/apns/APNs.java
+++ b/push/model/src/main/java/org/jboss/aerogear/unifiedpush/message/apns/APNs.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.aerogear.unifiedpush.message.ios;
+package org.jboss.aerogear.unifiedpush.message.apns;
 
 import org.codehaus.jackson.annotate.JsonProperty;
 import org.codehaus.jackson.map.annotate.JsonRootName;

--- a/push/model/src/main/java/org/jboss/aerogear/unifiedpush/message/ios/APNs.java
+++ b/push/model/src/main/java/org/jboss/aerogear/unifiedpush/message/ios/APNs.java
@@ -1,0 +1,92 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright Red Hat, Inc., and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.aerogear.unifiedpush.message.ios;
+
+import org.codehaus.jackson.annotate.JsonProperty;
+import org.codehaus.jackson.map.annotate.JsonRootName;
+
+/**
+ * iOS specific settings for Push Notifications
+ */
+@JsonRootName("apns")
+public class APNs {
+
+    @JsonProperty("action-category")
+    private String actionCategory;
+    private String title;
+    private String action;
+
+    @JsonProperty("url-args")
+    private String[] urlArgs;
+
+    @JsonProperty("content-available")
+    private boolean contentAvailable;
+
+    /**
+     * Returns the value of the 'action-category', which is used on the client (iOS for now),
+     * to invoke a certain "user action" on the device, based on the push message. Implemented for iOS8
+     */
+    public String getActionCategory() {
+        return actionCategory;
+    }
+
+    public void setActionCategory(String actionCategory) {
+        this.actionCategory = actionCategory;
+    }
+
+    /**
+     * Returns the value of the 'title' key from the submitted payload.
+     * This key is recognized in APNs for Safari, without any API invocation.
+     *
+     */
+    public String getTitle() { return title; }
+
+    public void setTitle(String title) { this.title = title; }
+
+    /**
+     * Returns the value of the 'action' key from the submitted payload.
+     * This key is recognized in APNs for Safari.
+     *
+     */
+    public String getAction() { return action; }
+
+    public void setAction(String action) { this.action = action; }
+
+    /**
+     * Used for in iOS specific feature, to indicate if content (for Newsstand or silent messages) has marked as
+     * being available
+     *
+     * Not supported on other platforms.
+     */
+    public boolean isContentAvailable() {
+        return contentAvailable;
+    }
+
+    public void setContentAvailable(boolean contentAvailable) {
+        this.contentAvailable = contentAvailable;
+    }
+
+    /**
+     * Returns the value of the 'url-args' key from the submitted payload.
+     * This key is recognized in APNs for Safari.
+     *
+     */
+    public String[] getUrlArgs() { return urlArgs; }
+
+    public void setUrlArgs(String[] urlArgs) { this.urlArgs = urlArgs; }
+
+}

--- a/push/model/src/test/java/org/jboss/aerogear/unifiedpush/message/UnifiedPushMessageTest.java
+++ b/push/model/src/test/java/org/jboss/aerogear/unifiedpush/message/UnifiedPushMessageTest.java
@@ -329,6 +329,38 @@ public class UnifiedPushMessageTest {
     }
 
     @Test
+    public void testLocalizedTitleKey() throws IOException {
+        final Map<String, Object> container = new LinkedHashMap<String, Object>();
+        final Map<String, Object> messageObject = new LinkedHashMap<String, Object>();
+        final Map<String, Object> apnsObject = new LinkedHashMap<String, Object>();
+
+        apnsObject.put("localized-title-key", "myLocalizedTitle");
+        messageObject.put("alert", "Howdy");
+        messageObject.put("apns",apnsObject);
+        container.put("message", messageObject);
+
+        // parse it:
+        final UnifiedPushMessage unifiedPushMessage = parsePushMessage(container);
+        assertEquals("myLocalizedTitle", unifiedPushMessage.getMessage().getApns().getLocalizedTitleKey());
+    }
+
+    @Test
+    public void testLocalizedTitleArguments() throws IOException {
+        final Map<String, Object> container = new LinkedHashMap<String, Object>();
+        final Map<String, Object> messageObject = new LinkedHashMap<String, Object>();
+        final Map<String, Object> apnsObject = new LinkedHashMap<String, Object>();
+        String[] arguments = {"Jambon","ham"};
+        apnsObject.put("localized-title-arguments", arguments);
+        messageObject.put("alert", "Howdy");
+        messageObject.put("apns",apnsObject);
+        container.put("message", messageObject);
+
+        // parse it:
+        final UnifiedPushMessage unifiedPushMessage = parsePushMessage(container);
+        assertEquals("[Jambon, ham]", Arrays.toString(unifiedPushMessage.getMessage().getApns().getLocalizedTitleArguments()));
+    }
+
+    @Test
     public void testMultipleAliasCriteria() throws IOException {
         final Map<String, Object> container = new LinkedHashMap<String, Object>();
         final Map<String, Object> messageObject = new LinkedHashMap<String, Object>();

--- a/push/model/src/test/java/org/jboss/aerogear/unifiedpush/message/UnifiedPushMessageTest.java
+++ b/push/model/src/test/java/org/jboss/aerogear/unifiedpush/message/UnifiedPushMessageTest.java
@@ -51,13 +51,13 @@ public class UnifiedPushMessageTest {
         Message message = new Message();
 
         message.setAlert("HELLO!");
-        message.setActionCategory("some value");
+        message.getApns().setActionCategory("some value");
         message.setSound("default");
         message.setBadge(2);
         message.setPage("/MainPage.xaml");
         message.getWindows().setType(Type.tile);
         message.getWindows().setTileType(TileType.TileWideBlockAndText01);
-        message.setContentAvailable(true);
+        message.getApns().setContentAvailable(true);
 
         final HashMap<String, Object> data = new HashMap<String, Object>();
         data.put("key", "value");
@@ -205,6 +205,7 @@ public class UnifiedPushMessageTest {
 
         final Map<String, Object> container = new LinkedHashMap<String, Object>();
         final Map<String, Object> messageObject = new LinkedHashMap<String, Object>();
+        final Map<String, Object> apnsObject = new LinkedHashMap<String, Object>();
 
         messageObject.put("alert", "Howdy");
         messageObject.put("sound", "default");
@@ -213,8 +214,8 @@ public class UnifiedPushMessageTest {
         data.put("someKey", "someValue");
         messageObject.put("user-data", data);
 
-        messageObject.put("content-available", true);
-
+        apnsObject .put("content-available", true);
+        messageObject.put("apns",apnsObject );
         container.put("message", messageObject);
 
         // parse it:
@@ -222,7 +223,7 @@ public class UnifiedPushMessageTest {
 
         assertEquals("Howdy", unifiedPushMessage.getMessage().getAlert());
         assertEquals(-1, unifiedPushMessage.getMessage().getBadge());
-        assertTrue(unifiedPushMessage.getMessage().isContentAvailable());
+        assertTrue(unifiedPushMessage.getMessage().getApns().isContentAvailable());
     }
 
     @Test
@@ -244,7 +245,7 @@ public class UnifiedPushMessageTest {
 
         assertEquals("Howdy", unifiedPushMessage.getMessage().getAlert());
         assertEquals(-1, unifiedPushMessage.getMessage().getBadge());
-        assertFalse(unifiedPushMessage.getMessage().isContentAvailable());
+        assertFalse(unifiedPushMessage.getMessage().getApns().isContentAvailable());
     }
 
     @Test
@@ -278,15 +279,17 @@ public class UnifiedPushMessageTest {
     public void testAction() throws IOException{
         final Map<String, Object> container = new LinkedHashMap<String, Object>();
         final Map<String, Object> messageObject = new LinkedHashMap<String, Object>();
+        final Map<String, Object> apnsObject = new LinkedHashMap<String, Object>();
+
+        apnsObject.put("action", "View");
 
         messageObject.put("alert", "howdy");
-        messageObject.put("action", "View");
-
+        messageObject.put("apns",apnsObject);
         container.put("message", messageObject);
 
         // parse it:
         final UnifiedPushMessage unifiedPushMessage = parsePushMessage(container);
-        assertEquals("View", unifiedPushMessage.getMessage().getAction());
+        assertEquals("View", unifiedPushMessage.getMessage().getApns().getAction());
 
     }
 
@@ -294,34 +297,35 @@ public class UnifiedPushMessageTest {
     public void testUrlArgs() throws IOException {
         final Map<String, Object> container = new LinkedHashMap<String, Object>();
         final Map<String, Object> messageObject = new LinkedHashMap<String, Object>();
+        final Map<String, Object> apnsObject = new LinkedHashMap<String, Object>();
         final String[] urlArgs = { "Arg1", "Arg2" };
 
-
-
+        apnsObject.put("title", "I'm a Title");
+        apnsObject.put("url-args", urlArgs);
+        messageObject.put("apns",apnsObject);
         messageObject.put("alert", "howdy");
-        messageObject.put("title", "I'm a Title");
-        messageObject.put("url-args", urlArgs);
 
         container.put("message", messageObject);
 
         // parse it:
         final UnifiedPushMessage unifiedPushMessage = parsePushMessage(container);
-        assertEquals("[Arg1, Arg2]", Arrays.toString(unifiedPushMessage.getMessage().getUrlArgs()));
+        assertEquals("[Arg1, Arg2]", Arrays.toString(unifiedPushMessage.getMessage().getApns().getUrlArgs()));
     }
 
     @Test
     public void testActionCategory() throws IOException {
         final Map<String, Object> container = new LinkedHashMap<String, Object>();
         final Map<String, Object> messageObject = new LinkedHashMap<String, Object>();
+        final Map<String, Object> apnsObject = new LinkedHashMap<String, Object>();
 
+        apnsObject.put("action-category", "POSTS");
         messageObject.put("alert", "Howdy");
-        messageObject.put("action-category", "POSTS");
-
+        messageObject.put("apns",apnsObject);
         container.put("message", messageObject);
 
         // parse it:
         final UnifiedPushMessage unifiedPushMessage = parsePushMessage(container);
-        assertEquals("POSTS", unifiedPushMessage.getMessage().getActionCategory());
+        assertEquals("POSTS", unifiedPushMessage.getMessage().getApns().getActionCategory());
     }
 
     @Test
@@ -556,6 +560,7 @@ public class UnifiedPushMessageTest {
         //given
         final Map<String, Object> container = new LinkedHashMap<String, Object>();
         final Map<String, Object> messageObject = new LinkedHashMap<String, Object>();
+        final Map<String, Object> apnsObject = new LinkedHashMap<String, Object>();
 
         messageObject.put("alert", "HELLO!");
         messageObject.put("sound", "default");
@@ -565,13 +570,14 @@ public class UnifiedPushMessageTest {
         data.put("key", "value");
         data.put("key2", "value");
         messageObject.put("user-data", data);
-        messageObject.put("action-category", "category");
-        messageObject.put("content-available", "true");
+        apnsObject.put("action-category", "category");
+        apnsObject.put("content-available", "true");
         messageObject.put("simple-push", "version=123");
         Map<String, Object> windows = new HashMap<String, Object>();
         windows.put("type", "tile");
         windows.put("tileType", "TileWideBlockAndText01");
         messageObject.put("windows", windows);
+        messageObject.put("apns",apnsObject);
 
         container.put("message", messageObject);
 

--- a/push/model/src/test/resources/message-format.json
+++ b/push/model/src/test/resources/message-format.json
@@ -23,7 +23,9 @@
       "action": null,
       "action-category": "some value",
       "url-args": null,
-      "content-available": true
+      "content-available": true,
+      "localized-title-key": null,
+      "localized-title-arguments": null
     },
 
     "user-data": {

--- a/push/model/src/test/resources/message-format.json
+++ b/push/model/src/test/resources/message-format.json
@@ -3,8 +3,6 @@
   "clientIdentifier": null,
   "message": {
     "alert": "HELLO!",
-    "title": null,
-    "action": null,
     "sound": "default",
     "badge": 2,
     "page": "/MainPage.xaml",
@@ -20,9 +18,14 @@
       "textFields": [
       ]
     },
-    "action-category": "some value",
-    "url-args": null,
-    "content-available": true,
+    "apns": {
+      "title": null,
+      "action": null,
+      "action-category": "some value",
+      "url-args": null,
+      "content-available": true
+    },
+
     "user-data": {
       "key2": "other value",
       "key": "value"

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/APNsPushNotificationSender.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/APNsPushNotificationSender.java
@@ -83,15 +83,21 @@ public class APNsPushNotificationSender implements PushNotificationSender {
                 .alertTitle(apns.getTitle()) // The title of the notification in Safari
                 .alertAction(apns.getAction()) // The label of the action button, if the user sets the notifications to appear as alerts in Safari.
                 .urlArgs(apns.getUrlArgs())
-                .category(apns.getActionCategory()); // iOS8: User Action category
+                .category(apns.getActionCategory()) // iOS8: User Action category
+                .localizedTitleKey(apns.getLocalizedTitleKey()); //iOS8 : Localized Title Key
 
-                // apply the 'content-available:1' value:
-                if (apns.isContentAvailable()) {
-                    // content-available is for 'silent' notifications and Newsstand
-                    builder = builder.instantDeliveryOrSilentNotification();
-                }
+        //this kind of check should belong in java-apns
+        if(apns.getLocalizedTitleArguments() != null) {
+            builder .localizedArguments(apns.getLocalizedTitleArguments()); //iOS8 : Localized Title Arguments;
+        }
 
-                builder = builder.customFields(message.getUserData()); // adding other (submitted) fields
+       // apply the 'content-available:1' value:
+        if (apns.isContentAvailable()) {
+            // content-available is for 'silent' notifications and Newsstand
+            builder = builder.instantDeliveryOrSilentNotification();
+        }
+
+        builder = builder.customFields(message.getUserData()); // adding other (submitted) fields
 
         // we are done with adding values here, before building let's check if the msg is too long
         if (builder.isTooLong()) {

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/APNsPushNotificationSender.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/APNsPushNotificationSender.java
@@ -30,6 +30,7 @@ import org.jboss.aerogear.unifiedpush.api.Variant;
 import org.jboss.aerogear.unifiedpush.api.iOSVariant;
 import org.jboss.aerogear.unifiedpush.message.Message;
 import org.jboss.aerogear.unifiedpush.message.UnifiedPushMessage;
+import org.jboss.aerogear.unifiedpush.message.ios.APNs;
 import org.jboss.aerogear.unifiedpush.service.ClientInstallationService;
 import org.jboss.aerogear.unifiedpush.utils.AeroGearLogger;
 
@@ -73,18 +74,19 @@ public class APNsPushNotificationSender implements PushNotificationSender {
         final iOSVariant iOSVariant = (iOSVariant) variant;
 
         Message message = pushMessage.getMessage();
+        APNs apns = message.getApns();
         PayloadBuilder builder = APNS.newPayload()
                 // adding recognized key values
                 .alertBody(message.getAlert()) // alert dialog, in iOS or Safari
                 .badge(message.getBadge()) // little badge icon update;
                 .sound(message.getSound()) // sound to be played by app
-                .alertTitle(message.getApns().getTitle()) // The title of the notification in Safari
-                .alertAction(message.getApns().getAction()) // The label of the action button, if the user sets the notifications to appear as alerts in Safari.
-                .urlArgs(message.getApns().getUrlArgs())
-                .category(message.getApns().getActionCategory()); // iOS8: User Action category
+                .alertTitle(apns.getTitle()) // The title of the notification in Safari
+                .alertAction(apns.getAction()) // The label of the action button, if the user sets the notifications to appear as alerts in Safari.
+                .urlArgs(apns.getUrlArgs())
+                .category(apns.getActionCategory()); // iOS8: User Action category
 
                 // apply the 'content-available:1' value:
-                if (message.getApns().isContentAvailable()) {
+                if (apns.isContentAvailable()) {
                     // content-available is for 'silent' notifications and Newsstand
                     builder = builder.instantDeliveryOrSilentNotification();
                 }

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/APNsPushNotificationSender.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/APNsPushNotificationSender.java
@@ -76,15 +76,15 @@ public class APNsPushNotificationSender implements PushNotificationSender {
         PayloadBuilder builder = APNS.newPayload()
                 // adding recognized key values
                 .alertBody(message.getAlert()) // alert dialog, in iOS or Safari
-                .alertTitle(message.getTitle()) // The title of the notification in Safari
-                .alertAction(message.getAction()) // The label of the action button, if the user sets the notifications to appear as alerts in Safari.
-                .urlArgs(message.getUrlArgs())
                 .badge(message.getBadge()) // little badge icon update;
                 .sound(message.getSound()) // sound to be played by app
-                .category(message.getActionCategory()); // iOS8: User Action category
+                .alertTitle(message.getApns().getTitle()) // The title of the notification in Safari
+                .alertAction(message.getApns().getAction()) // The label of the action button, if the user sets the notifications to appear as alerts in Safari.
+                .urlArgs(message.getApns().getUrlArgs())
+                .category(message.getApns().getActionCategory()); // iOS8: User Action category
 
                 // apply the 'content-available:1' value:
-                if (message.isContentAvailable()) {
+                if (message.getApns().isContentAvailable()) {
                     // content-available is for 'silent' notifications and Newsstand
                     builder = builder.instantDeliveryOrSilentNotification();
                 }

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/APNsPushNotificationSender.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/APNsPushNotificationSender.java
@@ -80,7 +80,7 @@ public class APNsPushNotificationSender implements PushNotificationSender {
                 .alertBody(message.getAlert()) // alert dialog, in iOS or Safari
                 .badge(message.getBadge()) // little badge icon update;
                 .sound(message.getSound()) // sound to be played by app
-                .alertTitle(apns.getTitle()) // The title of the notification in Safari
+                .alertTitle(apns.getTitle()) // The title of the notification in Safari and Apple Watch
                 .alertAction(apns.getAction()) // The label of the action button, if the user sets the notifications to appear as alerts in Safari.
                 .urlArgs(apns.getUrlArgs())
                 .category(apns.getActionCategory()) // iOS8: User Action category

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/APNsPushNotificationSender.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/APNsPushNotificationSender.java
@@ -30,7 +30,7 @@ import org.jboss.aerogear.unifiedpush.api.Variant;
 import org.jboss.aerogear.unifiedpush.api.iOSVariant;
 import org.jboss.aerogear.unifiedpush.message.Message;
 import org.jboss.aerogear.unifiedpush.message.UnifiedPushMessage;
-import org.jboss.aerogear.unifiedpush.message.ios.APNs;
+import org.jboss.aerogear.unifiedpush.message.apns.APNs;
 import org.jboss.aerogear.unifiedpush.service.ClientInstallationService;
 import org.jboss.aerogear.unifiedpush.utils.AeroGearLogger;
 


### PR DESCRIPTION
Like we did for Windows, moving specific payload for iOS/Safari to its own section
@edewit @corinnekrych @cvasilak You mind to review ?