### PR TITLE
Adding migration to dist

### DIFF
--- a/dist/src/main/assembly/assembly.xml
+++ b/dist/src/main/assembly/assembly.xml
@@ -37,6 +37,14 @@
                 <include>*.war</include>
             </includes>
         </fileSet>
+        <!-- Bundle the migration distribution --> 
+        <fileSet>
+            <directory>${project.basedir}/../migrator/target</directory>
+            <outputDirectory>/migration</outputDirectory>
+            <includes>
+                <include>*.zip</include>
+            </includes>
+        </fileSet>
         <!-- Bundle the unifiedpush-* source JAR files --> 
         <fileSet>
             <directory>target/src</directory>

--- a/dist/src/main/assembly/assembly.xml
+++ b/dist/src/main/assembly/assembly.xml
@@ -40,7 +40,7 @@
         <!-- Bundle the migration distribution --> 
         <fileSet>
             <directory>${project.basedir}/../migrator/target</directory>
-            <outputDirectory>/migration</outputDirectory>
+            <outputDirectory>/migrator</outputDirectory>
             <includes>
                 <include>*.zip</include>
             </includes>


### PR DESCRIPTION
 to ensure the migration tool is part of the UPS distribution archive 

How to test?

Run  `mvn clean install -Pdist,test` on the branch and make sure the migration tool is there