### PR TITLE
Oauth client and nodejs sample

### DIFF
--- a/directgrant.js
+++ b/directgrant.js
@@ -1,0 +1,61 @@
+var http = require('http');
+
+
+var options = {
+    host: 'localhost',
+    path: '/auth/realms/aerogear/tokens/grants/access',
+    //since we are listening on a custom port, we need to specify it by hand
+    port: '8080',
+    //This is what changes the request to a POST request
+    method: 'POST',
+    headers: {
+        'Content-Type': 'application/x-www-form-urlencoded'
+    }
+};
+
+callback = function(response) {
+    var str = ''
+    response.on('data', function (chunk) {
+        console.log("receiving data");
+        str += chunk;
+    });
+
+    response.on('end', function () {
+        var response = JSON.parse(str);
+        var access_token = response.access_token;
+        console.log(access_token);
+        //let's create an application
+        var upsOptions = {
+            host: 'localhost',
+            path: '/ag-push/rest/applications/',
+            port: '8080',
+            //This is what changes the request to a POST request
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization' : 'Bearer ' + access_token
+            }
+        };
+        var upsReq = http.request(upsOptions, upsCallback);
+        upsReq.write("{\"description\":\"test direct grant\",\"name\":\"directGrantCreatedApp\"}");
+        upsReq.end();
+
+    });
+}
+
+upsCallback = function(response) {
+    var str = ''
+    response.on('data', function (chunk) {
+        console.log("receiving data");
+        str += chunk;
+    });
+
+    response.on('end', function () {
+        console.log(str);
+    });
+}
+
+var req = http.request(options, callback);
+//This is the data we are posting, it needs to be a string or a buffer
+req.write("username=admin&password=123&client_id=ups-client");
+req.end();

--- a/servers/auth-server/src/main/webapp/WEB-INF/ups-realm.json
+++ b/servers/auth-server/src/main/webapp/WEB-INF/ups-realm.json
@@ -23,9 +23,6 @@
                 { "type" : "password",
                     "value" : "123" }
             ],
-            "requiredActions": [
-                "UPDATE_PASSWORD"
-            ],
             "realmRoles": [ "admin" ],
             "applicationRoles": {
                "realm-management": [ "realm-admin" ],
@@ -38,9 +35,6 @@
             "credentials" : [
                 { "type" : "password",
                     "value" : "developer" }
-            ],
-            "requiredActions": [
-                "UPDATE_PASSWORD"
             ],
             "realmRoles": [ "developer" ],
             "applicationRoles": {
@@ -64,6 +58,10 @@
         {
             "client": "unified-push-server-js",
             "roles": ["admin", "developer"]
+        },
+        {
+            "client": "ups-client",
+            "roles": ["admin", "developer"]
         }
     ],
     "applications": [
@@ -81,5 +79,14 @@
                 "/ag-push/*"
             ]
         }
+    ],
+    "oauthClients": [
+        {
+            "name": "ups-client",
+            "enabled": true,
+            "publicClient": true,
+            "directGrantsOnly": true
+        }
     ]
+
 }

--- a/servers/auth-server/src/main/webapp/WEB-INF/ups-realm.json
+++ b/servers/auth-server/src/main/webapp/WEB-INF/ups-realm.json
@@ -6,6 +6,7 @@
     "accessCodeLifespanUserAction": 300,
     "ssoSessionIdleTimeout": 600,
     "ssoSessionMaxLifespan": 36000,
+    "passwordCredentialGrantAllowed": true,
     "sslRequired": "external",
     "registrationAllowed": false,
     "social": false,


### PR DESCRIPTION
In this PR : 
- Added an oauth client with "direct grant only" enabled and scope mappings
- Removed the required action "update_password"
- added a simple nodejs script that : logs in to retrieve the access token and then create a push application.

@matzew can you take a look ? 