### PR TITLE
base for JMS unit tests AGPUSH-1349

### DIFF
--- a/push/sender/pom.xml
+++ b/push/sender/pom.xml
@@ -152,6 +152,18 @@
                     <artifactId>mockito-core</artifactId>
                     <scope>test</scope>
                 </dependency>
+
+                <dependency>
+                    <groupId>org.jboss.arquillian.junit</groupId>
+                    <artifactId>arquillian-junit-container</artifactId>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.arquillian.container</groupId>
+                    <artifactId>arquillian-container-chameleon</artifactId>
+                    <version>1.0.0.Final-SNAPSHOT</version>
+                    <scope>test</scope>
+                </dependency>
             </dependencies>
         </profile>
     </profiles>

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/jms/AbstractJMSMessageConsumer.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/jms/AbstractJMSMessageConsumer.java
@@ -25,7 +25,6 @@ import javax.jms.Queue;
 import javax.jms.Topic;
 
 import org.jboss.aerogear.unifiedpush.message.MessageDeliveryException;
-import org.jboss.aerogear.unifiedpush.message.TokenLoader;
 import org.jboss.aerogear.unifiedpush.utils.AeroGearLogger;
 
 /**
@@ -33,7 +32,7 @@ import org.jboss.aerogear.unifiedpush.utils.AeroGearLogger;
  */
 abstract class AbstractJMSMessageConsumer<T> implements MessageListener {
 
-    private final AeroGearLogger logger = AeroGearLogger.getInstance(TokenLoader.class);
+    private final AeroGearLogger logger = AeroGearLogger.getInstance(AbstractJMSMessageConsumer.class);
 
     public abstract void onMessage(T message);
 

--- a/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/message/MockProviders.java
+++ b/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/message/MockProviders.java
@@ -1,0 +1,49 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright Red Hat, Inc., and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.aerogear.unifiedpush.message;
+
+import static org.mockito.Mockito.mock;
+
+import javax.enterprise.context.RequestScoped;
+import javax.enterprise.inject.Produces;
+
+import org.jboss.aerogear.unifiedpush.dao.PushMessageInformationDao;
+import org.jboss.aerogear.unifiedpush.dao.VariantMetricInformationDao;
+import org.jboss.aerogear.unifiedpush.service.GenericVariantService;
+
+@RequestScoped
+public class MockProviders {
+
+    private PushMessageInformationDao pushMessageInformationDao = mock(PushMessageInformationDao.class);
+    private GenericVariantService genericVariantService = mock(GenericVariantService.class);
+    private VariantMetricInformationDao variantMetricInformationDao = mock(VariantMetricInformationDao.class);
+
+    @Produces
+    public PushMessageInformationDao getPushMessageInformationDao() {
+        return pushMessageInformationDao;
+    }
+
+    @Produces
+    public GenericVariantService getGenericVariantService() {
+        return genericVariantService;
+    }
+
+    @Produces
+    public VariantMetricInformationDao getVariantMetricInformationDao() {
+        return variantMetricInformationDao;
+    }
+}

--- a/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/message/TestNotificationRouter.java
+++ b/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/message/TestNotificationRouter.java
@@ -1,0 +1,166 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright Red Hat, Inc., and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.aerogear.unifiedpush.message;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+
+import javax.enterprise.context.RequestScoped;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+
+import org.jboss.aerogear.unifiedpush.api.AndroidVariant;
+import org.jboss.aerogear.unifiedpush.api.PushApplication;
+import org.jboss.aerogear.unifiedpush.api.PushMessageInformation;
+import org.jboss.aerogear.unifiedpush.api.SimplePushVariant;
+import org.jboss.aerogear.unifiedpush.api.iOSVariant;
+import org.jboss.aerogear.unifiedpush.dao.PushMessageInformationDao;
+import org.jboss.aerogear.unifiedpush.message.holder.MessageHolderWithVariants;
+import org.jboss.aerogear.unifiedpush.message.jms.DispatchToQueue;
+import org.jboss.aerogear.unifiedpush.message.sender.PushNotificationSender;
+import org.jboss.aerogear.unifiedpush.service.GenericVariantService;
+import org.jboss.aerogear.unifiedpush.service.metrics.PushMessageMetricsService;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+
+
+@RunWith(Arquillian.class)
+public class TestNotificationRouter {
+
+    @Deployment
+    public static WebArchive archive() {
+
+        String[] libs = new String[] {
+                "org.mockito:mockito-core",
+                "org.codehaus.jackson:jackson-mapper-asl"
+        };
+
+        return ShrinkWrap
+                .create(WebArchive.class)
+                .addAsLibraries(Maven.resolver().loadPomFromFile("pom.xml").resolve(libs).withTransitivity().as(JavaArchive.class))
+                .addClasses(NotificationRouter.class, PushNotificationSender.class)
+                .addClasses(MockProviders.class)
+                .addClasses(MessageHolderWithVariants.class, DispatchToQueue.class, GenericVariantService.class, PushMessageMetricsService.class)
+                .addClasses(UnifiedPushMessage.class, InternalUnifiedPushMessage.class, Config.class, Criteria.class, Message.class)
+                .addPackage(org.jboss.aerogear.unifiedpush.utils.AeroGearLogger.class.getPackage())
+                .addPackage(org.jboss.aerogear.unifiedpush.api.PushApplication.class.getPackage())
+                .addPackage(org.jboss.aerogear.unifiedpush.message.holder.AbstractMessageHolder.class.getPackage())
+                .addPackage(org.jboss.aerogear.unifiedpush.dao.PushApplicationDao.class.getPackage())
+                .addPackage(org.jboss.aerogear.unifiedpush.service.PushApplicationService.class.getPackage())
+                .addPackage(org.jboss.aerogear.unifiedpush.message.windows.Windows.class.getPackage())
+                .addPackage(org.jboss.aerogear.unifiedpush.message.apns.APNs.class.getPackage())
+                .addAsWebInfResource("hornetq-jms.xml")
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Inject
+    private NotificationRouter router;
+
+    @Inject
+    private Counter messageCounter;
+
+    private PushApplication app;
+    private InternalUnifiedPushMessage message;
+
+    @Before
+    public void setUp() {
+        app = new PushApplication();
+        message = new InternalUnifiedPushMessage();
+    }
+
+    @Test
+    public void testNoVariants() {
+        assertTrue("variants are empty", app.getVariants().isEmpty());
+        router.submit(app, message);
+        assertEquals("when variants are empty, no message is dispatched", 0, messageCounter.getCounter());
+    }
+
+    @Test
+    public void testTwoVariantsOfSameType() {
+        app.getVariants().add(new SimplePushVariant());
+        app.getVariants().add(new SimplePushVariant());
+        router.submit(app, message);
+        assertEquals("the message should be dispatched", 1, messageCounter.getCounter());
+    }
+
+    @Test
+    public void testThreeVariantsOfDifferentType() {
+        app.getVariants().add(new AndroidVariant());
+        app.getVariants().add(new iOSVariant());
+        app.getVariants().add(new SimplePushVariant());
+        router.submit(app, message);
+        assertEquals("the 3 messages should be dispatched", 3, messageCounter.getCounter());
+    }
+
+    @Test
+    public void testInvokesMetricsService(PushMessageInformationDao pushMessageInformationDao) {
+        router.submit(app, message);
+        verify(pushMessageInformationDao).create(Mockito.any(PushMessageInformation.class));
+    }
+
+    @Test
+    public void testVariantIDsSpecified(GenericVariantService genericVariantService) {
+        // given
+        SimplePushVariant simplePushVariant = new SimplePushVariant();
+        simplePushVariant.setId("id-simplepush-variant");
+        iOSVariant iOSVariant = new iOSVariant();
+        iOSVariant.setId("id-ios-variant");
+        AndroidVariant androidVariant = new AndroidVariant();
+        androidVariant.setId("id-android-variant");
+
+        app.getVariants().addAll(Arrays.asList(simplePushVariant, iOSVariant, androidVariant));
+        message.getCriteria().setVariants(Arrays.asList("id-ios-variant", "id-android-variant"));
+
+        when(genericVariantService.findByVariantID("id-ios-variant")).thenReturn(iOSVariant);
+        when(genericVariantService.findByVariantID("id-android-variant")).thenReturn(androidVariant);
+        when(genericVariantService.findByVariantID("id-simplepush-variant")).thenReturn(androidVariant);
+
+        // when
+        router.submit(app, message);
+        assertEquals("the 2 messages should be dispatched", 2, messageCounter.getCounter());
+    }
+
+    public void observeMessageHolderWithVariants(@Observes @DispatchToQueue MessageHolderWithVariants msg) {
+        messageCounter.increment();
+    }
+
+    @RequestScoped
+    public static class Counter {
+        private volatile int counter = 0;
+        public void increment() {
+            counter += 1;
+        }
+        public int getCounter() {
+            return counter;
+        }
+    }
+
+
+}

--- a/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/message/jms/TestMessageHolderWithTokens.java
+++ b/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/message/jms/TestMessageHolderWithTokens.java
@@ -1,0 +1,108 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright Red Hat, Inc., and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.aerogear.unifiedpush.message.jms;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import javax.enterprise.event.Event;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+
+import org.jboss.aerogear.unifiedpush.api.AndroidVariant;
+import org.jboss.aerogear.unifiedpush.api.PushMessageInformation;
+import org.jboss.aerogear.unifiedpush.api.Variant;
+import org.jboss.aerogear.unifiedpush.message.Config;
+import org.jboss.aerogear.unifiedpush.message.Criteria;
+import org.jboss.aerogear.unifiedpush.message.Message;
+import org.jboss.aerogear.unifiedpush.message.MessageDeliveryException;
+import org.jboss.aerogear.unifiedpush.message.UnifiedPushMessage;
+import org.jboss.aerogear.unifiedpush.message.holder.MessageHolderWithTokens;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(Arquillian.class)
+public class TestMessageHolderWithTokens {
+
+    @Deployment
+    public static WebArchive archive() {
+
+        String[] libs = new String[] {
+                "org.mockito:mockito-core",
+                "org.codehaus.jackson:jackson-mapper-asl"
+        };
+
+        return ShrinkWrap
+                .create(WebArchive.class)
+                .addAsLibraries(Maven.resolver().loadPomFromFile("pom.xml").resolve(libs).withTransitivity().as(JavaArchive.class))
+                .addClasses(MessageHolderWithTokens.class, DispatchToQueue.class, Dequeue.class, MessageDeliveryException.class)
+                .addClasses(MessageHolderWithTokensConsumer.class, MessageHolderWithTokensProducer.class, AbstractJMSMessageConsumer.class)
+                .addClasses(UnifiedPushMessage.class, Config.class, Criteria.class, Message.class)
+                .addPackage(org.jboss.aerogear.unifiedpush.utils.AeroGearLogger.class.getPackage())
+                .addPackage(org.jboss.aerogear.unifiedpush.api.PushApplication.class.getPackage())
+                .addPackage(org.jboss.aerogear.unifiedpush.message.holder.AbstractMessageHolder.class.getPackage())
+                .addPackage(org.jboss.aerogear.unifiedpush.dao.PushApplicationDao.class.getPackage())
+                .addPackage(org.jboss.aerogear.unifiedpush.service.PushApplicationService.class.getPackage())
+                .addPackage(org.jboss.aerogear.unifiedpush.message.windows.Windows.class.getPackage())
+                .addPackage(org.jboss.aerogear.unifiedpush.message.apns.APNs.class.getPackage())
+                .addAsWebInfResource("hornetq-jms.xml")
+                .addAsWebInfResource("jboss-ejb3-message-holder-with-tokens.xml", "jboss-ejb3.xml")
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    private UnifiedPushMessage message;
+    private PushMessageInformation information;
+    private Variant variant;
+    private Collection<String> deviceTokens;
+    private static CountDownLatch delivered;
+
+    @Inject @DispatchToQueue
+    private Event<MessageHolderWithTokens> event;
+
+    @Before
+    public void setUp() {
+        information = new PushMessageInformation();
+        message = new UnifiedPushMessage();
+        deviceTokens = new ArrayList<String>();
+        delivered = new CountDownLatch(5);
+    }
+
+    @Test
+    public void test() throws InterruptedException {
+        variant = new AndroidVariant();
+        for (int i = 0; i < 5; i++) {
+            event.fire(new MessageHolderWithTokens(information, message, variant, deviceTokens));
+        }
+        delivered.await(5, TimeUnit.SECONDS);
+    }
+
+    public void observeMessageHolderWithVariants(@Observes @Dequeue MessageHolderWithTokens msg) {
+        delivered.countDown();
+    }
+
+}

--- a/push/sender/src/test/resources/arquillian.xml
+++ b/push/sender/src/test/resources/arquillian.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    JBoss, Home of Professional Open Source
+    Copyright Red Hat, Inc., and individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<arquillian xmlns="http://jboss.org/schema/arquillian"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="
+        http://jboss.org/schema/arquillian
+        http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+        
+    <defaultProtocol type="Servlet 3.0"></defaultProtocol>
+
+    <container qualifier="chameleon" default="true">
+        <configuration>
+            <property name="target">wildfly:8.0.0.Final:managed</property>
+            <property name="serverConfig">standalone-full.xml</property>
+        </configuration>
+    </container>
+</arquillian>

--- a/push/sender/src/test/resources/hornetq-jms.xml
+++ b/push/sender/src/test/resources/hornetq-jms.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    JBoss, Home of Professional Open Source
+    Copyright Red Hat, Inc., and individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    	http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<messaging-deployment xmlns="urn:jboss:messaging-deployment:1.0">
+    <hornetq-server>
+        <jms-destinations>
+            <!-- Push Message Queues split by Push Networks -->
+            <jms-queue name="AdmPushMessageQueue">
+                <entry name="/queue/AdmPushMessageQueue"/>
+            </jms-queue>
+            <jms-queue name="APNsPushMessageQueue">
+                <entry name="/queue/APNsPushMessageQueue"/>
+            </jms-queue>
+            <jms-queue name="GCMPushMessageQueue">
+                <entry name="/queue/GCMPushMessageQueue"/>
+            </jms-queue>
+            <jms-queue name="MPNSPushMessageQueue">
+                <entry name="/queue/MPNSPushMessageQueue"/>
+            </jms-queue>
+            <jms-queue name="SimplePushMessageQueue">
+                <entry name="/queue/SimplePushMessageQueue"/>
+            </jms-queue>
+            <jms-queue name="WNSPushMessageQueue">
+                <entry name="/queue/WNSPushMessageQueue"/>
+            </jms-queue>
+            
+            <!-- Token Batches split by Push Network Types -->
+            <jms-queue name="AdmTokenBatchQueue">
+                <entry name="/queue/AdmTokenBatchQueue"/>
+            </jms-queue>
+            <jms-queue name="APNsTokenBatchQueue">
+                <entry name="/queue/APNsTokenBatchQueue"/>
+            </jms-queue>
+            <jms-queue name="GCMTokenBatchQueue">
+                <entry name="/queue/GCMTokenBatchQueue"/>
+            </jms-queue>
+            <jms-queue name="MPNSTokenBatchQueue">
+                <entry name="/queue/MPNSTokenBatchQueue"/>
+            </jms-queue>
+            <jms-queue name="SimplePushTokenBatchQueue">
+                <entry name="/queue/SimplePushTokenBatchQueue"/>
+            </jms-queue>
+            <jms-queue name="WNSTokenBatchQueue">
+                <entry name="/queue/WNSTokenBatchQueue" />
+            </jms-queue>
+            
+            <!-- Metric Collection Queue -->
+            <jms-queue name="MetricsQueue">
+                <entry name="/queue/MetricsQueue"/>
+            </jms-queue>
+        </jms-destinations>
+    </hornetq-server>
+</messaging-deployment>

--- a/push/sender/src/test/resources/jboss-ejb3-message-holder-with-tokens.xml
+++ b/push/sender/src/test/resources/jboss-ejb3-message-holder-with-tokens.xml
@@ -1,0 +1,145 @@
+<?xml version="1.1" encoding="UTF-8"?>
+<!--
+
+    JBoss, Home of Professional Open Source
+    Copyright Red Hat, Inc., and individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<jboss:ejb-jar xmlns:jboss="http://www.jboss.com/xml/ns/javaee"
+               xmlns="http://java.sun.com/xml/ns/javaee"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xmlns:s="urn:security:1.1"
+               xsi:schemaLocation="http://www.jboss.com/xml/ns/javaee http://www.jboss.org/j2ee/schema/jboss-ejb3-2_0.xsd http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/ejb-jar_3_1.xsd"
+               version="3.1"
+               impl-version="2.0">
+    <enterprise-beans>
+        <!-- Token Batch Queue MDBs -->
+        <message-driven>
+            <ejb-name>AdmTokenBatchConsumer</ejb-name>
+            <ejb-class>org.jboss.aerogear.unifiedpush.message.jms.MessageHolderWithTokensConsumer</ejb-class>
+            <transaction-type>Container</transaction-type>
+            <activation-config>
+                <activation-config-property>
+                    <activation-config-property-name>destination</activation-config-property-name>
+                    <activation-config-property-value>queue/AdmTokenBatchQueue</activation-config-property-value>
+                </activation-config-property>
+                <activation-config-property>
+                    <activation-config-property-name>destinationType</activation-config-property-name>
+                    <activation-config-property-value>javax.jms.Queue</activation-config-property-value>
+                </activation-config-property>
+                <activation-config-property>
+                    <activation-config-property-name>acknowledgeMode</activation-config-property-name>
+                    <activation-config-property-value>Auto-acknowledge</activation-config-property-value>
+                </activation-config-property>
+            </activation-config>
+        </message-driven>
+        <message-driven>
+            <ejb-name>APNsTokenBatchConsumer</ejb-name>
+            <ejb-class>org.jboss.aerogear.unifiedpush.message.jms.MessageHolderWithTokensConsumer</ejb-class>
+            <transaction-type>Container</transaction-type>
+            <activation-config>
+                <activation-config-property>
+                    <activation-config-property-name>destination</activation-config-property-name>
+                    <activation-config-property-value>queue/APNsTokenBatchQueue</activation-config-property-value>
+                </activation-config-property>
+                <activation-config-property>
+                    <activation-config-property-name>destinationType</activation-config-property-name>
+                    <activation-config-property-value>javax.jms.Queue</activation-config-property-value>
+                </activation-config-property>
+                <activation-config-property>
+                    <activation-config-property-name>acknowledgeMode</activation-config-property-name>
+                    <activation-config-property-value>Auto-acknowledge</activation-config-property-value>
+                </activation-config-property>
+            </activation-config>
+        </message-driven>
+        <message-driven>
+            <ejb-name>GCMTokenBatchConsumer</ejb-name>
+            <ejb-class>org.jboss.aerogear.unifiedpush.message.jms.MessageHolderWithTokensConsumer</ejb-class>
+            <transaction-type>Container</transaction-type>
+            <activation-config>
+                <activation-config-property>
+                    <activation-config-property-name>destination</activation-config-property-name>
+                    <activation-config-property-value>queue/GCMTokenBatchQueue</activation-config-property-value>
+                </activation-config-property>
+                <activation-config-property>
+                    <activation-config-property-name>destinationType</activation-config-property-name>
+                    <activation-config-property-value>javax.jms.Queue</activation-config-property-value>
+                </activation-config-property>
+                <activation-config-property>
+                    <activation-config-property-name>acknowledgeMode</activation-config-property-name>
+                    <activation-config-property-value>Auto-acknowledge</activation-config-property-value>
+                </activation-config-property>
+            </activation-config>
+        </message-driven>
+        <message-driven>
+            <ejb-name>MPNSTokenBatchConsumer</ejb-name>
+            <ejb-class>org.jboss.aerogear.unifiedpush.message.jms.MessageHolderWithTokensConsumer</ejb-class>
+            <transaction-type>Container</transaction-type>
+            <activation-config>
+                <activation-config-property>
+                    <activation-config-property-name>destination</activation-config-property-name>
+                    <activation-config-property-value>queue/MPNSTokenBatchQueue</activation-config-property-value>
+                </activation-config-property>
+                <activation-config-property>
+                    <activation-config-property-name>destinationType</activation-config-property-name>
+                    <activation-config-property-value>javax.jms.Queue</activation-config-property-value>
+                </activation-config-property>
+                <activation-config-property>
+                    <activation-config-property-name>acknowledgeMode</activation-config-property-name>
+                    <activation-config-property-value>Auto-acknowledge</activation-config-property-value>
+                </activation-config-property>
+            </activation-config>
+        </message-driven>
+        <message-driven>
+            <ejb-name>SimplePushTokenBatchConsumer</ejb-name>
+            <ejb-class>org.jboss.aerogear.unifiedpush.message.jms.MessageHolderWithTokensConsumer</ejb-class>
+            <transaction-type>Container</transaction-type>
+            <activation-config>
+                <activation-config-property>
+                    <activation-config-property-name>destination</activation-config-property-name>
+                    <activation-config-property-value>queue/SimplePushTokenBatchQueue</activation-config-property-value>
+                </activation-config-property>
+                <activation-config-property>
+                    <activation-config-property-name>destinationType</activation-config-property-name>
+                    <activation-config-property-value>javax.jms.Queue</activation-config-property-value>
+                </activation-config-property>
+                <activation-config-property>
+                    <activation-config-property-name>acknowledgeMode</activation-config-property-name>
+                    <activation-config-property-value>Auto-acknowledge</activation-config-property-value>
+                </activation-config-property>
+            </activation-config>
+        </message-driven>
+        <message-driven>
+            <ejb-name>WNSTokenBatchConsumer</ejb-name>
+            <ejb-class>org.jboss.aerogear.unifiedpush.message.jms.MessageHolderWithTokensConsumer</ejb-class>
+            <transaction-type>Container</transaction-type>
+            <activation-config>
+                <activation-config-property>
+                    <activation-config-property-name>destination</activation-config-property-name>
+                    <activation-config-property-value>queue/WNSTokenBatchQueue</activation-config-property-value>
+                </activation-config-property>
+                <activation-config-property>
+                    <activation-config-property-name>destinationType</activation-config-property-name>
+                    <activation-config-property-value>javax.jms.Queue</activation-config-property-value>
+                </activation-config-property>
+                <activation-config-property>
+                    <activation-config-property-name>acknowledgeMode</activation-config-property-name>
+                    <activation-config-property-value>Auto-acknowledge</activation-config-property-value>
+                </activation-config-property>
+            </activation-config>
+        </message-driven>
+        
+    </enterprise-beans>
+</jboss:ejb-jar>


### PR DESCRIPTION
This is a work towards https://issues.jboss.org/browse/AGPUSH-1349 but just a first part.

I would like this to be reviewed before I continue with other JMS tasks because this lay basis for proper testing of the JMS / batch loading which requires a real container to be used.

----

Contains:

* introduction of arquillian tests with managed WildFly 8 container
  * leverages [arquillian-container-chameleon](https://github.com/arquillian/arquillian-container-chameleon) - provides simplest configuration possible together with classpath separation and auto-download
* tests message delivery through JMS
* tests `NotificationRouter` (CDI)

Testing:

* kick off tests :football: , throw feet on the table and watch