### PR TITLE
change default Nothing Selected to All Variants on Send Notification dialog AGPUSH-1449

### DIFF
--- a/admin-ui/app/dialogs/send-push-notification.html
+++ b/admin-ui/app/dialogs/send-push-notification.html
@@ -19,7 +19,7 @@
     <div class="form-group">
       <label class="col-sm-3 control-label" for="textInput-modal-markup">Variants</label>
       <div class="col-sm-9">
-        <select pf-select multiple ng-model="selectedVariants" ng-options="variant.variantID as variant.name for variant in app.variants"></select>
+        <select pf-select="{ noneSelectedText: 'All Variants' }" multiple ng-model="selectedVariants" ng-options="variant.variantID as variant.name for variant in app.variants"></select>
       </div>
     </div>
 

--- a/admin-ui/bower.json
+++ b/admin-ui/bower.json
@@ -12,7 +12,7 @@
     "bootstrap-select": "1.6.5",
     "es5-shim": "2.0.12",
     "patternfly": "1.3.0",
-    "angular-patternfly": "0.0.5",
+    "angular-patternfly": "0.0.6",
     "font-awesome": "4.1.0",
     "ng-idle": "1.0.4",
     "google-code-prettify": "1.0.4",


### PR DESCRIPTION
http://issues.jboss.org/browse/AGPUSH-1449

The Send Push Notification dialog should say "All Variants" by default and when checked some variants and then uncheck them, it should still say "All Variants".