### PR TITLE
Change REST endpoints response type from "text/plain" to "application/json" with empty JSON body

### DIFF
--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/installations/InstallationRegistrationEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/installations/InstallationRegistrationEndpoint.java
@@ -215,6 +215,7 @@ public class InstallationRegistrationEndpoint extends AbstractBaseEndpoint {
     @POST
     @Path("/importer")
     @Consumes(MediaType.MULTIPART_FORM_DATA)
+    @Produces(MediaType.APPLICATION_JSON)
     public Response importDevice(
             @MultipartForm
             ImporterForm form,
@@ -244,8 +245,7 @@ public class InstallationRegistrationEndpoint extends AbstractBaseEndpoint {
         clientInstallationService.addInstallations(variant, devices);
 
         // return directly, the above is async and may take a bit :-)
-        return Response.status(Status.OK)
-                .entity("Job submitted for processing").build();
+        return Response.ok("{}").build();
     }
 
     private ResponseBuilder appendPreflightResponseHeaders(HttpHeaders headers, ResponseBuilder response) {

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/sender/PushNotificationSenderEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/sender/PushNotificationSenderEndpoint.java
@@ -104,7 +104,7 @@ public class PushNotificationSenderEndpoint {
      */
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.TEXT_PLAIN)
+    @Produces(MediaType.APPLICATION_JSON)
     public Response send(final UnifiedPushMessage message, @Context HttpServletRequest request) {
 
         final PushApplication pushApplication = loadPushApplicationWhenAuthorized(request);
@@ -126,8 +126,7 @@ public class PushNotificationSenderEndpoint {
         logger.fine("Message sent by: '" + message.getClientIdentifier() + "'");
         logger.info("Message submitted to PushNetworks for further processing");
 
-        return Response.status(Status.ACCEPTED)
-                .entity("Job submitted").build();
+        return Response.status(Status.ACCEPTED).entity("{}").build();
     }
 
     /**


### PR DESCRIPTION
See https://issues.jboss.org/browse/AGPUSH-1376

@lfryc I think that we may do the same for `/registry/device/importer/`. WDYT?