### PR TITLE
Update to KeyCloak 1.2.0.CR1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.jboss.aerogear</groupId>
         <artifactId>aerogear-parent</artifactId>
-        <version>0.2.13</version>
+        <version>0.2.14-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jboss.aerogear.unifiedpush</groupId>


### PR DESCRIPTION
This updates fixes:

https://issues.jboss.org/browse/AGPUSH-1352

I've already tested against our supported databases, but a sanity check is always welcome.

@sebastienblanc @matzew care to take a look? It depends on https://github.com/aerogear/aerogear-parent/pull/47