### PR TITLE
added search ability to Activity Log AGPUSH-1390

### DIFF
--- a/admin-ui/app/components/app-detail/app-detail.js
+++ b/admin-ui/app/components/app-detail/app-detail.js
@@ -19,7 +19,7 @@ angular.module('upsConsole')
               self.tab = 'variants';
             }
           }),
-        metricsEndpoint.fetchApplicationMetrics($routeParams.app, 1)
+        metricsEndpoint.fetchApplicationMetrics($routeParams.app, null, 1)
           .then(function( data ) {
             self.notifications = data.pushMetrics;
           })

--- a/admin-ui/app/components/app-detail/include/activity.html
+++ b/admin-ui/app/components/app-detail/include/activity.html
@@ -2,11 +2,10 @@
 
 <p>Explore push messages that you have sent to the registered devices.</p>
 
-
 <div id="DataTables_Table_0_wrapper" class="dataTables_wrapper no-footer">
   <div class="dataTables_header">
     <div id="DataTables_Table_0_filter" class="dataTables_filter">
-      <label><input type="search" class="" aria-controls="DataTables_Table_0"></label>
+      <label><input type="search" class="" aria-controls="DataTables_Table_0" ng-model="activity.searchString" ng-model-options="{debounce: 300}"></label>
     </div>
     <div class="dataTables_info" id="DataTables_Table_0_info" role="status" aria-live="polite">
       Showing <b>{{ activity.currentStart }}</b> to <b>{{ activity.currentEnd }}</b> of <b>{{ activity.totalCount }}</b> Messages
@@ -64,7 +63,7 @@
 
   </div>
 
-  <div class="dataTables_footer">
+  <div class="dataTables_footer" ng-if="activity.totalCount / activity.perPage > 1">
     <div class="dataTables_paginate paging_bootstrap_input">
       <pagination direction-links="true" boundary-links="false"
                   total-items="activity.totalCount"
@@ -73,8 +72,7 @@
                   class="pull-right ups-pagination"
                   max-size="10"
                   ng-change="activity.onPageChange( activity.currentPage )"
-                  rotate="false"
-                  ng-if="activity.totalCount / activity.perPage > 1">
+                  rotate="false">
       </pagination>
     </div>
   </div>

--- a/admin-ui/app/components/app-detail/include/activity.js
+++ b/admin-ui/app/components/app-detail/include/activity.js
@@ -10,9 +10,10 @@ angular.module('upsConsole')
     this.currentStart = 0;
     this.currentEnd = 0;
     this.perPage = 10;
+    this.searchString = '';
 
-    function fetchMetricsPage( page ) {
-      metricsEndpoint.fetchApplicationMetrics(self.app.pushApplicationID, page, self.perPage)
+    function fetchMetrics( page, searchString ) {
+      metricsEndpoint.fetchApplicationMetrics(self.app.pushApplicationID, searchString, page, self.perPage)
         .then(function( data ) {
           self.metrics = data.pushMetrics;
           self.totalCount = data.totalItems;
@@ -30,14 +31,19 @@ angular.module('upsConsole')
     }
 
     // initial page
-    fetchMetricsPage( 1 );
+    fetchMetrics( 1, null );
 
     this.onPageChange = function ( page ) {
-      fetchMetricsPage( page );
+      fetchMetrics( page, self.searchString );
     };
 
     $scope.$on('upsNotificationSent', function( pushData, app ) {
-      fetchMetricsPage( self.currentPage );
+      fetchMetrics( self.currentPage, self.searchString );
+    });
+
+    $scope.$watch(function() { return self.searchString }, function( searchString ) {
+      self.currentPage = 1;
+      fetchMetrics( self.currentPage, self.searchString );
     });
 
   });

--- a/admin-ui/app/scripts/endpoints/metricsEndpoint.js
+++ b/admin-ui/app/scripts/endpoints/metricsEndpoint.js
@@ -32,10 +32,11 @@ upsServices.factory('metricsEndpoint', function ($resource, $q) {
       });
       return deferred.promise;
     },
-    fetchApplicationMetrics: function(applicationId, pageNo, perPage) {
+    fetchApplicationMetrics: function(applicationId, searchString, pageNo, perPage) {
       perPage = perPage || 10;
+      searchString = searchString || null;
       var deferred = $q.defer();
-      this.application({id: applicationId, page: pageNo - 1, per_page: perPage, sort:'desc'}, function (data, responseHeaders) {
+      this.application({id: applicationId, page: pageNo - 1, per_page: perPage, sort:'desc', search: searchString}, function (data, responseHeaders) {
         angular.forEach(data, function (metric) {
           angular.forEach(metric.variantInformations, function (variant) {
             if (!variant.deliveryStatus) {

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/metrics/PushMetricsEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/metrics/PushMetricsEndpoint.java
@@ -16,16 +16,20 @@
  */
 package org.jboss.aerogear.unifiedpush.rest.metrics;
 
-import org.jboss.aerogear.unifiedpush.api.PushMessageInformation;
-import org.jboss.aerogear.unifiedpush.dao.PageResult;
-import org.jboss.aerogear.unifiedpush.service.metrics.PushMessageMetricsService;
+import static org.jboss.aerogear.unifiedpush.rest.util.HttpRequestUtil.extractSortingQueryParamValue;
 
 import javax.inject.Inject;
-import javax.ws.rs.*;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-import static org.jboss.aerogear.unifiedpush.rest.util.HttpRequestUtil.extractSortingQueryParamValue;
+import org.jboss.aerogear.unifiedpush.api.PushMessageInformation;
+import org.jboss.aerogear.unifiedpush.dao.PageResult;
+import org.jboss.aerogear.unifiedpush.service.metrics.PushMessageMetricsService;
 
 @Path("/metrics/messages")
 public class PushMetricsEndpoint {
@@ -42,7 +46,8 @@ public class PushMetricsEndpoint {
             @PathParam("id") String id,
             @QueryParam("page") Integer page,
             @QueryParam("per_page") Integer pageSize,
-            @QueryParam("sort") String sorting) {
+            @QueryParam("sort") String sorting,
+            @QueryParam("search") String search) {
 
         pageSize = parsePageSize(pageSize);
 
@@ -55,7 +60,7 @@ public class PushMetricsEndpoint {
         }
 
         PageResult<PushMessageInformation> pageResult =
-                metricsService.findAllForPushApplication(id, extractSortingQueryParamValue(sorting), page, pageSize);
+                metricsService.findAllForPushApplication(id, search, extractSortingQueryParamValue(sorting), page, pageSize);
 
         return Response.ok(pageResult.getResultList())
                 .header("total", pageResult.getCount()).build();

--- a/model/api/src/main/java/org/jboss/aerogear/unifiedpush/dao/PushMessageInformationDao.java
+++ b/model/api/src/main/java/org/jboss/aerogear/unifiedpush/dao/PushMessageInformationDao.java
@@ -70,7 +70,7 @@ public interface PushMessageInformationDao extends GenericBaseDao<PushMessageInf
      *
      * @return list of push message info objects
      */
-    PageResult<PushMessageInformation> findAllForPushApplication(String pushApplicationId, boolean ascending, Integer page, Integer pageSize);
+    PageResult<PushMessageInformation> findAllForPushApplication(String pushApplicationId, String search, boolean ascending, Integer page, Integer pageSize);
 
     /**
      * Loads all push message metadata objects for the given Variant, but offers a way to order (asc/desc) by date.

--- a/model/jpa/src/test/java/org/jboss/aerogear/unifiedpush/jpa/PushMessageInformationDaoTest.java
+++ b/model/jpa/src/test/java/org/jboss/aerogear/unifiedpush/jpa/PushMessageInformationDaoTest.java
@@ -139,7 +139,7 @@ public class PushMessageInformationDaoTest {
     public void findByPushApplicationID() {
         int page = 0;
         int pageSize = 20;
-        PageResult<PushMessageInformation> messageInformations = pushMessageInformationDao.findAllForPushApplication("231231231", Boolean.TRUE, page, pageSize);
+        PageResult<PushMessageInformation> messageInformations = pushMessageInformationDao.findAllForPushApplication("231231231", null, Boolean.TRUE, page, pageSize);
         assertThat(messageInformations.getResultList()).isNotEmpty();
         assertThat(messageInformations.getResultList()).hasSize(2);
     }
@@ -222,7 +222,7 @@ public class PushMessageInformationDaoTest {
     public void ascendingDateOrdering() {
 
         PageResult<PushMessageInformation> messageInformations =
-                pushMessageInformationDao.findAllForPushApplication("231231231", Boolean.TRUE, 0, 25);
+                pushMessageInformationDao.findAllForPushApplication("231231231", null, Boolean.TRUE, 0, 25);
         final List<PushMessageInformation> list = messageInformations.getResultList();
         assertThat(list).hasSize(2);
 
@@ -232,11 +232,19 @@ public class PushMessageInformationDaoTest {
     @Test
     public void descendingDateOrdering() {
         PageResult<PushMessageInformation> messageInformations =
-                pushMessageInformationDao.findAllForPushApplication("231231231", Boolean.FALSE, 0, 25);
+                pushMessageInformationDao.findAllForPushApplication("231231231", null, Boolean.FALSE, 0, 25);
         final List<PushMessageInformation> list = messageInformations.getResultList();
         assertThat(list).hasSize(2);
 
         assertThat(list.get(0).getSubmitDate()).isAfter(list.get(1).getSubmitDate());
+    }
+
+    @Test
+    public void testSearchString() {
+        PageResult<PushMessageInformation> messageInformations =
+                pushMessageInformationDao.findAllForPushApplication("231231231", "foo", Boolean.TRUE, 0, 25);
+        final List<PushMessageInformation> list = messageInformations.getResultList();
+        assertThat(list).hasSize(1);
     }
 
     @Test

--- a/model/jpa/src/test/resources/MessageInformation.xml
+++ b/model/jpa/src/test/resources/MessageInformation.xml
@@ -37,23 +37,27 @@
     <table name="SA.PUSHMESSAGEINFORMATION">
         <column>id</column>
         <column>pushApplicationId</column>
+        <column>rawJsonMessage</column>
         <column>submitDate</column>
         <column>totalReceivers</column>
         <row>
             <value>1</value>
             <value>231231231</value>
+            <value>{ "message": { "alert": "foo" } }</value>
             <value>1980-02-01</value>
             <value>0</value>
         </row>
         <row>
             <value>2</value>
             <value>231231231</value>
+            <value>{ "message": { "alert": "bar" } }</value>
             <value>1980-02-04</value>
             <value>0</value>
         </row>
         <row>
             <value>3</value>
             <value>231231232</value>
+            <value>{ "message": { "alert": "foo" } }</value>
             <value>2015-01-22</value>
             <value>0</value>
         </row>

--- a/service/src/main/java/org/jboss/aerogear/unifiedpush/service/metrics/PushMessageMetricsService.java
+++ b/service/src/main/java/org/jboss/aerogear/unifiedpush/service/metrics/PushMessageMetricsService.java
@@ -18,6 +18,7 @@ package org.jboss.aerogear.unifiedpush.service.metrics;
 
 import java.util.Date;
 
+import javax.ejb.Stateless;
 import javax.inject.Inject;
 
 import org.jboss.aerogear.unifiedpush.api.PushMessageInformation;
@@ -26,9 +27,6 @@ import org.jboss.aerogear.unifiedpush.dao.PageResult;
 import org.jboss.aerogear.unifiedpush.dao.PushMessageInformationDao;
 import org.jboss.aerogear.unifiedpush.dao.VariantMetricInformationDao;
 import org.jboss.aerogear.unifiedpush.utils.DateUtils;
-
-
-import javax.ejb.Stateless;
 
 /**
  * Service class to handle different aspects of the Push Message Information metadata for the "Push Message History" view
@@ -90,8 +88,8 @@ public class PushMessageMetricsService {
      *
      * @return list of push message info objects
      */
-    public PageResult<PushMessageInformation> findAllForPushApplication(String pushApplicationID, boolean sorting, Integer page, Integer pageSize) {
-        return pushMessageInformationDao.findAllForPushApplication(pushApplicationID, sorting, page, pageSize);
+    public PageResult<PushMessageInformation> findAllForPushApplication(String pushApplicationID, String search, boolean sorting, Integer page, Integer pageSize) {
+        return pushMessageInformationDao.findAllForPushApplication(pushApplicationID, search, sorting, page, pageSize);
     }
 
     /**


### PR DESCRIPTION
https://issues.jboss.org/browse/AGPUSH-1390

What:

* we want to search for messages by their content (in fact we can search for anything in raw JSON message)

Testing:

* send more than 10 testing notifications so that you have >=2 pages in the Activity Log
* try search for some alert strings in the table header on Activity Log page