### PR TITLE
AGPUSH-971 : Advanced Analytics, Server Side implementation

### DIFF
--- a/admin-ui/app/views/notification.html
+++ b/admin-ui/app/views/notification.html
@@ -56,6 +56,18 @@
                       <td>Message:</td>
                       <td colspan="2"><strong>{{ activityCtrl.parse(metric).alert }}</strong></td>
                     </tr>
+                    <tr>
+                      <td>Installations being opened:</td>
+                      <td colspan="2">{{ metric.appOpenCounter }}</td>
+                    </tr>
+                    <tr>
+                      <td>First time being opened:</td>
+                      <td colspan="2">{{ metric.firstOpenDate | date : 'd MMM, HH:mm:ss, yyyy'}}</td>
+                    </tr>
+                    <tr>
+                      <td>last time being opened:</td>
+                      <td colspan="2">{{ metric.lastOpenDate | date : 'd MMM, HH:mm:ss, yyyy'}}</td>
+                    </tr>
                   </table>
                   <hr ng-show="metric.deliveryFailed">
                   <table ng-show="metric.deliveryFailed">
@@ -67,18 +79,6 @@
                     <tr ng-if="activityCtrl.detailsPage()">
                       <td>Reason:</td>
                       <td colspan="2">{{ metric.variantInformations[0].reason }}</td>
-                    </tr>
-                    <tr>
-                      <td>Isntallations being opened:</td>
-                      <td colspan="2">{{ metric.appOpenCounter}}</td>
-                    </tr>
-                    <tr>
-                      <td>First time being opened:</td>
-                      <td colspan="2">{{ metric.firstOpenDate}}</td>
-                    </tr>
-                    <tr>
-                      <td>last time being opened:</td>
-                      <td colspan="2">{{ metric.lastOpenDate}}</td>
                     </tr>
                   </table>
                   <hr ng-show="!activityCtrl.detailsPage() && metric.variantInformations.length">

--- a/admin-ui/app/views/notification.html
+++ b/admin-ui/app/views/notification.html
@@ -68,6 +68,18 @@
                       <td>Reason:</td>
                       <td colspan="2">{{ metric.variantInformations[0].reason }}</td>
                     </tr>
+                    <tr>
+                      <td>Isntallations being opened:</td>
+                      <td colspan="2">{{ metric.appOpenCounter}}</td>
+                    </tr>
+                    <tr>
+                      <td>First time being opened:</td>
+                      <td colspan="2">{{ metric.firstOpenDate}}</td>
+                    </tr>
+                    <tr>
+                      <td>last time being opened:</td>
+                      <td colspan="2">{{ metric.lastOpenDate}}</td>
+                    </tr>
                   </table>
                   <hr ng-show="!activityCtrl.detailsPage() && metric.variantInformations.length">
                   <table ng-if="!activityCtrl.detailsPage() && metric.variantInformations.length">

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/installations/InstallationRegistrationEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/installations/InstallationRegistrationEndpoint.java
@@ -139,12 +139,13 @@ public class InstallationRegistrationEndpoint extends AbstractBaseEndpoint {
                     pushMessageInformation.setLastOpenDate(new Date());
                 } else {
                     pushMessageInformation.setFirstOpenDate(new Date());
+                    pushMessageInformation.setLastOpenDate(new Date());
                 }
 
-                long counter = pushMessageInformation.getAppOpenCounter();
-                pushMessageInformation.setAppOpenCounter(counter++);
+
+                pushMessageInformation.setAppOpenCounter(pushMessageInformation.getAppOpenCounter() + 1);
                 metricsService.updatePushMessageInformation(pushMessageInformation);
-                logger.info("Mobile Application opened for the " + counter + " time.");
+                logger.info("Mobile Application opened for the " + pushMessageInformation.getAppOpenCounter() + " time.");
             }
         }
         // async:

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/installations/InstallationRegistrationEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/installations/InstallationRegistrationEndpoint.java
@@ -19,7 +19,6 @@ package org.jboss.aerogear.unifiedpush.rest.registry.installations;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.jboss.aerogear.unifiedpush.api.Installation;
-import org.jboss.aerogear.unifiedpush.api.PushMessageInformation;
 import org.jboss.aerogear.unifiedpush.api.Variant;
 import org.jboss.aerogear.unifiedpush.rest.AbstractBaseEndpoint;
 import org.jboss.aerogear.unifiedpush.service.metrics.PushMessageMetricsService;
@@ -39,7 +38,6 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.Response.Status;
 import java.io.IOException;
-import java.util.Date;
 import java.util.List;
 
 @Path("/registry/device")
@@ -127,26 +125,10 @@ public class InstallationRegistrationEndpoint extends AbstractBaseEndpoint {
         logger.finest("Mobile Application on device was launched");
 
         //let's do update the analytics
-        //TODO should move to the service layer
+
         String pushIdentifier = extractPushIdentifier(request);
-        logger.info("PUSHIDENTIFIER : " + pushIdentifier);
         if(pushIdentifier != null) {
-            PushMessageInformation pushMessageInformation = metricsService.getPushMessageInformation(pushIdentifier);
-            if (pushMessageInformation != null) { //if we are here, app has been opened due to a push message
-
-                //if the firstOpenDate is not null that means it's no the first one, let's update the lastDateOpen
-                if (pushMessageInformation.getFirstOpenDate() != null) {
-                    pushMessageInformation.setLastOpenDate(new Date());
-                } else {
-                    pushMessageInformation.setFirstOpenDate(new Date());
-                    pushMessageInformation.setLastOpenDate(new Date());
-                }
-
-
-                pushMessageInformation.setAppOpenCounter(pushMessageInformation.getAppOpenCounter() + 1);
-                metricsService.updatePushMessageInformation(pushMessageInformation);
-                logger.info("Mobile Application opened for the " + pushMessageInformation.getAppOpenCounter() + " time.");
-            }
+            metricsService.updateAnalytics(pushIdentifier, variant.getVariantID());
         }
         // async:
         clientInstallationService.addInstallation(variant, entity);

--- a/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/PushMessageInformation.java
+++ b/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/PushMessageInformation.java
@@ -117,6 +117,11 @@ public class PushMessageInformation extends BaseModel {
         this.totalReceivers = totalReceivers;
     }
 
+    /**
+     * The number of time this Push Application was opened after a Push Notification
+     *
+     * @return the number of time this Push Application was opened after a Push Notification
+     */
     public long getAppOpenCounter() {
         return appOpenCounter;
     }
@@ -125,6 +130,11 @@ public class PushMessageInformation extends BaseModel {
         this.appOpenCounter = appOpenCounter;
     }
 
+    /**
+     * The date of the first time this Push Application was opened after a Push Notification
+     *
+     * @return the date of the first time this Push Application was opened after a Push Notification
+     */
     public Date getFirstOpenDate() {
         return firstOpenDate;
     }
@@ -133,6 +143,11 @@ public class PushMessageInformation extends BaseModel {
         this.firstOpenDate = firstOpenDate;
     }
 
+    /**
+     * The date of the last time this Push Application was opened after a Push Notification
+     *
+     * @return the date of the last time this Push Application was opened after a Push Notification
+     */
     public Date getLastOpenDate() {
         return lastOpenDate;
     }

--- a/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/PushMessageInformation.java
+++ b/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/PushMessageInformation.java
@@ -36,6 +36,10 @@ public class PushMessageInformation extends BaseModel {
     private Date submitDate = new Date();
     private long totalReceivers;
 
+    private long appOpenCounter;
+    private Date firstOpenDate;
+    private Date lastOpenDate;
+
     private Set<VariantMetricInformation> variantInformations = new HashSet<VariantMetricInformation>();
 
     /**
@@ -111,6 +115,30 @@ public class PushMessageInformation extends BaseModel {
 
     public void setTotalReceivers(long totalReceivers) {
         this.totalReceivers = totalReceivers;
+    }
+
+    public long getAppOpenCounter() {
+        return appOpenCounter;
+    }
+
+    public void setAppOpenCounter(long appOpenCounter) {
+        this.appOpenCounter = appOpenCounter;
+    }
+
+    public Date getFirstOpenDate() {
+        return firstOpenDate;
+    }
+
+    public void setFirstOpenDate(Date firstOpenDate) {
+        this.firstOpenDate = firstOpenDate;
+    }
+
+    public Date getLastOpenDate() {
+        return lastOpenDate;
+    }
+
+    public void setLastOpenDate(Date lastOpenDate) {
+        this.lastOpenDate = lastOpenDate;
     }
 
     public void addVariantInformations(VariantMetricInformation variantMetricInformation) {

--- a/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/VariantMetricInformation.java
+++ b/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/VariantMetricInformation.java
@@ -31,6 +31,7 @@ public class VariantMetricInformation extends BaseModel {
     private long receivers;
     private Boolean deliveryStatus = Boolean.FALSE;
     private String reason;
+    private long variantOpenCounter;
 
     @JsonIgnore
     private PushMessageInformation pushMessageInformation;
@@ -88,5 +89,17 @@ public class VariantMetricInformation extends BaseModel {
 
     public void setPushMessageInformation(PushMessageInformation pushMessageInformation) {
         this.pushMessageInformation = pushMessageInformation;
+    }
+
+    /**
+     * To track how many time this variant has been opened after a Push Notification
+     *
+     */
+    public long getVariantOpenCounter() {
+        return variantOpenCounter;
+    }
+
+    public void setVariantOpenCounter(long variantOpenCounter) {
+        this.variantOpenCounter = variantOpenCounter;
     }
 }

--- a/model/api/src/main/java/org/jboss/aerogear/unifiedpush/dao/PushMessageInformationDao.java
+++ b/model/api/src/main/java/org/jboss/aerogear/unifiedpush/dao/PushMessageInformationDao.java
@@ -72,4 +72,6 @@ public interface PushMessageInformationDao extends GenericBaseDao<PushMessageInf
     List<PushMessageInformation> findLastThreeActivity();
 
     long getNumberOfPushMessagesForApplications();
+
+    PushMessageInformation getPushMessageInformation(String id);
 }

--- a/model/api/src/main/java/org/jboss/aerogear/unifiedpush/dao/PushMessageInformationDao.java
+++ b/model/api/src/main/java/org/jboss/aerogear/unifiedpush/dao/PushMessageInformationDao.java
@@ -74,4 +74,5 @@ public interface PushMessageInformationDao extends GenericBaseDao<PushMessageInf
     long getNumberOfPushMessagesForApplications();
 
     PushMessageInformation getPushMessageInformation(String id);
+
 }

--- a/model/api/src/main/java/org/jboss/aerogear/unifiedpush/dao/VariantMetricInformationDao.java
+++ b/model/api/src/main/java/org/jboss/aerogear/unifiedpush/dao/VariantMetricInformationDao.java
@@ -1,0 +1,32 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright Red Hat, Inc., and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.aerogear.unifiedpush.dao;
+import org.jboss.aerogear.unifiedpush.api.VariantMetricInformation;
+
+
+public interface VariantMetricInformationDao extends GenericBaseDao<VariantMetricInformation, String>{
+
+    /**
+     * Finds a VariantMetricInformation instance by the related variantID
+     *
+     * @param variantID that is associated with the VariantMetricInformation instance
+     * @return a VariantMetricInformation instance
+     */
+    VariantMetricInformation findVariantMetricInformationByVariantID(String variantID);
+
+}
+

--- a/model/jpa/src/main/java/org/jboss/aerogear/unifiedpush/jpa/dao/impl/JPAPushMessageInformationDao.java
+++ b/model/jpa/src/main/java/org/jboss/aerogear/unifiedpush/jpa/dao/impl/JPAPushMessageInformationDao.java
@@ -129,6 +129,14 @@ public class JPAPushMessageInformationDao extends JPABaseDao<PushMessageInformat
                 "IN (select p.pushApplicationID from PushApplication p)", Long.class).getSingleResult();
     }
 
+    @Override
+    public PushMessageInformation getPushMessageInformation(String id) {
+        return getSingleResultForQuery(createQuery(
+                "select pmi from PushMessageInformation pmi where pmi.id = :id")
+                .setParameter("id", id));
+
+    }
+
 
     /**
      * Helper that returns 'ASC' when true and 'DESC' when false.

--- a/model/jpa/src/main/java/org/jboss/aerogear/unifiedpush/jpa/dao/impl/JPAPushMessageInformationDao.java
+++ b/model/jpa/src/main/java/org/jboss/aerogear/unifiedpush/jpa/dao/impl/JPAPushMessageInformationDao.java
@@ -137,7 +137,6 @@ public class JPAPushMessageInformationDao extends JPABaseDao<PushMessageInformat
 
     }
 
-
     /**
      * Helper that returns 'ASC' when true and 'DESC' when false.
      */

--- a/model/jpa/src/main/java/org/jboss/aerogear/unifiedpush/jpa/dao/impl/JPAVariantMetricInformationDao.java
+++ b/model/jpa/src/main/java/org/jboss/aerogear/unifiedpush/jpa/dao/impl/JPAVariantMetricInformationDao.java
@@ -1,0 +1,39 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright Red Hat, Inc., and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.aerogear.unifiedpush.jpa.dao.impl;
+
+import org.jboss.aerogear.unifiedpush.api.VariantMetricInformation;
+import org.jboss.aerogear.unifiedpush.dao.VariantMetricInformationDao;
+
+
+public class JPAVariantMetricInformationDao extends JPABaseDao<VariantMetricInformation, String> implements VariantMetricInformationDao {
+
+    @Override
+    public VariantMetricInformation findVariantMetricInformationByVariantID(String variantID){
+        return getSingleResultForQuery(createQuery(
+                "select vmi from VariantMetricInformation vmi where vmi.variantID = :variantId")
+                .setParameter("variantId", variantID));
+
+    }
+
+    @Override
+    public Class<VariantMetricInformation> getType() {
+        return VariantMetricInformation.class;
+    }
+
+}

--- a/model/jpa/src/test/java/org/jboss/aerogear/unifiedpush/jpa/PushMessageInformationDaoTest.java
+++ b/model/jpa/src/test/java/org/jboss/aerogear/unifiedpush/jpa/PushMessageInformationDaoTest.java
@@ -18,9 +18,10 @@ package org.jboss.aerogear.unifiedpush.jpa;
 
 import net.jakubholy.dbunitexpress.EmbeddedDbTesterRule;
 import org.jboss.aerogear.unifiedpush.api.PushMessageInformation;
+import org.jboss.aerogear.unifiedpush.api.VariantMetricInformation;
 import org.jboss.aerogear.unifiedpush.dao.PageResult;
 import org.jboss.aerogear.unifiedpush.dao.PushMessageInformationDao;
-import org.jboss.aerogear.unifiedpush.jpa.dao.impl.JPAVariantMetricInformationDao;
+import org.jboss.aerogear.unifiedpush.dao.VariantMetricInformationDao;
 import org.jboss.aerogear.unifiedpush.utils.DaoDeployment;
 import org.jboss.aerogear.unifiedpush.utils.DateUtils;
 import org.jboss.aerogear.unifiedpush.utils.TestUtils;
@@ -49,7 +50,7 @@ public class PushMessageInformationDaoTest {
     @Inject
     private PushMessageInformationDao pushMessageInformationDao;
     @Inject
-    private JPAVariantMetricInformationDao variantMetricInformationDao;
+    private VariantMetricInformationDao variantMetricInformationDao;
     private String pushMessageInformationID = "1";
 
     @Deployment
@@ -64,9 +65,6 @@ public class PushMessageInformationDaoTest {
     public void setUp() {
         // start the shindig
         entityManager.getTransaction().begin();
-        variantMetricInformationDao = new JPAVariantMetricInformationDao();
-        variantMetricInformationDao.setEntityManager(entityManager);
-
     }
 
     private void flushAndClear() {

--- a/model/jpa/src/test/java/org/jboss/aerogear/unifiedpush/jpa/PushMessageInformationDaoTest.java
+++ b/model/jpa/src/test/java/org/jboss/aerogear/unifiedpush/jpa/PushMessageInformationDaoTest.java
@@ -20,6 +20,7 @@ import net.jakubholy.dbunitexpress.EmbeddedDbTesterRule;
 import org.jboss.aerogear.unifiedpush.api.PushMessageInformation;
 import org.jboss.aerogear.unifiedpush.dao.PageResult;
 import org.jboss.aerogear.unifiedpush.dao.PushMessageInformationDao;
+import org.jboss.aerogear.unifiedpush.jpa.dao.impl.JPAVariantMetricInformationDao;
 import org.jboss.aerogear.unifiedpush.utils.DaoDeployment;
 import org.jboss.aerogear.unifiedpush.utils.DateUtils;
 import org.jboss.aerogear.unifiedpush.utils.TestUtils;
@@ -47,6 +48,8 @@ public class PushMessageInformationDaoTest {
     private EntityManager entityManager;
     @Inject
     private PushMessageInformationDao pushMessageInformationDao;
+    @Inject
+    private JPAVariantMetricInformationDao variantMetricInformationDao;
     private String pushMessageInformationID = "1";
 
     @Deployment
@@ -61,6 +64,9 @@ public class PushMessageInformationDaoTest {
     public void setUp() {
         // start the shindig
         entityManager.getTransaction().begin();
+        variantMetricInformationDao = new JPAVariantMetricInformationDao();
+        variantMetricInformationDao.setEntityManager(entityManager);
+
     }
 
     private void flushAndClear() {
@@ -246,5 +252,11 @@ public class PushMessageInformationDaoTest {
 
         messageInformations = pushMessageInformationDao.findAllForPushApplication("231231231", Boolean.TRUE);
         assertThat(messageInformations).hasSize(0);
+    }
+
+    @Test
+    public void findVariantMetricByVariantId() {
+        VariantMetricInformation variantMetricInformation = variantMetricInformationDao.findVariantMetricInformationByVariantID("213");
+        assertThat(variantMetricInformation).isNotNull();
     }
 }

--- a/model/jpa/testData/create_db_content.ddl
+++ b/model/jpa/testData/create_db_content.ddl
@@ -74,6 +74,7 @@ CREATE TABLE PushMessageInformation (
   rawJsonMessage    VARCHAR(4500) DEFAULT NULL,
   submitDate        DATE          DEFAULT NULL,
   totalReceivers    BIGINT       NOT NULL,
+  appOpenCounter    BIGINT      DEFAULT 0,
   PRIMARY KEY (id)
 );
 
@@ -84,5 +85,7 @@ CREATE TABLE VariantMetricInformation (
   receivers              BIGINT       NOT NULL,
   variantID              VARCHAR(255) NOT NULL,
   variantInformations_id VARCHAR(255) DEFAULT NULL,
+  pushMessageInformation_id VARCHAR(255) DEFAULT NULL,
+  variantOpenCounter    BIGINT  DEFAULT 0,
   PRIMARY KEY (id)
 );

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/SenderServiceImpl.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/SenderServiceImpl.java
@@ -67,6 +67,7 @@ public class SenderServiceImpl implements SenderService {
                         message.getClientIdentifier()
                         );
 
+        message.getMessage().getUserData().put("push-identifier",pushMessageInformation.getId());
         // collections for all the different variants:
         final Set<Variant> variants = new HashSet<Variant>();
 
@@ -145,6 +146,11 @@ public class SenderServiceImpl implements SenderService {
         public void onError(final String reason) {
             logger.warning(String.format("Error on '%s' delivery", variant.getType().getTypeName()));
             updateStatusOfPushMessageInformation(pushMessageInformation, variant.getVariantID(), tokenSize, Boolean.FALSE, reason);
+        }
+
+        @Override
+        public PushMessageInformation getPushMessageInformation() {
+            return pushMessageInformation;
         }
     }
 }

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/SenderServiceImpl.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/SenderServiceImpl.java
@@ -67,6 +67,7 @@ public class SenderServiceImpl implements SenderService {
                         message.getClientIdentifier()
                         );
 
+        //Let's put a unique identifier into the payload to be able to do some analytics around that Push Notification
         message.getMessage().getUserData().put("push-identifier",pushMessageInformation.getId());
         // collections for all the different variants:
         final Set<Variant> variants = new HashSet<Variant>();

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/APNsPushNotificationSender.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/APNsPushNotificationSender.java
@@ -44,7 +44,7 @@ import static org.jboss.aerogear.unifiedpush.message.util.ConfigurationUtils.try
 import static org.jboss.aerogear.unifiedpush.message.util.ConfigurationUtils.tryGetIntegerProperty;
 
 @SenderType(iOSVariant.class)
-public class APNsPushNotificationSender implements PushNotificationSender {
+public class APNsPushNotificationSender  implements PushNotificationSender {
 
     public static final String CUSTOM_AEROGEAR_APNS_PUSH_HOST = "custom.aerogear.apns.push.host";
     public static final String CUSTOM_AEROGEAR_APNS_PUSH_PORT = "custom.aerogear.apns.push.port";
@@ -70,7 +70,6 @@ public class APNsPushNotificationSender implements PushNotificationSender {
         if (tokens.isEmpty()) {
             return;
         }
-
         final iOSVariant iOSVariant = (iOSVariant) variant;
 
         Message message = pushMessage.getMessage();

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/NotificationSenderCallback.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/NotificationSenderCallback.java
@@ -16,6 +16,8 @@
  */
 package org.jboss.aerogear.unifiedpush.message.sender;
 
+import org.jboss.aerogear.unifiedpush.api.PushMessageInformation;
+
 /**
  * A simple Callback interface used when sending {@link org.jboss.aerogear.unifiedpush.message.UnifiedPushMessage} to
  * an actual push network.
@@ -35,4 +37,6 @@ public interface NotificationSenderCallback {
      * underlying push network.
      */
     void onError(String reason);
+
+    PushMessageInformation getPushMessageInformation();
 }

--- a/service/src/main/java/org/jboss/aerogear/unifiedpush/service/metrics/PushMessageMetricsService.java
+++ b/service/src/main/java/org/jboss/aerogear/unifiedpush/service/metrics/PushMessageMetricsService.java
@@ -21,6 +21,7 @@ import org.jboss.aerogear.unifiedpush.dao.PageResult;
 import org.jboss.aerogear.unifiedpush.dao.PushMessageInformationDao;
 import org.jboss.aerogear.unifiedpush.utils.DateUtils;
 
+import javax.ejb.Stateless;
 import javax.inject.Inject;
 import java.util.Date;
 
@@ -28,6 +29,7 @@ import java.util.Date;
  * Service class to handle different aspects of the Push Message Information metadata for the "Push Message History" view
  * on the Admin UI.
  */
+@Stateless
 public class PushMessageMetricsService {
 
     // that's what we currently use as the maximum days the message information objects are stored
@@ -89,5 +91,9 @@ public class PushMessageMetricsService {
     public void deleteOutdatedPushInformationData() {
         final Date historyDate = DateUtils.calculatePastDate(DAYS_OF_MAX_OLDEST_INFO_MSG);
         pushMessageInformationDao.deletePushInformationOlderThan(historyDate);
+    }
+
+    public PushMessageInformation getPushMessageInformation(String id) {
+        return pushMessageInformationDao.getPushMessageInformation(id);
     }
 }

--- a/service/src/main/java/org/jboss/aerogear/unifiedpush/service/metrics/PushMessageMetricsService.java
+++ b/service/src/main/java/org/jboss/aerogear/unifiedpush/service/metrics/PushMessageMetricsService.java
@@ -17,8 +17,10 @@
 package org.jboss.aerogear.unifiedpush.service.metrics;
 
 import org.jboss.aerogear.unifiedpush.api.PushMessageInformation;
+import org.jboss.aerogear.unifiedpush.api.VariantMetricInformation;
 import org.jboss.aerogear.unifiedpush.dao.PageResult;
 import org.jboss.aerogear.unifiedpush.dao.PushMessageInformationDao;
+import org.jboss.aerogear.unifiedpush.dao.VariantMetricInformationDao;
 import org.jboss.aerogear.unifiedpush.utils.DateUtils;
 
 import javax.ejb.Stateless;
@@ -38,6 +40,9 @@ public class PushMessageMetricsService {
 
     @Inject
     private PushMessageInformationDao pushMessageInformationDao;
+
+    @Inject
+    private VariantMetricInformationDao variantMetricInformationDao;
 
     /**
      * Starts the capturing of metadata around a push message request.
@@ -95,5 +100,30 @@ public class PushMessageMetricsService {
 
     public PushMessageInformation getPushMessageInformation(String id) {
         return pushMessageInformationDao.getPushMessageInformation(id);
+    }
+
+    public void updateAnalytics(String pushIdentifier, String variantID) {
+        PushMessageInformation pushMessageInformation = this.getPushMessageInformation(pushIdentifier);
+
+        if (pushMessageInformation != null) { //if we are here, app has been opened due to a push message
+
+            //if the firstOpenDate is not null that means it's no the first one, let's update the lastDateOpen
+            if (pushMessageInformation.getFirstOpenDate() != null) {
+                pushMessageInformation.setLastOpenDate(new Date());
+            } else {
+                pushMessageInformation.setFirstOpenDate(new Date());
+                pushMessageInformation.setLastOpenDate(new Date());
+            }
+            //update the general counter
+            pushMessageInformation.setAppOpenCounter(pushMessageInformation.getAppOpenCounter() + 1);
+
+            //update the variant counter
+            VariantMetricInformation variantMetricInformation = variantMetricInformationDao.findVariantMetricInformationByVariantID(variantID);
+            variantMetricInformation.setVariantOpenCounter(variantMetricInformation.getVariantOpenCounter() +1);
+            variantMetricInformationDao.update(variantMetricInformation);
+
+            this.updatePushMessageInformation(pushMessageInformation);
+        }
+
     }
 }

--- a/service/src/test/java/org/jboss/aerogear/unifiedpush/service/AbstractBaseServiceTest.java
+++ b/service/src/test/java/org/jboss/aerogear/unifiedpush/service/AbstractBaseServiceTest.java
@@ -21,17 +21,14 @@ import org.apache.openejb.junit.ApplicationComposer;
 import org.apache.openejb.mockito.MockitoInjector;
 import org.apache.openejb.testing.MockInjector;
 import org.apache.openejb.testing.Module;
-import org.jboss.aerogear.unifiedpush.jpa.dao.impl.JPACategoryDao;
-import org.jboss.aerogear.unifiedpush.jpa.dao.impl.JPAInstallationDao;
-import org.jboss.aerogear.unifiedpush.jpa.dao.impl.JPAPushApplicationDao;
-import org.jboss.aerogear.unifiedpush.jpa.dao.impl.JPAPushMessageInformationDao;
-import org.jboss.aerogear.unifiedpush.jpa.dao.impl.JPAVariantDao;
+import org.jboss.aerogear.unifiedpush.jpa.dao.impl.*;
 import org.jboss.aerogear.unifiedpush.service.impl.ClientInstallationServiceImpl;
 import org.jboss.aerogear.unifiedpush.service.impl.GenericVariantServiceImpl;
 import org.jboss.aerogear.unifiedpush.service.impl.PushApplicationServiceImpl;
 import org.jboss.aerogear.unifiedpush.service.impl.PushSearchByDeveloperServiceImpl;
 import org.jboss.aerogear.unifiedpush.service.impl.PushSearchServiceImpl;
 import org.jboss.aerogear.unifiedpush.service.impl.SearchManager;
+import org.jboss.aerogear.unifiedpush.service.metrics.PushMessageMetricsService;
 import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.keycloak.KeycloakPrincipal;
@@ -117,11 +114,13 @@ public abstract class AbstractBaseServiceTest {
         beans.addManagedClass(GenericVariantServiceImpl.class);
         beans.addManagedClass(JPAVariantDao.class);
         beans.addManagedClass(JPACategoryDao.class);
+        beans.addManagedClass(JPAVariantMetricInformationDao.class);
         beans.addManagedClass(PushSearchByDeveloperServiceImpl.class);
         beans.addManagedClass(PushApplicationServiceImpl.class);
         beans.addManagedClass(JPAPushApplicationDao.class);
         beans.addManagedClass(PushSearchServiceImpl.class);
         beans.addManagedClass(SearchManager.class);
+        beans.addManagedClass(PushMessageMetricsService.class);
 
         return beans;
     }

--- a/service/src/test/java/org/jboss/aerogear/unifiedpush/service/PushMessageMetricServiceTest.java
+++ b/service/src/test/java/org/jboss/aerogear/unifiedpush/service/PushMessageMetricServiceTest.java
@@ -1,0 +1,71 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright Red Hat, Inc., and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.aerogear.unifiedpush.service;
+
+
+import org.jboss.aerogear.unifiedpush.api.PushMessageInformation;
+import org.jboss.aerogear.unifiedpush.api.VariantMetricInformation;
+import org.jboss.aerogear.unifiedpush.dao.VariantMetricInformationDao;
+import org.jboss.aerogear.unifiedpush.service.metrics.PushMessageMetricsService;
+import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import javax.inject.Inject;
+
+public class PushMessageMetricServiceTest extends AbstractBaseServiceTest{
+
+    @Inject
+    private PushMessageMetricsService pushMessageMetricsService;
+
+    @Inject
+    private VariantMetricInformationDao variantMetricInformationDao;
+
+    private PushMessageInformation pushMessageInformation;
+
+    @Override
+    protected void specificSetup() {
+         pushMessageInformation =
+                pushMessageMetricsService.storeNewRequestFrom(
+                        "123",
+                        "hello",
+                        "127.0.01",
+                        "testcase"
+                );
+
+        VariantMetricInformation variantMetricInformation = new VariantMetricInformation();
+        variantMetricInformation.setVariantID("321");
+        pushMessageInformation.addVariantInformations(variantMetricInformation);
+        pushMessageMetricsService.updatePushMessageInformation(pushMessageInformation);
+    }
+
+    @Test
+    public void updateAnalyticsTest() {
+        pushMessageMetricsService.updateAnalytics(pushMessageInformation.getId(),"321");
+        PushMessageInformation updatedPushInformation = pushMessageMetricsService.getPushMessageInformation(pushMessageInformation.getId());
+        assertThat(updatedPushInformation.getAppOpenCounter()).isEqualTo(1);
+        VariantMetricInformation updatedVariantMetric = variantMetricInformationDao.findVariantMetricInformationByVariantID("321");
+        assertThat(updatedVariantMetric.getVariantOpenCounter()).isEqualTo(1);
+
+        pushMessageMetricsService.updateAnalytics(pushMessageInformation.getId(),"321");
+        PushMessageInformation updatedPushInformation1 = pushMessageMetricsService.getPushMessageInformation(pushMessageInformation.getId());
+        assertThat(updatedPushInformation1.getAppOpenCounter()).isEqualTo(2);
+        VariantMetricInformation updatedVariantMetric1 = variantMetricInformationDao.findVariantMetricInformationByVariantID("321");
+        assertThat(updatedVariantMetric1.getVariantOpenCounter()).isEqualTo(2);
+
+    }
+
+}


### PR DESCRIPTION
This is the first step for the advanced analytics it contains : 
* Unique identifier added to the payload of each Push Message
* Retrieving the identifier when an installation registers
* Some basic calculation

The Admin console has a few updates but these are temporary since it will be replcaed by charts.

@matzew @edewit @lfryc Mind to take a look ? 

ps: I wonder if that PR should also be merged into the new-ui branch to be able to move on with the chart integration ? 