### PR TITLE
reintroduced Installation List with search capability AGPUSH-1406

### DIFF
--- a/admin-ui/app/components/app-detail/include/variantDetail.html
+++ b/admin-ui/app/components/app-detail/include/variantDetail.html
@@ -1,0 +1,121 @@
+<p ng-show="variant.type == 'ios'">Apple's Push Network (APNs) will be used.
+  To learn more about APNs, visit our <a ups-doc="docs-push-ios">iOS</a>
+  or <a ups-doc="docs-push-cordova">Apache Cordova</a> guides for push.
+</p>
+<p ng-show="variant.type == 'android'">Google's Cloud Messaging Network (GCM) will be used.
+  To learn more about GCM, visit our <a ups-doc="docs-push-android">Android</a>, <a ups-doc="docs-push-chrome">Chrome</a> or <a ups-doc="docs-push-cordova">Apache Cordova</a> guides for push.
+</p>
+<p ng-show="variant.type == 'simplePush'">A Server implementing the <em>SimplePush</em> protocol will be used.
+  More information can be found in <a ups-doc="simplepush-protocol">SimplePush Protocol Draft</a>.
+  The <a ups-doc="simplepush-quickstart">AeroGears' SimplePush Quickstart</a> also contains useful information.
+</p>
+<p ng-show="variant.type == 'adm'">Amazon's Device Messaging Network (ADM) will be used.
+  To learn more about, visit our <a ups-doc="docs-push-adm">adm</a> or <a ups-doc="docs-push-cordova">Apache Cordova</a> guides for push.
+</p>
+<dl class="dl-horizontal" ng-if="variant.type == 'android'">
+  <dt>Project Number:</dt>
+  <dd>{{ variant.projectNumber }}</dd>
+  <dt>Google API Key:</dt>
+  <dd>
+    {{ variant.googleKey }}<br />
+    <button class="btn btn-sm btn-primary" ng-click="variants.edit( variant )"><span class="pficon pficon-refresh"></span> Change network options</button>
+  </dd>
+</dl>
+<dl class="dl-horizontal" ng-show="variant.type == 'windows_mpns'">
+  <dt>Type:</dt>
+  <dd>Microsoft Push Notification Service</dd>
+</dl>
+<dl class="dl-horizontal" ng-show="variant.type == 'windows_wns'">
+  <dt>Type:</dt>
+  <dd>Windows Push Network</dd>
+  <dt>Package SID:</dt>
+  <dd>{{ variant.sid }}</dd>
+  <dt>Client Secret:</dt>
+  <dd>
+    {{ variant.clientSecret }}<br />
+    <button class="btn btn-sm btn-primary" ng-click="variants.edit( variant )"><span class="pficon pficon-refresh"></span> Change network options</button>
+  </dd>
+</dl>
+<dl class="dl-horizontal" ng-show="variant.type == 'ios'">
+  <dt>Type:</dt>
+  <dd>
+    {{ variant.production ? 'Production' : 'Development' }}<br />
+    <button class="btn btn-sm btn-primary" ng-click="variants.edit( variant )"><span class="pficon pficon-refresh"></span> Change network options</button>
+  </dd>
+</dl>
+<dl class="dl-horizontal" ng-show="variant.type == 'chrome'">
+  <dt>Client Id:</dt>
+  <dd>{{ variant.clientId }}</dd>
+  <dt>Client Secret:</dt>
+  <dd>{{ variant.clientSecret }}</dd>
+  <dt>Refresh Token:</dt>
+  <dd>
+    {{ variant.refreshToken }}<br />
+    <button class="btn btn-sm btn-primary" ng-click="variants.edit( variant )"><span class="pficon pficon-refresh"></span> Change network options</button>
+  </dd>
+</dl>
+<dl class="dl-horizontal" ng-show="variant.type == 'adm'">
+  <dt>Client Id:</dt>
+  <dd>{{ variant.clientId }}</dd>
+  <dt>Client Secret:</dt>
+  <dd>
+    {{ variant.clientSecret }}<br />
+    <button class="btn btn-sm btn-primary" ng-click="variants.edit( variant )"><span class="pficon pficon-refresh"></span> Change network options</button>
+  </dd>
+</dl>
+
+<ups-client-snippets variant="variant" ng-if="variant.$deviceCount == 0 || variantDetail.forceShowSnippets"></ups-client-snippets>
+
+<p ng-if="variant.$deviceCount > 0">
+  This is a list of devices using this variable.
+  <a href ng-click="variantDetail.forceShowSnippets = true" ng-if="!variantDetail.forceShowSnippets">To see installation instructions and code snippet click here</a>
+</p>
+
+<div class="dataTables_wrapper no-footer" ng-if="variant.$deviceCount > 0">
+  <div class="dataTables_header">
+    <div class="dataTables_filter">
+      <label><input type="search" ng-model="variantDetail.searchString" ng-model-options="{debounce: 300}"></label>
+    </div>
+    <div class="dataTables_info" role="status" aria-live="polite">
+      Showing <b>{{ variantDetail.currentStart }}</b> to <b>{{ variantDetail.currentEnd }}</b> of <b>{{ variantDetail.totalCount }}</b> Devices
+    </div>
+  </div>
+
+  <div class="table-responsive">
+    <table class="datatable table table-striped table-bordered" pf-datatable>
+      <thead>
+      <tr>
+        <th>Device token</th>
+        <th>Device type</th>
+        <th>Categories</th>
+        <th>Alias</th>
+        <th>Receiving</th>
+      </tr>
+      </thead>
+      <tbody>
+      <tr ng-repeat="installation in variantDetail.installations">
+        <td title="{{ installation.deviceToken }}">{{ installation.deviceToken | limitTo : 25 }}{{ installation.deviceToken.length > 25 ? '&hellip;' : '' }}</td>
+        <td>{{ installation.deviceType }}</td>
+        <td><span ng-repeat="cat in installation.categories">{{cat.name}}{{$last ? '' : ', '}}</span></td>
+        <td title="{{ installation.alias }}">{{ installation.alias  | limitTo : 15 }}{{ installation.alias.length > 15 ? '&hellip;' : '' }}</td>
+        <td><input type="checkbox" ng-checked="installation.enabled" ng-click="variantDetail.enableInstallation(variant, installation, !installation.enabled)"></td>
+      </tr>
+      </tbody>
+    </table>
+
+  </div>
+
+  <div class="dataTables_footer" ng-if="variantDetail.totalCount / variantDetail.perPage > 1">
+    <div class="dataTables_paginate paging_bootstrap_input">
+      <pagination direction-links="true" boundary-links="false"
+                  total-items="variantDetail.totalCount"
+                  ng-model="variantDetail.currentPage"
+                  previous-text="&lsaquo;" next-text="&rsaquo;"
+                  class="pull-right ups-pagination"
+                  max-size="10"
+                  ng-change="variantDetail.onPageChange( variantDetail.currentPage )"
+                  rotate="false">
+      </pagination>
+    </div>
+  </div>
+</div>

--- a/admin-ui/app/components/app-detail/include/variantDetail.js
+++ b/admin-ui/app/components/app-detail/include/variantDetail.js
@@ -1,0 +1,46 @@
+angular.module('upsConsole')
+  .controller('VariantDetailController', function ( $modal, variantModal, $scope, installationsEndpoint ) {
+
+    var self = this;
+
+    this.variant = $scope.$parent.variant;
+    this.installations = [];
+    this.totalCount;
+    this.currentPage = 1;
+    this.currentStart = 0;
+    this.currentEnd = 0;
+    this.perPage = 10;
+    this.searchString = '';
+    this.forceShowSnippets = false;
+
+    function fetchInstallations( page, searchString ) {
+      installationsEndpoint.fetchInstallations(self.variant.variantID, searchString, page, self.perPage)
+        .then(function( data ) {
+          self.installations = data.installations;
+          self.totalCount = data.total;
+          self.currentStart = self.perPage * (self.currentPage - 1) + 1;
+          self.currentEnd = self.perPage * (self.currentPage - 1) + self.installations.length;
+        });
+    }
+
+    // initial page
+    fetchInstallations( 1, null );
+
+    this.onPageChange = function ( page ) {
+      fetchInstallations( page, self.searchString );
+    };
+
+    $scope.$watch(function() { return self.searchString }, function( searchString ) {
+      self.currentPage = 1;
+      fetchInstallations( self.currentPage, self.searchString );
+    });
+
+    self.enableInstallation = function( variant, installation, enabled ) {
+      var clone = angular.extend({}, installation, {enabled: enabled});
+      installationsEndpoint.update({variantId: self.variant.variantID, installationId: installation.id}, clone)
+        .then(function() {
+          installation.enabled = enabled;
+        });
+    }
+
+  });

--- a/admin-ui/app/components/app-detail/include/variants.html
+++ b/admin-ui/app/components/app-detail/include/variants.html
@@ -39,77 +39,11 @@
         </ul>
 
       </div><!-- vaiant header -->
-      <div class="ups-variant-body" ng-show="variant.$toggled">
 
-        <p ng-show="variant.type == 'ios'">Apple's Push Network (APNs) will be used.
-          To learn more about APNs, visit our <a ups-doc="docs-push-ios">iOS</a>
-          or <a ups-doc="docs-push-cordova">Apache Cordova</a> guides for push.
-        </p>
-        <p ng-show="variant.type == 'android'">Google's Cloud Messaging Network (GCM) will be used.
-          To learn more about GCM, visit our <a ups-doc="docs-push-android">Android</a>, <a ups-doc="docs-push-chrome">Chrome</a> or <a ups-doc="docs-push-cordova">Apache Cordova</a> guides for push.
-        </p>
-        <p ng-show="variant.type == 'simplePush'">A Server implementing the <em>SimplePush</em> protocol will be used.
-          More information can be found in <a ups-doc="simplepush-protocol">SimplePush Protocol Draft</a>.
-          The <a ups-doc="simplepush-quickstart">AeroGears' SimplePush Quickstart</a> also contains useful information.
-        </p>
-        <p ng-show="variant.type == 'adm'">Amazon's Device Messaging Network (ADM) will be used.
-          To learn more about, visit our <a ups-doc="docs-push-adm">adm</a> or <a ups-doc="docs-push-cordova">Apache Cordova</a> guides for push.
-        </p>
-        <dl class="dl-horizontal" ng-if="variant.type == 'android'">
-          <dt>Project Number:</dt>
-          <dd>{{ variant.projectNumber }}</dd>
-          <dt>Google API Key:</dt>
-          <dd>
-            {{ variant.googleKey }}<br />
-            <button class="btn btn-sm btn-primary" ng-click="variants.edit( variant )"><span class="pficon pficon-refresh"></span> Change network options</button>
-          </dd>
-        </dl>
-        <dl class="dl-horizontal" ng-show="variant.type == 'windows_mpns'">
-          <dt>Type:</dt>
-          <dd>Microsoft Push Notification Service</dd>
-        </dl>
-        <dl class="dl-horizontal" ng-show="variant.type == 'windows_wns'">
-          <dt>Type:</dt>
-          <dd>Windows Push Network</dd>
-          <dt>Package SID:</dt>
-          <dd>{{ variant.sid }}</dd>
-          <dt>Client Secret:</dt>
-          <dd>
-            {{ variant.clientSecret }}<br />
-            <button class="btn btn-sm btn-primary" ng-click="variants.edit( variant )"><span class="pficon pficon-refresh"></span> Change network options</button>
-          </dd>
-        </dl>
-        <dl class="dl-horizontal" ng-show="variant.type == 'ios'">
-          <dt>Type:</dt>
-          <dd>
-            {{ variant.production ? 'Production' : 'Development' }}<br />
-            <button class="btn btn-sm btn-primary" ng-click="variants.edit( variant )"><span class="pficon pficon-refresh"></span> Change network options</button>
-          </dd>
-        </dl>
-        <dl class="dl-horizontal" ng-show="variant.type == 'chrome'">
-          <dt>Client Id:</dt>
-          <dd>{{ variant.clientId }}</dd>
-          <dt>Client Secret:</dt>
-          <dd>{{ variant.clientSecret }}</dd>
-          <dt>Refresh Token:</dt>
-          <dd>
-            {{ variant.refreshToken }}<br />
-            <button class="btn btn-sm btn-primary" ng-click="variants.edit( variant )"><span class="pficon pficon-refresh"></span> Change network options</button>
-          </dd>
-        </dl>
-        <dl class="dl-horizontal" ng-show="variant.type == 'adm'">
-          <dt>Client Id:</dt>
-          <dd>{{ variant.clientId }}</dd>
-          <dt>Client Secret:</dt>
-          <dd>
-            {{ variant.clientSecret }}<br />
-            <button class="btn btn-sm btn-primary" ng-click="variants.edit( variant )"><span class="pficon pficon-refresh"></span> Change network options</button>
-          </dd>
-        </dl>
-
-        <ups-client-snippets variant="variant"></ups-client-snippets>
-
+      <div class="ups-variant-body" ng-if="variant.$toggled">
+        <ng-include src="'components/app-detail/include/variantDetail.html'" ng-controller="VariantDetailController as variantDetail"></ng-include>
       </div><!-- variant content -->
+
     </div><!-- variant -->
 
 

--- a/admin-ui/app/index.html
+++ b/admin-ui/app/index.html
@@ -169,6 +169,7 @@
 <script src="components/app-detail/app-detail.js"></script>
 <script src="components/app-detail/include/sender.js"></script>
 <script src="components/app-detail/include/variants.js"></script>
+<script src="components/app-detail/include/variantDetail.js"></script>
 <script src="components/app-detail/include/activity.js"></script>
 <script src="components/app-detail/include/analytics.js"></script>
 <script src="components/wizard01-create-app/wizard01-create-app.js"></script>
@@ -187,6 +188,7 @@
 
 <script src="scripts/endpoints/applicationsEndpoint.js"></script>
 <script src="scripts/endpoints/variantsEndpoint.js"></script>
+<script src="scripts/endpoints/installationsEndpoint.js"></script>
 <script src="scripts/endpoints/messageSenderEndpoint.js"></script>
 <script src="scripts/endpoints/metricsEndpoint.js"></script>
 <script src="scripts/endpoints/dashboardEndpoint.js"></script>

--- a/admin-ui/app/scripts/endpoints/installationsEndpoint.js
+++ b/admin-ui/app/scripts/endpoints/installationsEndpoint.js
@@ -15,11 +15,11 @@ upsServices.factory('installationsEndpoint', function ($resource, $q) {
       method: 'PUT'
     }
   });
-  installationsService.fetchInstallations = function(variantId, pageNo) {
+  installationsService.fetchInstallations = function(variantId, searchString, pageNo, perPage) {
     var deferred = $q.defer();
-    this.get({variantId: variantId, page: pageNo - 1, per_page: 10}, function (data, responseHeaders) {
+    this.get({variantId: variantId, search: searchString, page: pageNo - 1, per_page: perPage}, function (data, responseHeaders) {
       deferred.resolve({
-        page: data,
+        installations: data,
         total: responseHeaders('total')
       });
     });

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/InstallationManagementEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/InstallationManagementEndpoint.java
@@ -30,7 +30,6 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
-import com.qmino.miredot.annotations.ReturnType;
 import org.jboss.aerogear.unifiedpush.api.Installation;
 import org.jboss.aerogear.unifiedpush.dao.PageResult;
 import org.jboss.aerogear.unifiedpush.dto.Count;
@@ -38,6 +37,8 @@ import org.jboss.aerogear.unifiedpush.service.ClientInstallationService;
 import org.jboss.aerogear.unifiedpush.service.impl.SearchManager;
 import org.jboss.resteasy.spi.Link;
 import org.jboss.resteasy.spi.LinkHeader;
+
+import com.qmino.miredot.annotations.ReturnType;
 
 
 @Path("/applications/{variantID}/installations/")
@@ -67,8 +68,11 @@ public class InstallationManagementEndpoint {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @ReturnType("java.util.List<org.jboss.aerogear.unifiedpush.api.Installation>")
-    public Response findInstallations(@PathParam("variantID") String variantId, @QueryParam("page") Integer page,
-                                      @QueryParam("per_page") Integer pageSize, @Context UriInfo uri) {
+    public Response findInstallations(@PathParam("variantID") String variantId,
+                                      @QueryParam("page") Integer page,
+                                      @QueryParam("per_page") Integer pageSize,
+                                      @QueryParam("search") String search,
+                                      @Context UriInfo uri) {
         if (pageSize != null) {
             pageSize = Math.min(MAX_PAGE_SIZE, pageSize);
         } else {
@@ -79,13 +83,17 @@ public class InstallationManagementEndpoint {
             page = 0;
         }
 
+        if (search == null || search.isEmpty()) {
+            search = null;
+        }
+
         //Find the variant using the variantID
         if (!searchManager.getSearchService().existsVariantIDForDeveloper(variantId)) {
             return Response.status(Response.Status.NOT_FOUND).entity("Could not find requested Variant").build();
         }
 
         //Find the installations using the variantID
-        PageResult<Installation, Count> pageResult = searchManager.getSearchService().findAllInstallationsByVariantForDeveloper(variantId, page, pageSize);
+        PageResult<Installation, Count> pageResult = searchManager.getSearchService().findAllInstallationsByVariantForDeveloper(variantId, page, pageSize, search);
 
         final long totalPages = pageResult.getAggregate().getCount() / pageSize;
         LinkHeader header = getLinkHeader(page, totalPages, uri);

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/installations/ExportEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/installations/ExportEndpoint.java
@@ -16,16 +16,17 @@
  */
 package org.jboss.aerogear.unifiedpush.rest.registry.installations;
 
-import com.qmino.miredot.annotations.ReturnType;
-import org.jboss.aerogear.unifiedpush.rest.AbstractBaseEndpoint;
-import org.jboss.resteasy.annotations.GZIP;
-
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+
+import org.jboss.aerogear.unifiedpush.rest.AbstractBaseEndpoint;
+import org.jboss.resteasy.annotations.GZIP;
+
+import com.qmino.miredot.annotations.ReturnType;
 
 @Path("/export")
 public class ExportEndpoint extends AbstractBaseEndpoint {
@@ -43,7 +44,7 @@ public class ExportEndpoint extends AbstractBaseEndpoint {
     @GZIP
     @ReturnType("java.util.List<org.jboss.aerogear.unifiedpush.api.Installation>")
     public Response exportInstallations(@PathParam("variantId") String variantId) {
-        return Response.ok(getSearch().findAllInstallationsByVariantForDeveloper(variantId, 0, Integer.MAX_VALUE).getResultList()).build();
+        return Response.ok(getSearch().findAllInstallationsByVariantForDeveloper(variantId, 0, Integer.MAX_VALUE, null).getResultList()).build();
     }
 
 }

--- a/model/api/src/main/java/org/jboss/aerogear/unifiedpush/dao/InstallationDao.java
+++ b/model/api/src/main/java/org/jboss/aerogear/unifiedpush/dao/InstallationDao.java
@@ -71,7 +71,7 @@ public interface InstallationDao extends GenericBaseDao<Installation, String> {
      *
      * @return all installations found or empty list + the total count of results
      */
-    PageResult<Installation, Count> findInstallationsByVariantForDeveloper(String variantID, String developer, Integer page, Integer pageSize);
+    PageResult<Installation, Count> findInstallationsByVariantForDeveloper(String variantID, String developer, Integer page, Integer pageSize, String search);
 
     /**
      * Find all installations for the variant specified (used for admin role)
@@ -81,7 +81,7 @@ public interface InstallationDao extends GenericBaseDao<Installation, String> {
      *
      * @return all installations found or empty list + the total count of results
      */
-    PageResult<Installation, Count> findInstallationsByVariant(String variantID, Integer page, Integer pageSize);
+    PageResult<Installation, Count> findInstallationsByVariant(String variantID, Integer page, Integer pageSize, String search);
 
 
     /**

--- a/model/jpa/src/main/java/org/jboss/aerogear/unifiedpush/jpa/dao/impl/JPAInstallationDao.java
+++ b/model/jpa/src/main/java/org/jboss/aerogear/unifiedpush/jpa/dao/impl/JPAInstallationDao.java
@@ -26,11 +26,6 @@ import java.util.Map.Entry;
 import java.util.Set;
 
 import javax.persistence.TypedQuery;
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.Join;
-import javax.persistence.criteria.Predicate;
-import javax.persistence.criteria.Root;
 
 import org.hibernate.Query;
 import org.hibernate.ScrollMode;
@@ -49,39 +44,49 @@ public class JPAInstallationDao extends JPABaseDao<Installation, String> impleme
                     + " left join installation.categories c "
                     + " join installation.variant abstractVariant where abstractVariant.variantID = :variantID AND installation.enabled = true";
 
-    public PageResult<Installation, Count> findInstallationsByVariantForDeveloper(String variantID, String developer, Integer page, Integer pageSize) {
-        final CriteriaBuilder builder = entityManager.getCriteriaBuilder();
-        final CriteriaQuery<Installation> query = builder.createQuery(Installation.class);
-        Root<Installation> v = query.from(Installation.class);
-        final Join join = v.join("variant");
-        final Predicate[] predicates = getPredicates(variantID, developer, builder, join);
-        query.where(predicates);
+    private static final String FIND_INSTALLATIONS = "FROM Installation installation"
+                    + " JOIN installation.variant v"
+                    + " WHERE v.variantID = :variantID";
 
-        List<Installation> result = entityManager.createQuery(query)
-                .setFirstResult(page * pageSize).setMaxResults(pageSize).getResultList();
+    public PageResult<Installation, Count> findInstallationsByVariantForDeveloper(String variantID, String developer, Integer page, Integer pageSize, String search) {
 
-        CriteriaQuery<Long> countQuery = builder.createQuery(Long.class);
-        final Join<Object, Object> join1 = countQuery.from(Installation.class).join("variant");
-        countQuery.where(getPredicates(variantID, developer, builder, join1));
-        final Long count = entityManager.createQuery(countQuery.select(builder.count(join1))).getSingleResult();
 
-        return new PageResult<Installation, Count>(result, new Count(count));
+        final StringBuilder jpqlBase = new StringBuilder(FIND_INSTALLATIONS);
+        final Map<String, Object> parameters = new LinkedHashMap<String, Object>();
+        parameters.put("variantID", variantID);
+        if (developer != null) {
+            jpqlBase.append(" AND v.developer = :developer");
+            parameters.put("developer", developer);
+        }
+        if (search != null) {
+            jpqlBase.append(" AND ( deviceToken LIKE :search"
+                    + " OR deviceType LIKE :search"
+                    + " OR platform LIKE :search"
+                    + " OR operatingSystem LIKE :search"
+                    + " OR osVersion LIKE :search"
+                    + " OR alias LIKE :search )");
+            parameters.put("search", "%" + search + "%");
+        }
+
+
+        TypedQuery<Long> countQuery = createQuery("SELECT COUNT(installation) " + jpqlBase.toString(), Long.class);
+        TypedQuery<Installation> query = createQuery("SELECT installation " + jpqlBase.toString() + " ORDER BY installation.id").setFirstResult(page * pageSize).setMaxResults(pageSize);
+
+        List<Installation> resultList = setParameters(query, parameters).getResultList();
+        Long count = setParameters(countQuery, parameters).getSingleResult();
+
+        return new PageResult<Installation, Count>(resultList, new Count(count));
     }
 
-    public PageResult<Installation, Count> findInstallationsByVariant(String variantID, Integer page, Integer pageSize) {
-        return findInstallationsByVariantForDeveloper(variantID, null, page, pageSize);
+    private <X> TypedQuery<X> setParameters(TypedQuery<X> query, Map<String, Object> parameters) {
+        for (Entry<String, Object> entry : parameters.entrySet()) {
+            query.setParameter(entry.getKey(), entry.getValue());
+        }
+        return query;
     }
 
-    private Predicate[] getPredicates(String variantID, String developer, CriteriaBuilder builder, Join join) {
-        Predicate[] predicates;
-        if(developer!=null) {
-            predicates = new Predicate[]{builder.equal(join.get("variantID"), variantID),
-                    builder.and(builder.equal(join.get("developer"), developer))};
-        }
-        else {
-            predicates = new Predicate[]{builder.equal(join.get("variantID"), variantID)};
-        }
-        return predicates;
+    public PageResult<Installation, Count> findInstallationsByVariant(String variantID, Integer page, Integer pageSize, String search) {
+        return findInstallationsByVariantForDeveloper(variantID, null, page, pageSize, search);
     }
 
 

--- a/model/jpa/src/test/java/org/jboss/aerogear/unifiedpush/jpa/InstallationDaoTest.java
+++ b/model/jpa/src/test/java/org/jboss/aerogear/unifiedpush/jpa/InstallationDaoTest.java
@@ -92,12 +92,12 @@ public class InstallationDaoTest {
 
     @Test
     public void countDevicesForLoginName() {
-        assertThat(installationDao.getNumberOfDevicesForLoginName("me")).isEqualTo(6);
+        assertThat(installationDao.getNumberOfDevicesForLoginName("me")).isEqualTo(7);
     }
 
     @Test
     public void getNumberOfDevicesForVariantID() {
-        assertThat(installationDao.getNumberOfDevicesForVariantID("1")).isEqualTo(3);
+        assertThat(installationDao.getNumberOfDevicesForVariantID("1")).isEqualTo(4);
         assertThat(installationDao.getNumberOfDevicesForVariantID("2")).isEqualTo(3);
     }
 
@@ -501,23 +501,47 @@ public class InstallationDaoTest {
         String developer = "me";
 
         //when
-        final PageResult<Installation, Count> pageResult = installationDao.findInstallationsByVariantForDeveloper(androidVariantID, developer, 0, 1);
+        final PageResult<Installation, Count> pageResult = installationDao.findInstallationsByVariantForDeveloper(androidVariantID, developer, 0, 1, null);
 
         //then
         assertThat(pageResult).isNotNull();
         assertThat(pageResult.getResultList()).isNotEmpty().hasSize(1);
-        assertThat(pageResult.getAggregate().getCount()).isEqualTo(3);
+        assertThat(pageResult.getAggregate().getCount()).isEqualTo(4);
     }
 
     @Test
     public void shouldSelectInstallationsByVariant() {
         //when
-        final PageResult<Installation, Count> pageResult = installationDao.findInstallationsByVariant(androidVariantID, 0, 1);
+        final PageResult<Installation, Count> pageResult = installationDao.findInstallationsByVariant(androidVariantID, 0, 1, null);
 
         //then
         assertThat(pageResult).isNotNull();
         assertThat(pageResult.getResultList()).isNotEmpty().hasSize(1);
-        assertThat(pageResult.getAggregate().getCount()).isEqualTo(3);
+        assertThat(pageResult.getAggregate().getCount()).isEqualTo(4);
+    }
+
+    @Test
+    public void shouldSelectInstallationsByDeviceTokenSearch() {
+        //when
+        final PageResult<Installation, Count> pageResult = installationDao.findInstallationsByVariant(androidVariantID, 0, Integer.MAX_VALUE, "67890167890");
+        //then
+        assertThat(pageResult.getResultList()).isNotEmpty().hasSize(1);
+    }
+
+    @Test
+    public void shouldSelectInstallationsByDeviceTypeSearch() {
+        //when
+        final PageResult<Installation, Count> pageResult = installationDao.findInstallationsByVariant(androidVariantID, 0, Integer.MAX_VALUE, "Tablet");
+        //then
+        assertThat(pageResult.getResultList()).isNotEmpty().hasSize(2);
+    }
+
+    @Test
+    public void shouldSelectInstallationsByAliasSearch() {
+        //when
+        final PageResult<Installation, Count> pageResult = installationDao.findInstallationsByVariant(androidVariantID, 0, Integer.MAX_VALUE, "baz@");
+        //then
+        assertThat(pageResult.getResultList()).isNotEmpty().hasSize(1);
     }
 
     @Test(expected = PersistenceException.class)

--- a/model/jpa/src/test/resources/Installations.xml
+++ b/model/jpa/src/test/resources/Installations.xml
@@ -130,6 +130,14 @@
             <value>foo@bar.org</value>
             <value>JavaFX Monitor</value>
         </row>
+        <row>
+            <value>7</value>
+            <value>false</value>
+            <value>809543234234890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890</value>
+            <value>1</value>
+            <value>baz@bar.org</value>
+            <value></value>
+        </row>
     </table>
 
     <table name="SA.CATEGORY">

--- a/service/src/main/java/org/jboss/aerogear/unifiedpush/service/PushSearchService.java
+++ b/service/src/main/java/org/jboss/aerogear/unifiedpush/service/PushSearchService.java
@@ -93,7 +93,7 @@ public interface PushSearchService {
      *
      * @return page result containing the list plus a total number of rows
      */
-    PageResult<Installation, Count> findAllInstallationsByVariantForDeveloper(String variantID, Integer page, Integer pageSize);
+    PageResult<Installation, Count> findAllInstallationsByVariantForDeveloper(String variantID, Integer page, Integer pageSize, String search);
 
 
 }

--- a/service/src/main/java/org/jboss/aerogear/unifiedpush/service/impl/PushSearchByDeveloperServiceImpl.java
+++ b/service/src/main/java/org/jboss/aerogear/unifiedpush/service/impl/PushSearchByDeveloperServiceImpl.java
@@ -119,8 +119,8 @@ public class PushSearchByDeveloperServiceImpl implements PushSearchService {
     }
 
     @Override
-    public PageResult<Installation, Count> findAllInstallationsByVariantForDeveloper(String variantID, Integer page, Integer pageSize) {
-        return installationDao.findInstallationsByVariantForDeveloper(variantID,loginName.get(), page, pageSize);
+    public PageResult<Installation, Count> findAllInstallationsByVariantForDeveloper(String variantID, Integer page, Integer pageSize, String search) {
+        return installationDao.findInstallationsByVariantForDeveloper(variantID,loginName.get(), page, pageSize, search);
     }
 
     private long totalMessages() {

--- a/service/src/main/java/org/jboss/aerogear/unifiedpush/service/impl/PushSearchServiceImpl.java
+++ b/service/src/main/java/org/jboss/aerogear/unifiedpush/service/impl/PushSearchServiceImpl.java
@@ -71,8 +71,8 @@ public class PushSearchServiceImpl implements PushSearchService {
     }
 
     @Override
-    public PageResult<Installation, Count> findAllInstallationsByVariantForDeveloper(String variantID, Integer page, Integer pageSize) {
-        return installationDao.findInstallationsByVariant(variantID, page, pageSize);
+    public PageResult<Installation, Count> findAllInstallationsByVariantForDeveloper(String variantID, Integer page, Integer pageSize, String search) {
+        return installationDao.findInstallationsByVariant(variantID, page, pageSize, search);
     }
 
 


### PR DESCRIPTION
https://issues.jboss.org/browse/AGPUSH-1406

Summary:
* the device list is conditionally presented to a user in the Variant detail
  * the device list has: search capability
  * ...pagination
  * ability to enable/disable device
* the client device registration snippet is not shown when there are registered devices (but user can click to reveal it by hitting a link)
* and vice versa, no device list is shown when there are "No installations yet" and client device registration snippet is presented then

Note:
* I had to extend REST endpoint by one optional parameter "search" that allows full text search in some comment installation properties

Testing:
* test that features above works as you would expect

A mockup I used as a base for impl: http://andresgalante.com/ups-console/app-detail-variants.html