### PR TITLE
AGPUSH-1322 : remove cordova snippet link when Windows WNS

### DIFF
--- a/admin-ui/app/scripts/directives.js
+++ b/admin-ui/app/scripts/directives.js
@@ -92,7 +92,7 @@ angular.module('upsConsole')
           android:      { name: 'Android',    snippets: ['android', 'cordova'] },
           ios:          { name: 'iOS',        snippets: ['ios_objc', 'ios_swift', 'cordova']},
           windows_mpns: { name: 'Windows',    snippets: ['mpns', 'cordova'] },
-          windows_wns:  { name: 'Windows',    snippets: ['wns', 'cordova'] },
+          windows_wns:  { name: 'Windows',    snippets: ['wns'] },
           simplePush:   { name: 'SimplePush', snippets: ['cordova'] },
           adm:          { name: 'ADM',        snippets: ['cordova'] }
         };


### PR DESCRIPTION
WNS is not (yet) supported by Cordova, this PR make sure we don't show the Cordova snippet for this type of variant.
@lfryc @edewit can you take a look ? 
