### PR TITLE
Global enabling of direct access grant

### DIFF
--- a/servers/auth-server/src/main/webapp/WEB-INF/ups-realm.json
+++ b/servers/auth-server/src/main/webapp/WEB-INF/ups-realm.json
@@ -6,6 +6,7 @@
     "accessCodeLifespanUserAction": 300,
     "ssoSessionIdleTimeout": 600,
     "ssoSessionMaxLifespan": 36000,
+    "passwordCredentialGrantAllowed": true,
     "sslRequired": "external",
     "registrationAllowed": false,
     "social": false,


### PR DESCRIPTION
Done for AGPUSH-1149

W/ KC 1.3.0 this will be the default (see http://lists.jboss.org/pipermail/keycloak-dev/2015-June/004587.html), and it does not hurt doing this now. Actually adds more options for full integration of UPS into other systems