### PR TITLE
Split UnifiedPushMessage to hold internal information

### DIFF
--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/sender/PushNotificationSenderEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/sender/PushNotificationSenderEndpoint.java
@@ -28,8 +28,8 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
 import org.jboss.aerogear.unifiedpush.api.PushApplication;
+import org.jboss.aerogear.unifiedpush.message.InternalUnifiedPushMessage;
 import org.jboss.aerogear.unifiedpush.message.NotificationRouter;
-import org.jboss.aerogear.unifiedpush.message.UnifiedPushMessage;
 import org.jboss.aerogear.unifiedpush.rest.util.HttpBasicHelper;
 import org.jboss.aerogear.unifiedpush.rest.util.HttpRequestUtil;
 import org.jboss.aerogear.unifiedpush.service.PushApplicationService;
@@ -105,7 +105,7 @@ public class PushNotificationSenderEndpoint {
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    public Response send(final UnifiedPushMessage message, @Context HttpServletRequest request) {
+    public Response send(final InternalUnifiedPushMessage message, @Context HttpServletRequest request) {
 
         final PushApplication pushApplication = loadPushApplicationWhenAuthorized(request);
         if (pushApplication == null) {

--- a/push/model/src/main/java/org/jboss/aerogear/unifiedpush/message/UnifiedPushMessage.java
+++ b/push/model/src/main/java/org/jboss/aerogear/unifiedpush/message/UnifiedPushMessage.java
@@ -80,9 +80,6 @@ public class UnifiedPushMessage implements Serializable {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
-    private String ipAddress;
-    private String clientIdentifier;
-
     private Message message = new Message();
 
     private Criteria criteria = new Criteria();
@@ -115,29 +112,9 @@ public class UnifiedPushMessage implements Serializable {
         this.message = message;
     }
 
-    /**
-     * The IP address from the agent that did issue the push message request.
-     */
-    public String getIpAddress() {
-        return ipAddress;
-    }
-
-    public void setIpAddress(String ipAddress) {
-        this.ipAddress = ipAddress;
-    }
-
-    /**
-     * The Client Identifier showing who triggered the Push Notification
-     */
-    public String getClientIdentifier() { return clientIdentifier; }
-
-    public void setClientIdentifier(String clientIdentifier) { this.clientIdentifier = clientIdentifier; }
-
     public String toStrippedJsonString() {
         try {
             final HashMap<String, Object> json = new LinkedHashMap<String, Object>();
-            json.put("ipAddress", this.ipAddress);
-            json.put("clientIdentifier", this.clientIdentifier);
             json.put("alert", this.message.getAlert());
             json.put("criteria", this.criteria);
             json.put("config", this.config);

--- a/push/model/src/test/resources/message-format.json
+++ b/push/model/src/test/resources/message-format.json
@@ -1,6 +1,4 @@
 {
-  "ipAddress": null,
-  "clientIdentifier": null,
   "message": {
     "alert": "HELLO!",
     "sound": "default",

--- a/push/model/src/test/resources/message-tojson.json
+++ b/push/model/src/test/resources/message-tojson.json
@@ -1,6 +1,4 @@
 {
-  "ipAddress": null,
-  "clientIdentifier": null,
   "alert": "HELLO!",
   "criteria": {
     "categories": null,

--- a/push/model/src/test/resources/message-tostrippedjson.json
+++ b/push/model/src/test/resources/message-tostrippedjson.json
@@ -1,6 +1,4 @@
 {
-  "ipAddress": null,
-  "clientIdentifier": null,
   "alert": "HELLO!",
   "criteria": {
     "categories": null,

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/InternalUnifiedPushMessage.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/InternalUnifiedPushMessage.java
@@ -1,0 +1,38 @@
+package org.jboss.aerogear.unifiedpush.message;
+
+/**
+ * This is {@link UnifiedPushMessage} with some additional information, which we will use for internal purposes,
+ * like analytics tracking.
+ *
+ * For more information see
+ * <a href="https://issues.jboss.org/browse/AGPUSH-1381">https://issues.jboss.org/browse/AGPUSH-1381</a> and
+ * <a href="https://github.com/aerogear/aerogear-unifiedpush-server/pull/526#discussion-diff-28432730">
+ *     https://github.com/aerogear/aerogear-unifiedpush-server/pull/526#discussion-diff-28432730</a>
+ */
+public class InternalUnifiedPushMessage extends UnifiedPushMessage {
+
+    private String ipAddress;
+    private String clientIdentifier;
+
+    /**
+     * The IP address from the agent that did issue the push message request.
+     */
+    public String getIpAddress() {
+        return ipAddress;
+    }
+
+    public void setIpAddress(String ipAddress) {
+        this.ipAddress = ipAddress;
+    }
+
+    /**
+     * The Client Identifier showing who triggered the Push Notification.
+     */
+    public String getClientIdentifier() {
+        return clientIdentifier;
+    }
+
+    public void setClientIdentifier(String clientIdentifier) {
+        this.clientIdentifier = clientIdentifier;
+    }
+}

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/NotificationRouter.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/NotificationRouter.java
@@ -72,7 +72,7 @@ public class NotificationRouter {
      * @param message the message
      */
     @TransactionAttribute(TransactionAttributeType.REQUIRED)
-    public void submit(PushApplication pushApplication, UnifiedPushMessage message) {
+    public void submit(PushApplication pushApplication, InternalUnifiedPushMessage message) {
         logger.info("Processing send request with '" + message.toString() + "' payload");
 
         final PushMessageInformation pushMessageInformation =


### PR DESCRIPTION
JIRA issue: https://issues.jboss.org/browse/AGPUSH-1381

@matzew @sebastienblanc I've split `UnifiedPushMessage` and (for the quick fix) I've removed `ipAddress` from test json files. Is it ok? Should I override `UnifiedPushMessage.toStrippedJsonString()`?