### PR TITLE
Improved Arquillian test debugging + use non-conflicting port

### DIFF
--- a/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/message/TestMetricsCollector.java
+++ b/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/message/TestMetricsCollector.java
@@ -40,7 +40,6 @@ import org.jboss.aerogear.unifiedpush.service.metrics.PushMessageMetricsService;
 import org.jboss.aerogear.unifiedpush.test.archive.UnifiedPushArchive;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -50,8 +49,7 @@ public class TestMetricsCollector extends AbstractJMSTest {
 
     @Deployment
     public static WebArchive archive() {
-        return ShrinkWrap
-                .create(UnifiedPushArchive.class)
+        return UnifiedPushArchive.forTestClass(TestMetricsCollector.class)
                 .withMessaging()
                     .addClasses(MetricsCollector.class)
                     .addClasses(PushMessageMetricsService.class)

--- a/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/message/TestNotificationRouter.java
+++ b/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/message/TestNotificationRouter.java
@@ -41,21 +41,18 @@ import org.jboss.aerogear.unifiedpush.service.metrics.PushMessageMetricsService;
 import org.jboss.aerogear.unifiedpush.test.archive.UnifiedPushArchive;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 
-
 @RunWith(Arquillian.class)
 public class TestNotificationRouter {
 
     @Deployment
     public static WebArchive archive() {
-        return ShrinkWrap
-                .create(UnifiedPushArchive.class)
+        return UnifiedPushArchive.forTestClass(TestNotificationRouter.class)
                 .withMessaging()
                     .addClasses(NotificationRouter.class, PushNotificationSender.class)
                     .addClasses(PushMessageMetricsService.class)

--- a/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/message/configuration/TestSenderConfigurationProducer.java
+++ b/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/message/configuration/TestSenderConfigurationProducer.java
@@ -28,7 +28,6 @@ import org.jboss.aerogear.unifiedpush.message.sender.SenderTypeLiteral;
 import org.jboss.aerogear.unifiedpush.test.archive.UnifiedPushArchive;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -38,8 +37,7 @@ public class TestSenderConfigurationProducer {
 
     @Deployment
     public static WebArchive archive() {
-        return ShrinkWrap
-                .create(UnifiedPushArchive.class)
+        return UnifiedPushArchive.forTestClass(TestSenderConfigurationProducer.class)
                     .withApi()
                     .withUtils()
                     .addPackage(SenderConfiguration.class.getPackage())

--- a/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/message/jms/TestMessageHolderWithTokens.java
+++ b/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/message/jms/TestMessageHolderWithTokens.java
@@ -34,7 +34,6 @@ import org.jboss.aerogear.unifiedpush.message.holder.MessageHolderWithTokens;
 import org.jboss.aerogear.unifiedpush.test.archive.UnifiedPushArchive;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Before;
 import org.junit.Test;
@@ -47,8 +46,7 @@ public class TestMessageHolderWithTokens {
     @Deployment
     public static WebArchive archive() {
 
-        return ShrinkWrap
-                .create(UnifiedPushArchive.class)
+        return UnifiedPushArchive.forTestClass(TestMessageHolderWithTokens.class)
                 .withMessaging()
                     .addClasses(MessageHolderWithTokensConsumer.class, MessageHolderWithTokensProducer.class, AbstractJMSMessageListener.class)
                     .addAsWebInfResource("jboss-ejb3-message-holder-with-tokens.xml", "jboss-ejb3.xml")

--- a/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/message/jms/TestMessageRedelivery.java
+++ b/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/message/jms/TestMessageRedelivery.java
@@ -40,7 +40,6 @@ import org.jboss.aerogear.unifiedpush.message.holder.MessageHolderWithTokens;
 import org.jboss.aerogear.unifiedpush.test.archive.UnifiedPushArchive;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Before;
 import org.junit.Test;
@@ -55,8 +54,7 @@ public class TestMessageRedelivery {
 
     @Deployment
     public static WebArchive archive() {
-        return ShrinkWrap
-                .create(UnifiedPushArchive.class)
+        return UnifiedPushArchive.forTestClass(TestMessageRedelivery.class)
                 .withMessaging()
                     .addClasses(MessageHolderWithTokensProducer.class, MessageHolderWithTokensConsumer.class, AbstractJMSMessageListener.class)
                     .addAsWebInfResource("jboss-ejb3-message-holder-with-tokens.xml", "jboss-ejb3.xml")

--- a/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/test/archive/UnifiedPushArchive.java
+++ b/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/test/archive/UnifiedPushArchive.java
@@ -17,18 +17,28 @@
 package org.jboss.aerogear.unifiedpush.test.archive;
 
 import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.container.LibraryContainer;
 import org.jboss.shrinkwrap.api.container.ResourceContainer;
 import org.jboss.shrinkwrap.api.container.ServiceProviderContainer;
 import org.jboss.shrinkwrap.api.container.WebContainer;
+import org.jboss.shrinkwrap.impl.base.container.WebContainerBase;
 
 /**
  * An archive for specifying Arquillian micro-deployments with selected parts of UPS
  */
-public interface UnifiedPushArchive extends Archive<UnifiedPushArchive>, LibraryContainer<UnifiedPushArchive>,
+public abstract class UnifiedPushArchive extends WebContainerBase<UnifiedPushArchive> implements Archive<UnifiedPushArchive>, LibraryContainer<UnifiedPushArchive>,
         WebContainer<UnifiedPushArchive>, ResourceContainer<UnifiedPushArchive>, ServiceProviderContainer<UnifiedPushArchive> {
 
-    UnifiedPushArchive addMavenDependencies(String... deps);
+    public UnifiedPushArchive(final Archive<?> delegate) {
+        super(UnifiedPushArchive.class, delegate);
+    }
+
+    public static UnifiedPushArchive forTestClass(Class<?> clazz) {
+        return ShrinkWrap.create(UnifiedPushArchive.class, String.format("%s.war", clazz.getSimpleName()));
+    }
+
+    public abstract UnifiedPushArchive addMavenDependencies(String... deps);
 
     public abstract UnifiedPushArchive withMockito();
 

--- a/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/test/archive/UnifiedPushArchiveBase.java
+++ b/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/test/archive/UnifiedPushArchiveBase.java
@@ -21,9 +21,8 @@ import java.util.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ArchivePath;
 import org.jboss.shrinkwrap.api.ArchivePaths;
-import org.jboss.shrinkwrap.impl.base.container.WebContainerBase;
 
-public abstract class UnifiedPushArchiveBase extends WebContainerBase<UnifiedPushArchive> implements UnifiedPushArchive {
+public abstract class UnifiedPushArchiveBase extends UnifiedPushArchive {
 
  // -------------------------------------------------------------------------------------||
     // Class Members ----------------------------------------------------------------------||
@@ -82,7 +81,7 @@ public abstract class UnifiedPushArchiveBase extends WebContainerBase<UnifiedPus
      *            The storage backing.
      */
     public UnifiedPushArchiveBase(final Archive<?> delegate) {
-        super(UnifiedPushArchive.class, delegate);
+        super(delegate);
     }
 
     // -------------------------------------------------------------------------------------||

--- a/push/sender/src/test/resources/arquillian.xml
+++ b/push/sender/src/test/resources/arquillian.xml
@@ -27,8 +27,18 @@
 
     <container qualifier="chameleon" default="true">
         <configuration>
+            <!-- reconfigure to alternative servers (WildFly, JBoss AS, JBoss EAP) or modes (Managed, Remote, Embedded) using arquillian-container-chameleon -->>
+            <!-- (if running against different containers, be sure to check the port offset settings bellow) -->
             <property name="target">wildfly:8.0.0.Final:managed</property>
+            
+            <!-- use Full EE profile for a JMS support -->
             <property name="serverConfig">standalone-full.xml</property>
+
+            <!-- configure port offset for ports bound by application server so that they don't conflict with an another instance running parallely -->
+            <!-- both http and management ports are offset  -->
+            <property name="javaVmArguments">-Djboss.socket.binding.port-offset=4321</property>
+            <!--  tell Arquillian where he will find the running container -->
+            <property name="managementPort">14311</property>
         </configuration>
     </container>
 </arquillian>


### PR DESCRIPTION
https://issues.jboss.org/browse/AGPUSH-1434
https://issues.jboss.org/browse/AGPUSH-1433

How to test?

* run the tests when you are already having a WildFly instance running (the ports should not conflict due to port offset set in tests)
* watch the console and once Push Sender tests will be running, WildFly starts and then `TestClass.war` pattern deployments are being deployed (instead of `UUID.war`)