### PR TITLE
Added MireDot as a REST API doc generator

### DIFF
--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -26,9 +26,7 @@
     <artifactId>unifiedpush-jaxrs</artifactId>
     <name>UnifiedPush RESTful Endpoint</name>
 
-
     <dependencies>
-
         <dependency>
             <groupId>javax.enterprise</groupId>
             <artifactId>cdi-api</artifactId>
@@ -100,7 +98,58 @@
             <artifactId>json-patch</artifactId>
             <version>1.7</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.qmino</groupId>
+            <artifactId>miredot-annotations</artifactId>
+            <version>1.3.1</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.qmino</groupId>
+                <artifactId>miredot-plugin</artifactId>
+                <version>1.6.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>restdoc</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <licence>
+                        cHJvamVjdHxvcmcuamJvc3MuYWVyb2dlYXIudW5pZmllZHB1c2gudW5pZmllZHB1c2gtamF4cnN8MjAxNy0wNS0wMXx0cnVlfC0xI01Dd0NGQitaa0VVRVlsaU9LQjljR2h5TWNSWm1VMTREQWhRbUlHOXY3MExCR0FoT2FubklFSER2SWl1OVZnPT0=
+                    </licence>
+                    <output>
+                        <html>
+                            <baseUrl>https://SERVER:PORT/CONTEXT/rest</baseUrl>
+                            <initialCollapseLevel>100</initialCollapseLevel>
+                            <hideIssuesTab>false</hideIssuesTab>
+                        </html>
+                    </output>
+                    <restModel>
+                        <httpStatusCodes>
+                            <httpStatusCode>
+                                <httpCode>200</httpCode>
+                                <document>get</document>
+                                <defaultMessage>The service call has completed successfully</defaultMessage>
+                            </httpStatusCode>
+                        </httpStatusCodes>
+                    </restModel>
+                    <analysis>
+                        <checks>
+                            <JAVADOC_MISSING_AUTHORS>ignore</JAVADOC_MISSING_AUTHORS>
+                            <JAVADOC_MISSING_SUMMARY>ignore</JAVADOC_MISSING_SUMMARY>
+                        </checks>
+                    </analysis>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
     <profiles>
         <profile>
@@ -177,5 +226,21 @@
             </dependencies>
         </profile>
     </profiles>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>miredot</id>
+            <name>MireDot Releases</name>
+            <url>http://nexus.qmino.com/content/repositories/miredot</url>
+        </pluginRepository>
+    </pluginRepositories>
+
+    <repositories>
+        <repository>
+            <id>miredot</id>
+            <name>MireDot Releases</name>
+            <url>http://nexus.qmino.com/content/repositories/miredot</url>
+        </repository>
+    </repositories>
 
 </project>

--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -153,47 +153,6 @@
 
     <profiles>
         <profile>
-            <id>jaxrs-doclet</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>jax-rs-docs</id>
-                                <phase>generate-resources</phase>
-                                <configuration>
-                                    <doclet>com.lunatech.doclets.jax.jaxrs.JAXRSDoclet</doclet>
-                                    <docletArtifacts>
-                                        <docletArtifact>
-                                            <groupId>com.lunatech.jax-doclets</groupId>
-                                            <artifactId>doclets</artifactId>
-                                            <version>0.10.0</version>
-                                        </docletArtifact>
-                                    </docletArtifacts>
-                                    <detectOfflineLinks>false</detectOfflineLinks>
-                                    <offlineLinks>
-                                        <offlineLink>
-                                            <url>../javadocs</url>
-                                            <location>${project.basedir}/../target/site/apidocs</location>
-                                        </offlineLink>
-                                    </offlineLinks>
-                                    <additionalparam>-disablehttpexample -disablejavascriptexample</additionalparam>
-                                    <!-- only document the BASIC protected URIs for sender and (un)registration -->
-                                    <excludePackageNames>org.jboss.aerogear.unifiedpush.rest.metrics:org.jboss.aerogear.unifiedpush.rest.registry.applications:*.util.*</excludePackageNames>
-                                </configuration>
-                                <goals>
-                                    <goal>javadoc</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-	            </plugins>
-	        </build>
-		</profile>
-
-        <profile>
             <id>test</id>
             <activation>
                 <activeByDefault>true</activeByDefault>

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/metrics/DashboardEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/metrics/DashboardEndpoint.java
@@ -29,6 +29,7 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import com.qmino.miredot.annotations.ReturnType;
 import org.jboss.aerogear.unifiedpush.service.dashboard.Application;
 import org.jboss.aerogear.unifiedpush.service.dashboard.ApplicationVariant;
 import org.jboss.aerogear.unifiedpush.service.dashboard.DashboardData;
@@ -40,26 +41,45 @@ public class DashboardEndpoint {
     @Inject
     private SearchManager service;
 
+    /**
+     * GET dashboard data
+     *
+     * @return  {@link DashboardData} for the given user
+     */
     @GET
     @Produces(MediaType.APPLICATION_JSON)
+    @ReturnType("org.jboss.aerogear.unifiedpush.service.dashboard.DashboardData")
     public Response totalApplications(@Context HttpServletRequest request) {
         final DashboardData dataForUser =  service.getSearchService().loadDashboardData();
 
         return Response.ok(dataForUser).build();
     }
 
+    /**
+     * GET application variants
+     *
+     * @return  list of {@link ApplicationVariant}s
+     */
     @GET
     @Path("/warnings")
     @Produces(MediaType.APPLICATION_JSON)
+    @ReturnType("java.util.List<org.jboss.aerogear.unifiedpush.service.dashboard.ApplicationVariant>")
     public Response getVariantsWithWarnings(@Context HttpServletRequest request) {
         final List<ApplicationVariant> variantsWithWarnings = service.getSearchService().getVariantsWithWarnings();
 
         return Response.ok(variantsWithWarnings).build();
     }
 
+    /**
+     * GET active applications
+     *
+     * @param count number of active applications, default value = 3
+     * @return      list of active {@link Application}s
+     */
     @GET
     @Path("/active")
     @Produces(MediaType.APPLICATION_JSON)
+    @ReturnType("java.util.List<org.jboss.aerogear.unifiedpush.service.dashboard.Application>")
     public Response getLatestActivity(@QueryParam("count") @DefaultValue("3") int count, @Context HttpServletRequest request) {
         final List<Application> latestActivity = service.getSearchService().getLatestActivity(count);
 

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/metrics/PushMetricsEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/metrics/PushMetricsEndpoint.java
@@ -16,6 +16,7 @@
  */
 package org.jboss.aerogear.unifiedpush.rest.metrics;
 
+import com.qmino.miredot.annotations.ReturnType;
 import org.jboss.aerogear.unifiedpush.api.PushMessageInformation;
 import org.jboss.aerogear.unifiedpush.dao.PageResult;
 import org.jboss.aerogear.unifiedpush.service.metrics.PushMessageMetricsService;
@@ -35,9 +36,21 @@ public class PushMetricsEndpoint {
     @Inject
     private PushMessageMetricsService metricsService;
 
+    /**
+     * GET info about submitted push messages for the given Push Application
+     *
+     * @param id        id of {@link org.jboss.aerogear.unifiedpush.api.PushApplication}
+     * @param page      page number
+     * @param pageSize  number of items per page
+     * @param sorting   sorting order: {@code asc} (default) or {@code desc}
+     * @return          list of {@link PushMessageInformation}s
+     *
+     * @statuscode 404 The requested PushApplication resource does not exist
+     */
     @GET
     @Path("/application/{id}")
     @Produces(MediaType.APPLICATION_JSON)
+    @ReturnType("java.util.List<org.jboss.aerogear.unifiedpush.api.PushMessageInformation>")
     public Response pushMessageInformationPerApplication(
             @PathParam("id") String id,
             @QueryParam("page") Integer page,
@@ -61,9 +74,21 @@ public class PushMetricsEndpoint {
                 .header("total", pageResult.getCount()).build();
     }
 
+    /**
+     * GET info about submitted push messages for the given Variant
+     *
+     * @param id        id of {@link org.jboss.aerogear.unifiedpush.api.Variant}
+     * @param page      page number
+     * @param pageSize  number of items per page
+     * @param sorting   sorting order: {@code asc} (default) or {@code desc}
+     * @return          list of {@link PushMessageInformation}s
+     *
+     * @statuscode 404 The requested Variant resource does not exist
+     */
     @GET
     @Path("/variant/{id}")
     @Produces(MediaType.APPLICATION_JSON)
+    @ReturnType("java.util.List<org.jboss.aerogear.unifiedpush.api.PushMessageInformation>")
     public Response pushMessageInformationPerVariant(
             @PathParam("id") String id,
             @QueryParam("page") Integer page,

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/AbstractVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/AbstractVariantEndpoint.java
@@ -16,6 +16,7 @@
  */
 package org.jboss.aerogear.unifiedpush.rest.registry.applications;
 
+import com.qmino.miredot.annotations.ReturnType;
 import org.jboss.aerogear.unifiedpush.api.PushApplication;
 import org.jboss.aerogear.unifiedpush.api.Variant;
 import org.jboss.aerogear.unifiedpush.rest.AbstractBaseEndpoint;
@@ -48,10 +49,19 @@ public abstract class AbstractVariantEndpoint extends AbstractBaseEndpoint {
     @Inject
     protected GenericVariantService variantService;
 
-    // Secret Reset
+    /**
+     * Secret Reset
+     *
+     * @param variantId id of {@link Variant}
+     * @return          {@link Variant} with new secret
+     *
+     * @statuscode 200 The secret of Variant reset successfully
+     * @statuscode 404 The requested Variant resource does not exist
+     */
     @PUT
     @Path("/{variantId}/reset")
     @Consumes(MediaType.APPLICATION_JSON)
+    @ReturnType("org.jboss.aerogear.unifiedpush.api.Variant")
     public javax.ws.rs.core.Response resetSecret(@PathParam("variantId") String variantId) {
 
         Variant variant = variantService.findByVariantID(variantId);
@@ -70,9 +80,18 @@ public abstract class AbstractVariantEndpoint extends AbstractBaseEndpoint {
         return Response.status(Response.Status.NOT_FOUND).entity("Could not find requested Variant").build();
     }
 
+    /**
+     * Get Variant
+     *
+     * @param variantId id of {@link Variant}
+     * @return          requested {@link Variant}
+     *
+     * @statuscode 404 The requested Variant resource does not exist
+     */
     @GET
     @Path("/{variantId}")
     @Produces(MediaType.APPLICATION_JSON)
+    @ReturnType("org.jboss.aerogear.unifiedpush.api.Variant")
     public Response findVariantById(@PathParam("variantId") String variantId) {
 
         Variant variant = variantService.findByVariantID(variantId);
@@ -84,9 +103,17 @@ public abstract class AbstractVariantEndpoint extends AbstractBaseEndpoint {
         return Response.status(Response.Status.NOT_FOUND).entity("Could not find requested Variant").build();
     }
 
-    // DELETE
+    /**
+     * Delete Variant
+     *
+     * @param variantId id of {@link Variant}
+     *
+     * @statuscode 204 The Variant successfully deleted
+     * @statuscode 404 The requested Variant resource does not exist
+     */
     @DELETE
     @Path("/{variantId}")
+    @ReturnType("java.lang.Void")
     public Response deleteVariant(@PathParam("variantId") String variantId) {
 
         Variant variant = variantService.findByVariantID(variantId);

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/AdmVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/AdmVariantEndpoint.java
@@ -17,6 +17,7 @@
 package org.jboss.aerogear.unifiedpush.rest.registry.applications;
 
 
+import com.qmino.miredot.annotations.ReturnType;
 import org.jboss.aerogear.unifiedpush.api.AdmVariant;
 import org.jboss.aerogear.unifiedpush.api.PushApplication;
 
@@ -36,10 +37,21 @@ import javax.ws.rs.core.UriInfo;
 @Path("/applications/{pushAppID}/adm")
 public class AdmVariantEndpoint extends AbstractVariantEndpoint {
 
-
+    /**
+     * Add ADM Variant
+     *
+     * @param admVariant        new {@link AdmVariant}
+     * @param pushApplicationID id of {@link PushApplication}
+     * @return                  created {@link AdmVariant}
+     *
+     * @statuscode 201 The ADM Variant created successfully
+     * @statuscode 400 The format of the client request was incorrect
+     * @statuscode 404 The requested PushApplication resource does not exist
+     */
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
+    @ReturnType("org.jboss.aerogear.unifiedpush.api.AdmVariant")
     public Response registerAdmVariant(
             AdmVariant admVariant,
             @PathParam("pushAppID") String pushApplicationID,
@@ -71,19 +83,36 @@ public class AdmVariantEndpoint extends AbstractVariantEndpoint {
         return Response.created(uriInfo.getAbsolutePathBuilder().path(String.valueOf(admVariant.getVariantID())).build()).entity(admVariant).build();
     }
 
-    // READ
+    /**
+     * List ADM Variants for Push Application
+     *
+     * @param pushApplicationID id of {@link PushApplication}
+     * @return                  list of {@link AdmVariant}s
+     */
     @GET
     @Produces(MediaType.APPLICATION_JSON)
+    @ReturnType("java.util.Set<org.jboss.aerogear.unifiedpush.api.AdmVariant>")
     public Response listAllAdmVariationsForPushApp(@PathParam("pushAppID") String pushApplicationID) {
         final PushApplication application = getSearch().findByPushApplicationIDForDeveloper(pushApplicationID);
         return Response.ok(getVariantsByType(application, AdmVariant.class)).build();
     }
 
-    // UPDATE
+    /**
+     * Update ADM Variant
+     *
+     * @param id                    id of {@link PushApplication}
+     * @param androidID             id of {@link AdmVariant}
+     * @param updatedAdmApplication new info of {@link AdmVariant}
+     *
+     * @statuscode 204 The ADM Variant updated successfully
+     * @statuscode 400 The format of the client request was incorrect
+     * @statuscode 404 The requested ADM Variant resource does not exist
+     */
     @PUT
     @Path("/{admID}")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
+    @ReturnType("java.lang.Void")
     public Response updateAndroidVariation(
             @PathParam("pushAppID") String id,
             @PathParam("admID") String androidID,

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/AndroidVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/AndroidVariantEndpoint.java
@@ -16,6 +16,7 @@
  */
 package org.jboss.aerogear.unifiedpush.rest.registry.applications;
 
+import com.qmino.miredot.annotations.ReturnType;
 import org.jboss.aerogear.unifiedpush.api.AndroidVariant;
 import org.jboss.aerogear.unifiedpush.api.PushApplication;
 
@@ -37,10 +38,21 @@ import javax.ws.rs.core.UriInfo;
 @Path("/applications/{pushAppID}/android")
 public class AndroidVariantEndpoint extends AbstractVariantEndpoint {
 
-    // new Android
+    /**
+     * Add Android Variant
+     *
+     * @param androidVariant    new {@link AndroidVariant}
+     * @param pushApplicationID id of {@link PushApplication}
+     * @return                  created {@link AndroidVariant}
+     *
+     * @statuscode 201 The Android Variant created successfully
+     * @statuscode 400 The format of the client request was incorrect
+     * @statuscode 404 The requested PushApplication resource does not exist
+     */
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
+    @ReturnType("org.jboss.aerogear.unifiedpush.api.AndroidVariant")
     public Response registerAndroidVariant(
             AndroidVariant androidVariant,
             @PathParam("pushAppID") String pushApplicationID,
@@ -72,19 +84,36 @@ public class AndroidVariantEndpoint extends AbstractVariantEndpoint {
         return Response.created(uriInfo.getAbsolutePathBuilder().path(String.valueOf(androidVariant.getVariantID())).build()).entity(androidVariant).build();
     }
 
-    // READ
+    /**
+     * List Android Variants for Push Application
+     *
+     * @param pushApplicationID id of {@link PushApplication}
+     * @return                  list of {@link AndroidVariant}s
+     */
     @GET
     @Produces(MediaType.APPLICATION_JSON)
+    @ReturnType("java.util.Set<org.jboss.aerogear.unifiedpush.api.AndroidVariant>")
     public Response listAllAndroidVariationsForPushApp(@PathParam("pushAppID") String pushApplicationID) {
         final PushApplication application = getSearch().findByPushApplicationIDForDeveloper(pushApplicationID);
         return Response.ok(getVariantsByType(application, AndroidVariant.class)).build();
     }
 
-    // UPDATE
+    /**
+     * Update Android Variant
+     *
+     * @param id                        id of {@link PushApplication}
+     * @param androidID                 id of {@link AndroidVariant}
+     * @param updatedAndroidApplication new info of {@link AndroidVariant}
+     *
+     * @statuscode 204 The Android Variant updated successfully
+     * @statuscode 400 The format of the client request was incorrect
+     * @statuscode 404 The requested Android Variant resource does not exist
+     */
     @PUT
     @Path("/{androidID}")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
+    @ReturnType("java.lang.Void")
     public Response updateAndroidVariation(
             @PathParam("pushAppID") String id,
             @PathParam("androidID") String androidID,

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/InstallationManagementEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/InstallationManagementEndpoint.java
@@ -17,6 +17,7 @@
 package org.jboss.aerogear.unifiedpush.rest.registry.applications;
 
 
+import com.qmino.miredot.annotations.ReturnType;
 import org.jboss.aerogear.unifiedpush.api.Installation;
 import org.jboss.aerogear.unifiedpush.dao.PageResult;
 import org.jboss.aerogear.unifiedpush.service.ClientInstallationService;
@@ -50,8 +51,19 @@ public class InstallationManagementEndpoint {
     @Inject
     private ClientInstallationService clientInstallationService;
 
+    /**
+     * List Installations of specified Variant
+     *
+     * @param variantId id of {@link org.jboss.aerogear.unifiedpush.api.Variant}
+     * @param page      page number
+     * @param pageSize  number of items per page
+     * @return          list of {@link Installation}s
+     *
+     * @statuscode 404 The requested Variant resource does not exist
+     */
     @GET
     @Produces(MediaType.APPLICATION_JSON)
+    @ReturnType("java.util.List<org.jboss.aerogear.unifiedpush.api.Installation>")
     public Response findInstallations(@PathParam("variantID") String variantId, @QueryParam("page") Integer page,
                                       @QueryParam("per_page") Integer pageSize, @Context UriInfo uri) {
         if (pageSize != null) {
@@ -103,9 +115,19 @@ public class InstallationManagementEndpoint {
         return link;
     }
 
+    /**
+     * Get Installation of specified Variant
+     *
+     * @param variantId         id of {@link org.jboss.aerogear.unifiedpush.api.Variant}
+     * @param installationId    id of {@link Installation}
+     * @return                  requested {@link Installation}
+     *
+     * @statuscode 404 The requested Installation resource does not exist
+     */
     @GET
     @Path("/{installationID}")
     @Produces(MediaType.APPLICATION_JSON)
+    @ReturnType("org.jboss.aerogear.unifiedpush.api.Installation")
     public Response findInstallation(@PathParam("variantID") String variantId, @PathParam("installationID") String installationId) {
 
         Installation installation = clientInstallationService.findById(installationId);
@@ -117,10 +139,21 @@ public class InstallationManagementEndpoint {
         return Response.ok(installation).build();
     }
 
+    /**
+     * Update Installation of specified Variant
+     *
+     * @param entity            new info of {@link Installation}
+     * @param variantId         id of {@link org.jboss.aerogear.unifiedpush.api.Variant}
+     * @param installationId    id of {@link Installation}
+     *
+     * @statuscode 204 The Installation updated successfully
+     * @statuscode 404 The requested Installation resource does not exist
+     */
     @PUT
     @Path("/{installationID}")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
+    @ReturnType("java.lang.Void")
     public Response updateInstallation(Installation entity, @PathParam("variantID") String variantId, @PathParam("installationID") String installationId) {
 
         Installation installation = clientInstallationService.findById(installationId);
@@ -135,9 +168,19 @@ public class InstallationManagementEndpoint {
 
     }
 
+    /**
+     * Delete Installation of specified Variant
+     *
+     * @param variantId         id of {@link org.jboss.aerogear.unifiedpush.api.Variant}
+     * @param installationId    id of {@link Installation}
+     *
+     * @statuscode 204 The Installation successfully deleted
+     * @statuscode 404 The requested Installation resource does not exist
+     */
     @DELETE
     @Path("/{installationID}")
     @Produces(MediaType.APPLICATION_JSON)
+    @ReturnType("java.lang.Void")
     public Response removeInstallation(@PathParam("variantID") String variantId, @PathParam("installationID") String installationId) {
 
         Installation installation = clientInstallationService.findById(installationId);

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/PushApplicationEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/PushApplicationEndpoint.java
@@ -37,6 +37,7 @@ import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriBuilder;
 
+import com.qmino.miredot.annotations.ReturnType;
 import org.jboss.aerogear.unifiedpush.api.PushApplication;
 import org.jboss.aerogear.unifiedpush.api.Variant;
 import org.jboss.aerogear.unifiedpush.dao.InstallationDao;
@@ -59,10 +60,19 @@ public class PushApplicationEndpoint extends AbstractBaseEndpoint {
     @Inject
     private InstallationDao installationDao;
 
-    // CREATE
+    /**
+     * Create Push Application
+     *
+     * @param pushApp   new {@link PushApplication}
+     * @return          created {@link PushApplication}
+     *
+     * @statuscode 201 The PushApplication Variant created successfully
+     * @statuscode 400 The format of the client request was incorrect
+     */
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
+    @ReturnType("org.jboss.aerogear.unifiedpush.api.PushApplication")
     public Response registerPushApplication(PushApplication pushApp) {
 
          // some validation
@@ -82,9 +92,16 @@ public class PushApplicationEndpoint extends AbstractBaseEndpoint {
                 .build();
     }
 
-    // READ
+    /**
+     * List Push Applications
+     *
+     * @param page      page number
+     * @param pageSize  number of items per page
+     * @return          list of {@link PushApplication}s
+     */
     @GET
     @Produces(MediaType.APPLICATION_JSON)
+    @ReturnType("java.util.List<org.jboss.aerogear.unifiedpush.api.PushApplication>")
     public Response listAllPushApplications(@QueryParam("page") Integer page,
                                             @QueryParam("per_page") Integer pageSize,
                                             @QueryParam("includeDeviceCount") @DefaultValue("false") boolean includeDeviceCount,
@@ -113,9 +130,20 @@ public class PushApplicationEndpoint extends AbstractBaseEndpoint {
         return response.build();
     }
 
+    /**
+     * Get Push Application.
+     *
+     * @param pushApplicationID     id of {@link PushApplication}
+     * @param includeDeviceCount    boolean param to put device count into response headers, default {@code false}
+     * @param includeActivity       boolean param to put activity into response headers, default {@code false}
+     * @return                      requested {@link PushApplication}
+     *
+     * @statuscode 404 The requested PushApplication resource does not exist
+     */
     @GET
     @Path("/{pushAppID}")
     @Produces(MediaType.APPLICATION_JSON)
+    @ReturnType("org.jboss.aerogear.unifiedpush.api.PushApplication")
     public Response findById(
             @PathParam("pushAppID") String pushApplicationID,
             @QueryParam("includeDeviceCount") @DefaultValue("false") boolean includeDeviceCount,
@@ -154,11 +182,21 @@ public class PushApplicationEndpoint extends AbstractBaseEndpoint {
         response.header("deviceCount_app_" + app.getPushApplicationID(), appCount);
     }
 
-    // UPDATE
+    /**
+     * Update Push Application
+     *
+     * @param pushApplicationID id of {@link PushApplication}
+     * @param updatedPushApp    new info of {@link PushApplication}
+     *
+     * @statuscode 204 The PushApplication updated successfully
+     * @statuscode 400 The format of the client request was incorrect
+     * @statuscode 404 The requested PushApplication resource does not exist
+     */
     @PUT
     @Path("/{pushAppID}")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
+    @ReturnType("java.lang.Void")
     public Response updatePushApplication(@PathParam("pushAppID") String pushApplicationID, PushApplication updatedPushApp) {
 
         PushApplication pushApp = getSearch().findByPushApplicationIDForDeveloper(pushApplicationID);
@@ -187,11 +225,20 @@ public class PushApplicationEndpoint extends AbstractBaseEndpoint {
         return Response.status(Status.NOT_FOUND).entity("Could not find requested PushApplicationEntity").build();
     }
 
-    // UPDATE (MasterSecret Reset)
+    /**
+     * Reset MasterSecret for Push Application
+     *
+     * @param pushApplicationID id of {@link PushApplication}
+     * @return                  updated {@link PushApplication}
+     *
+     * @statuscode 204 The MasterSecret for Push Application reset successfully
+     * @statuscode 404 The requested PushApplication resource does not exist
+     */
     @PUT
     @Path("/{pushAppID}/reset")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
+    @ReturnType("org.jboss.aerogear.unifiedpush.api.PushApplication")
     public Response resetMasterSecret(@PathParam("pushAppID") String pushApplicationID) {
 
         //PushApplication pushApp = pushAppService.findByPushApplicationIDForDeveloper(pushApplicationID, extractUsername(request));
@@ -209,10 +256,18 @@ public class PushApplicationEndpoint extends AbstractBaseEndpoint {
         return Response.status(Status.NOT_FOUND).entity("Could not find requested PushApplicationEntity").build();
     }
 
-    // DELETE
+    /**
+     * Delete Push Application
+     *
+     * @param pushApplicationID id of {@link PushApplication}
+     *
+     * @statuscode 204 The PushApplication successfully deleted
+     * @statuscode 404 The requested PushApplication resource does not exist
+     */
     @DELETE
     @Path("/{pushAppID}")
     @Produces(MediaType.APPLICATION_JSON)
+    @ReturnType("java.lang.Void")
     public Response deletePushApplication(@PathParam("pushAppID") String pushApplicationID) {
 
         PushApplication pushApp = getSearch().findByPushApplicationIDForDeveloper(pushApplicationID);
@@ -224,8 +279,15 @@ public class PushApplicationEndpoint extends AbstractBaseEndpoint {
         return Response.status(Status.NOT_FOUND).entity("Could not find requested PushApplicationEntity").build();
     }
 
+    /**
+     * Count Push Applications
+     *
+     * @param pushApplicationID id of {@link PushApplication}
+     * @return                  count number for each {@link org.jboss.aerogear.unifiedpush.api.VariantType}
+     */
     @GET
     @Path("/{pushAppID}/count")
+    @ReturnType("java.util.Map<java.lang.String, java.lang.Long>")
     public Response countInstallations(@PathParam("pushAppID") String pushApplicationID) {
 
         Map<String, Long> result = pushAppService.countInstallationsByType(pushApplicationID);

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/SimplePushVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/SimplePushVariantEndpoint.java
@@ -16,6 +16,7 @@
  */
 package org.jboss.aerogear.unifiedpush.rest.registry.applications;
 
+import com.qmino.miredot.annotations.ReturnType;
 import org.jboss.aerogear.unifiedpush.api.PushApplication;
 import org.jboss.aerogear.unifiedpush.api.SimplePushVariant;
 
@@ -37,10 +38,21 @@ import javax.ws.rs.core.UriInfo;
 @Path("/applications/{pushAppID}/simplePush")
 public class SimplePushVariantEndpoint extends AbstractVariantEndpoint {
 
-    // new SimplePush
+    /**
+     * Add SimplePush Variant
+     *
+     * @param simplePushVariant new {@link SimplePushVariant}
+     * @param pushApplicationID id of {@link PushApplication}
+     * @return                  created {@link SimplePushVariant}
+     *
+     * @statuscode 201 The SimplePush Variant created successfully
+     * @statuscode 400 The format of the client request was incorrect
+     * @statuscode 404 The requested PushApplication resource does not exist
+     */
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
+    @ReturnType("org.jboss.aerogear.unifiedpush.api.SimplePushVariant")
     public Response registerSimplePushVariant(
             SimplePushVariant simplePushVariant,
             @PathParam("pushAppID") String pushApplicationID,
@@ -72,20 +84,37 @@ public class SimplePushVariantEndpoint extends AbstractVariantEndpoint {
         return Response.created(uriInfo.getAbsolutePathBuilder().path(String.valueOf(simplePushVariant.getVariantID())).build()).entity(simplePushVariant).build();
     }
 
-    // READ
+    /**
+     * List SimplePush Variants for Push Application
+     *
+     * @param pushApplicationID id of {@link PushApplication}
+     * @return                  list of {@link SimplePushVariant}s
+     */
     @GET
     @Produces(MediaType.APPLICATION_JSON)
+    @ReturnType("java.util.Set<org.jboss.aerogear.unifiedpush.api.SimplePushVariant>")
     public Response listAllSimplePushVariationsForPushApp(@PathParam("pushAppID") String pushApplicationID) {
 
         final PushApplication application = getSearch().findByPushApplicationIDForDeveloper(pushApplicationID);
         return Response.ok(getVariantsByType(application, SimplePushVariant.class)).build();
     }
 
-    // UPDATE
+    /**
+     * Update SimplePush Variant
+     *
+     * @param id                            id of {@link PushApplication}
+     * @param simplePushID                  id of {@link SimplePushVariant}
+     * @param updatedSimplePushApplication  new info of {@link SimplePushVariant}
+     *
+     * @statuscode 204 The SimplePush Variant updated successfully
+     * @statuscode 400 The format of the client request was incorrect
+     * @statuscode 404 The requested SimplePush Variant resource does not exist
+     */
     @PUT
     @Path("/{simplePushID}")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
+    @ReturnType("java.lang.Void")
     public Response updateSimplePushVariation(
             @PathParam("pushAppID") String id,
             @PathParam("simplePushID") String simplePushID,

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/WindowsVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/WindowsVariantEndpoint.java
@@ -16,6 +16,7 @@
  */
 package org.jboss.aerogear.unifiedpush.rest.registry.applications;
 
+import com.qmino.miredot.annotations.ReturnType;
 import org.jboss.aerogear.unifiedpush.api.PushApplication;
 import org.jboss.aerogear.unifiedpush.api.WindowsVariant;
 import org.jboss.aerogear.unifiedpush.api.WindowsWNSVariant;
@@ -36,9 +37,21 @@ import javax.ws.rs.core.UriInfo;
 @Path("/applications/{pushAppID}/windows{type}")
 public class WindowsVariantEndpoint extends AbstractVariantEndpoint {
 
+    /**
+     * Add Windows Variant
+     *
+     * @param windowsVariant    new {@link WindowsVariant}
+     * @param pushApplicationID id of {@link PushApplication}
+     * @return                  created {@link WindowsVariant}
+     *
+     * @statuscode 201 The Windows Variant created successfully
+     * @statuscode 400 The format of the client request was incorrect
+     * @statuscode 404 The requested PushApplication resource does not exist
+     */
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
+    @ReturnType("org.jboss.aerogear.unifiedpush.api.WindowsVariant")
     public Response registerWindowsVariant(
             WindowsVariant windowsVariant,
             @PathParam("pushAppID") String pushApplicationID,
@@ -69,18 +82,35 @@ public class WindowsVariantEndpoint extends AbstractVariantEndpoint {
         return Response.created(uriInfo.getAbsolutePathBuilder().path(String.valueOf(windowsVariant.getVariantID())).build()).entity(windowsVariant).build();
     }
 
+    /**
+     * List Windows Variants for Push Application
+     *
+     * @param pushApplicationID id of {@link PushApplication}
+     * @return                  list of {@link WindowsVariant}s
+     */
     @GET
     @Produces(MediaType.APPLICATION_JSON)
+    @ReturnType("java.util.Set<org.jboss.aerogear.unifiedpush.api.WindowsVariant>")
     public Response listAllWindowsVariationsForPushApp(@PathParam("pushAppID") String pushApplicationID) {
         final PushApplication application = getSearch().findByPushApplicationIDForDeveloper(pushApplicationID);
         return Response.ok(getVariantsByType(application, WindowsVariant.class)).build();
     }
 
-    // UPDATE
+    /**
+     * Update Windows Variant
+     *
+     * @param windowsID             id of {@link WindowsVariant}
+     * @param updatedWindowsVariant new info of {@link WindowsVariant}
+     *
+     * @statuscode 204 The Windows Variant updated successfully
+     * @statuscode 400 The format of the client request was incorrect
+     * @statuscode 404 The requested Windows Variant resource does not exist
+     */
     @PUT
     @Path("/{windowsID}")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
+    @ReturnType("java.lang.Void")
     public Response updateWindowsVariation(
             @PathParam("windowsID") String windowsID,
             WindowsVariant updatedWindowsVariant) {

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/iOSVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/iOSVariantEndpoint.java
@@ -16,6 +16,13 @@
  */
 package org.jboss.aerogear.unifiedpush.rest.registry.applications;
 
+import com.qmino.miredot.annotations.ReturnType;
+import org.jboss.aerogear.unifiedpush.api.PushApplication;
+import org.jboss.aerogear.unifiedpush.api.iOSVariant;
+import org.jboss.aerogear.unifiedpush.rest.annotations.PATCH;
+import org.jboss.aerogear.unifiedpush.rest.util.iOSApplicationUploadForm;
+import org.jboss.resteasy.annotations.providers.multipart.MultipartForm;
+
 import javax.validation.ConstraintViolationException;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
@@ -31,19 +38,24 @@ import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriInfo;
 
-import org.jboss.aerogear.unifiedpush.api.PushApplication;
-import org.jboss.aerogear.unifiedpush.api.iOSVariant;
-import org.jboss.aerogear.unifiedpush.rest.annotations.PATCH;
-import org.jboss.aerogear.unifiedpush.rest.util.iOSApplicationUploadForm;
-import org.jboss.resteasy.annotations.providers.multipart.MultipartForm;
-
 @Path("/applications/{pushAppID}/ios")
 public class iOSVariantEndpoint extends AbstractVariantEndpoint {
 
-    // new iOS
+    /**
+     * Add iOS Variant
+     *
+     * @param form              new iOS Variant
+     * @param pushApplicationID id of {@link PushApplication}
+     * @return                  created {@link iOSVariant}
+     *
+     * @statuscode 201 The iOS Variant created successfully
+     * @statuscode 400 The format of the client request was incorrect
+     * @statuscode 404 The requested PushApplication resource does not exist
+     */
     @POST
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Produces(MediaType.APPLICATION_JSON)
+    @ReturnType("org.jboss.aerogear.unifiedpush.api.iOSVariant")
     public Response registeriOSVariant(
             @MultipartForm iOSApplicationUploadForm form,
             @PathParam("pushAppID") String pushApplicationID,
@@ -92,9 +104,15 @@ public class iOSVariantEndpoint extends AbstractVariantEndpoint {
         return Response.created(uriInfo.getAbsolutePathBuilder().path(String.valueOf(iOSVariant.getVariantID())).build()).entity(iOSVariant).build();
     }
 
-    // READ
+    /**
+     * List iOS Variants for Push Application
+     *
+     * @param pushApplicationID id of {@link PushApplication}
+     * @return                  list of {@link iOSVariant}s
+     */
     @GET
     @Produces(MediaType.APPLICATION_JSON)
+    @ReturnType("java.util.Set<org.jboss.aerogear.unifiedpush.api.iOSVariant>")
     public Response listAlliOSVariantsForPushApp(@PathParam("pushAppID") String pushApplicationID) {
         final PushApplication application = getSearch().findByPushApplicationIDForDeveloper(pushApplicationID);
         return Response.ok(getVariantsByType(application, iOSVariant.class)).build();
@@ -104,6 +122,7 @@ public class iOSVariantEndpoint extends AbstractVariantEndpoint {
     @Path("/{iOSID}")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
+    @ReturnType("java.lang.Void")
     public Response updateiOSVariant(
             @PathParam("pushAppID") String pushApplicationId,
             @PathParam("iOSID") String iOSID,
@@ -124,11 +143,22 @@ public class iOSVariantEndpoint extends AbstractVariantEndpoint {
         return Response.status(Status.NOT_FOUND).entity("Could not find requested Variant").build();
     }
 
-    // UPDATE
+    /**
+     * Update ADM Variant
+     *
+     * @param pushApplicationId     id of {@link PushApplication}
+     * @param iOSID                 id of {@link iOSVariant}
+     * @param updatedForm           new info of {@link iOSVariant}
+     *
+     * @statuscode 204 The iOS Variant updated successfully
+     * @statuscode 400 The format of the client request was incorrect
+     * @statuscode 404 The requested iOS Variant resource does not exist
+     */
     @PUT
     @Path("/{iOSID}")
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Produces(MediaType.APPLICATION_JSON)
+    @ReturnType("java.lang.Void")
     public Response updateiOSVariant(
             @MultipartForm iOSApplicationUploadForm updatedForm,
             @PathParam("pushAppID") String pushApplicationId,

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/installations/ExportEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/installations/ExportEndpoint.java
@@ -16,7 +16,7 @@
  */
 package org.jboss.aerogear.unifiedpush.rest.registry.installations;
 
-
+import com.qmino.miredot.annotations.ReturnType;
 import org.jboss.aerogear.unifiedpush.rest.AbstractBaseEndpoint;
 import org.jboss.resteasy.annotations.GZIP;
 
@@ -34,14 +34,14 @@ public class ExportEndpoint extends AbstractBaseEndpoint {
      * Endpoint for exporting as JSON file device installations for a given variant.
      * Only Keycloak authenticated can access it
      *
-     * @param variantId  the variant ID
-     *
-     * @return JSON response
+     * @param variantId the variant ID
+     * @return          list of {@link org.jboss.aerogear.unifiedpush.api.Installation}s
      */
     @GET
     @Path("/{variantId}/installations/")
     @Produces(MediaType.APPLICATION_JSON)
     @GZIP
+    @ReturnType("java.util.List<org.jboss.aerogear.unifiedpush.api.Installation>")
     public Response exportInstallations(@PathParam("variantId") String variantId) {
         return Response.ok(getSearch().findAllInstallationsByVariantForDeveloper(variantId, 0, Integer.MAX_VALUE).getResultList()).build();
     }

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/installations/InstallationRegistrationEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/installations/InstallationRegistrationEndpoint.java
@@ -18,18 +18,26 @@ package org.jboss.aerogear.unifiedpush.rest.registry.installations;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.qmino.miredot.annotations.ReturnType;
 import org.jboss.aerogear.unifiedpush.api.Installation;
 import org.jboss.aerogear.unifiedpush.api.Variant;
+import org.jboss.aerogear.unifiedpush.message.EmptyJSON;
 import org.jboss.aerogear.unifiedpush.rest.AbstractBaseEndpoint;
-import org.jboss.aerogear.unifiedpush.utils.AeroGearLogger;
 import org.jboss.aerogear.unifiedpush.rest.util.HttpBasicHelper;
 import org.jboss.aerogear.unifiedpush.service.ClientInstallationService;
 import org.jboss.aerogear.unifiedpush.service.GenericVariantService;
+import org.jboss.aerogear.unifiedpush.utils.AeroGearLogger;
 import org.jboss.resteasy.annotations.providers.multipart.MultipartForm;
 
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.*;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.OPTIONS;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
@@ -92,10 +100,19 @@ public class InstallationRegistrationEndpoint extends AbstractBaseEndpoint {
      * @HTTP 400 (Bad Request) The format of the client request was incorrect (e.g. missing required values).
      * @HTTP 401 (Unauthorized) The request requires authentication.
      * @HTTP 404 (Not Found) The requested Variant resource does not exist.
+     *
+     * @param entity    {@link Installation} for Device registration
+     * @return          registered {@link Installation}
+     *
+     * @statuscode 200 Successful storage of the device metadata
+     * @statuscode 400 The format of the client request was incorrect (e.g. missing required values)
+     * @statuscode 401 The request requires authentication
+     * @statuscode 404 The requested Variant resource does not exist
      */
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
+    @ReturnType("org.jboss.aerogear.unifiedpush.api.Installation")
     public Response registerInstallation(
             Installation entity,
             @Context HttpServletRequest request) {
@@ -140,9 +157,16 @@ public class InstallationRegistrationEndpoint extends AbstractBaseEndpoint {
      * @HTTP 204 (OK) Successful unregistration.
      * @HTTP 401 (Unauthorized) The request requires authentication.
      * @HTTP 404 (Not Found) The requested device metadata does not exist.
+     *
+     * @param token device token
+     *
+     * @statuscode 204 Successful unregistration
+     * @statuscode 401 The request requires authentication
+     * @statuscode 404 The requested device metadata does not exist
      */
     @DELETE
     @Path("{token: .*}")
+    @ReturnType("java.lang.Void")
     public Response unregisterInstallations(
             @PathParam("token") String token,
             @Context HttpServletRequest request) {
@@ -211,11 +235,20 @@ public class InstallationRegistrationEndpoint extends AbstractBaseEndpoint {
      * @HTTP 400 (Bad Request) The format of the client request was incorrect.
      * @HTTP 401 (Unauthorized) The request requires authentication.
      * @HTTP 404 (Not Found) The requested Variant resource does not exist.
+     *
+     * @param form  JSON file to import
+     * @return      empty JSON body
+     *
+     * @statuscode 200 Successful submission of import job
+     * @statuscode 400 The format of the client request was incorrect
+     * @statuscode 401 The request requires authentication
+     * @statuscode 404 The requested Variant resource does not exist
      */
     @POST
     @Path("/importer")
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Produces(MediaType.APPLICATION_JSON)
+    @ReturnType("org.jboss.aerogear.unifiedpush.message.EmptyJSON")
     public Response importDevice(
             @MultipartForm
             ImporterForm form,
@@ -245,7 +278,7 @@ public class InstallationRegistrationEndpoint extends AbstractBaseEndpoint {
         clientInstallationService.addInstallations(variant, devices);
 
         // return directly, the above is async and may take a bit :-)
-        return Response.ok("{}").build();
+        return Response.ok(EmptyJSON.STRING).build();
     }
 
     private ResponseBuilder appendPreflightResponseHeaders(HttpHeaders headers, ResponseBuilder response) {

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/installations/InstallationRegistrationEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/installations/InstallationRegistrationEndpoint.java
@@ -96,11 +96,6 @@ public class InstallationRegistrationEndpoint extends AbstractBaseEndpoint {
      *
      * Details about JSON format can be found HERE!
      *
-     * @HTTP 200 (OK) Successful storage of the device metadata.
-     * @HTTP 400 (Bad Request) The format of the client request was incorrect (e.g. missing required values).
-     * @HTTP 401 (Unauthorized) The request requires authentication.
-     * @HTTP 404 (Not Found) The requested Variant resource does not exist.
-     *
      * @param entity    {@link Installation} for Device registration
      * @return          registered {@link Installation}
      *
@@ -153,10 +148,6 @@ public class InstallationRegistrationEndpoint extends AbstractBaseEndpoint {
      *   -X DELETE
      *   https://SERVER:PORT/context/rest/registry/device/{token}
      * </pre>
-     *
-     * @HTTP 204 (OK) Successful unregistration.
-     * @HTTP 401 (Unauthorized) The request requires authentication.
-     * @HTTP 404 (Not Found) The requested device metadata does not exist.
      *
      * @param token device token
      *
@@ -230,11 +221,6 @@ public class InstallationRegistrationEndpoint extends AbstractBaseEndpoint {
      *   ...
      * ]
      * </pre>
-     *
-     * @HTTP 200 (OK) Successful submission of import job.
-     * @HTTP 400 (Bad Request) The format of the client request was incorrect.
-     * @HTTP 401 (Unauthorized) The request requires authentication.
-     * @HTTP 404 (Not Found) The requested Variant resource does not exist.
      *
      * @param form  JSON file to import
      * @return      empty JSON body

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/sender/PushNotificationSenderEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/sender/PushNotificationSenderEndpoint.java
@@ -100,11 +100,6 @@ public class PushNotificationSenderEndpoint {
      *
      * Details about the Message Format can be found HERE!
      *
-     * @HTTP 202 (Accepted) Indicates the Job has been accepted and is being process by the AeroGear UnifiedPush Server.
-     * @HTTP 401 (Unauthorized) The request requires authentication.
-     * @HTTP 404 (Not Found) The requested PushApplication resource does not exist.
-     * @RequestHeader aerogear-sender The header to identify the used client. If the header is not present, the standard "user-agent" header is used.
-     *
      * @param message   message to send
      * @return      empty JSON body
      *

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/sender/PushNotificationSenderEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/sender/PushNotificationSenderEndpoint.java
@@ -27,7 +27,10 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
+import com.qmino.miredot.annotations.BodyType;
+import com.qmino.miredot.annotations.ReturnType;
 import org.jboss.aerogear.unifiedpush.api.PushApplication;
+import org.jboss.aerogear.unifiedpush.message.EmptyJSON;
 import org.jboss.aerogear.unifiedpush.message.InternalUnifiedPushMessage;
 import org.jboss.aerogear.unifiedpush.message.NotificationRouter;
 import org.jboss.aerogear.unifiedpush.rest.util.HttpBasicHelper;
@@ -101,10 +104,19 @@ public class PushNotificationSenderEndpoint {
      * @HTTP 401 (Unauthorized) The request requires authentication.
      * @HTTP 404 (Not Found) The requested PushApplication resource does not exist.
      * @RequestHeader aerogear-sender The header to identify the used client. If the header is not present, the standard "user-agent" header is used.
+     *
+     * @param message   message to send
+     * @return      empty JSON body
+     *
+     * @statuscode 202 Indicates the Job has been accepted and is being process by the AeroGear UnifiedPush Server
+     * @statuscode 401 The request requires authentication
+     * @statuscode 404 The requested PushApplication resource does not exist
      */
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
+    @BodyType("org.jboss.aerogear.unifiedpush.message.UnifiedPushMessage")
+    @ReturnType("org.jboss.aerogear.unifiedpush.message.EmptyJSON")
     public Response send(final InternalUnifiedPushMessage message, @Context HttpServletRequest request) {
 
         final PushApplication pushApplication = loadPushApplicationWhenAuthorized(request);
@@ -126,7 +138,7 @@ public class PushNotificationSenderEndpoint {
         logger.fine("Message sent by: '" + message.getClientIdentifier() + "'");
         logger.info("Message submitted to PushNetworks for further processing");
 
-        return Response.status(Status.ACCEPTED).entity("{}").build();
+        return Response.status(Status.ACCEPTED).entity(EmptyJSON.STRING).build();
     }
 
     /**

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/util/HealthCheck.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/util/HealthCheck.java
@@ -42,6 +42,11 @@ public class HealthCheck {
     @Inject
     private HealthNetworkService healthNetworkService;
 
+    /**
+     * Get health status
+     *
+     * @return {@link HealthStatus} with details
+     */
     @GET
     @Path("/health")
     @Produces(MediaType.APPLICATION_JSON)

--- a/pom.xml
+++ b/pom.xml
@@ -238,40 +238,6 @@
             </modules>
         </profile>
 
-        <!--
-            Profile for JAX-RS doclet generation. This is only working on JDK7, due to the usage of outdated tools
-
-            Usage:
-               - mvn clean install -Pjaxrs-doclet,test
-        -->
-        <profile>
-            <id>jaxrs-doclet</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-enforcer-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>enforce-tools</id>
-                                <goals>
-                                    <goal>enforce</goal>
-                                </goals>
-                                <configuration>
-                                    <rules>
-                                        <requireJavaVersion>
-                                            <!-- Enforce java 1.7 for compiling -->
-                                            <!-- This is needed because jax-doclet is broken on jdk8 -->
-                                            <version>(,1.8)</version>
-                                        </requireJavaVersion>
-                                    </rules>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-	            </plugins>
-	        </build>
-		</profile>
-
         <profile>
             <id>code-coverage</id>
             <properties>

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/EmptyJSON.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/EmptyJSON.java
@@ -1,0 +1,28 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright Red Hat, Inc., and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.aerogear.unifiedpush.message;
+
+/**
+ * JSON with empty body.
+ */
+public final class EmptyJSON {
+
+    public static final EmptyJSON OBJECT = new EmptyJSON();
+    public static final String STRING = "{}";
+
+    private EmptyJSON() {}
+}


### PR DESCRIPTION
This work is based on [current discussion](http://aerogear-dev.1069024.n5.nabble.com/aerogear-dev-do-we-want-swagger-for-REST-endpoint-documentation-td11342.html).

I haven't removed jax-doclets and only added Miredot.

There are some examples of possible [documentation variants](http://condor.pp.ua/aerogear-ups-rest-api-doc/). In this source code I use the second variant (Multi page collapse all).

We are also able to:
* change title;
* hide `Issues` tab;
* add HTML snippet with introduction text.

Also I'm able to refactor current API realisation later. It will simplify and improve documentaion.