### PR TITLE
add new user creation script and enable full scope for oauth client

### DIFF
--- a/directgrant.js
+++ b/directgrant.js
@@ -1,4 +1,4 @@
-var http = require('http');
+var http = require('http'); // replace with require('https') for ssl support
 
 
 var options = {

--- a/newuser.js
+++ b/newuser.js
@@ -1,0 +1,61 @@
+var http = require('http'); // replace with require('https') for ssl support
+
+
+var options = {
+  host: 'localhost',
+  path: '/auth/realms/aerogear/tokens/grants/access',
+  //since we are listening on a custom port, we need to specify it by hand
+  port: '8080',
+  //This is what changes the request to a POST request
+  method: 'POST',
+  headers: {
+          'Content-Type': 'application/x-www-form-urlencoded'
+      }
+};
+
+callback = function(response) {
+  var str = ''
+  response.on('data', function (chunk) {
+    console.log("receiving data");
+    str += chunk;
+  });
+
+  response.on('end', function () {
+    var response = JSON.parse(str);
+    var access_token = response.access_token;
+    console.log(response);
+    //let's create an application
+    var upsOptions = {
+      host: 'localhost',
+      path: '/auth/admin/realms/aerogear/users',
+      port: '8080',
+     //This is what changes the request to a POST request
+     method: 'POST',
+      headers: {
+          'Content-Type': 'application/json',
+          'Authorization' : 'Bearer ' + access_token
+      }
+    };
+    var upsReq = http.request(upsOptions, upsCallback);
+    upsReq.write("{\"enabled\":true,\"username\":\"bob\", \"credentials\" : [ { \"type\" : \"password\",\"value\" : \"password\" }]}");
+    upsReq.end();
+
+  });
+}
+
+upsCallback = function(response) {
+  var str = ''
+  response.on('data', function (chunk) {
+    console.log("receiving data");
+    str += chunk;
+  });
+
+  response.on('end', function () {
+   console.log(str);
+  });
+}
+
+var req = http.request(options, callback);
+//This is the data we are posting, it needs to be a string or a buffer
+req.write("username=admin&password=123&client_id=ups-client");
+req.end();

--- a/servers/auth-server/src/main/webapp/WEB-INF/ups-realm.json
+++ b/servers/auth-server/src/main/webapp/WEB-INF/ups-realm.json
@@ -25,7 +25,7 @@
             ],
             "realmRoles": [ "admin" ],
             "applicationRoles": {
-               "realm-management": [ "realm-admin"],
+               "realm-management": [ "realm-admin" ],
                "account": [ "manage-account" ]
             }
         },

--- a/servers/auth-server/src/main/webapp/WEB-INF/ups-realm.json
+++ b/servers/auth-server/src/main/webapp/WEB-INF/ups-realm.json
@@ -25,7 +25,7 @@
             ],
             "realmRoles": [ "admin" ],
             "applicationRoles": {
-               "realm-management": [ "realm-admin" ],
+               "realm-management": [ "realm-admin"],
                "account": [ "manage-account" ]
             }
         },
@@ -85,7 +85,8 @@
             "name": "ups-client",
             "enabled": true,
             "publicClient": true,
-            "directGrantsOnly": true
+            "directGrantsOnly": true,
+            "fullScopeAllowed" : true
         }
     ]
 


### PR DESCRIPTION
* Script that shows how to create an user
* Allow full scope for the oauth client (to have user creation rights)

BTW, I tested the scripts against https (on openshift) and it works, https node mod must be used instead of http.

@matzew can you review ? 
