### PR TITLE
Improve sq lqueries

### DIFF
--- a/model/jpa/src/main/java/org/jboss/aerogear/unifiedpush/jpa/dao/impl/JPAPushMessageInformationDao.java
+++ b/model/jpa/src/main/java/org/jboss/aerogear/unifiedpush/jpa/dao/impl/JPAPushMessageInformationDao.java
@@ -127,15 +127,13 @@ public class JPAPushMessageInformationDao extends JPABaseDao<PushMessageInformat
     @Override
     public List<String> findVariantIDsWithWarnings() {
         return createQuery("select distinct vmi.variantID from VariantMetricInformation vmi" +
-                " where vmi.variantID IN (select t.variantID from Variant t)" +
-                " and vmi.deliveryStatus = false", String.class)
+                " where vmi.deliveryStatus = false", String.class)
                 .getResultList();
     }
 
     @Override
     public List<PushMessageInformation> findLatestActivity(int maxResults) {
-        return createQuery("select pmi from PushMessageInformation pmi where pmi.pushApplicationId" +
-                " IN (select p.pushApplicationID from PushApplication p)" +
+        return createQuery("select pmi from PushMessageInformation pmi" +
                 " ORDER BY pmi.submitDate " + DESC)
                 .setMaxResults(maxResults)
                 .getResultList();
@@ -143,8 +141,7 @@ public class JPAPushMessageInformationDao extends JPABaseDao<PushMessageInformat
 
     @Override
     public long getNumberOfPushMessagesForApplications() {
-        return createQuery("select count(pmi) from PushMessageInformation pmi where pmi.pushApplicationId " +
-                "IN (select p.pushApplicationID from PushApplication p)", Long.class).getSingleResult();
+        return createQuery("select count(pmi) from PushMessageInformation pmi", Long.class).getSingleResult();
     }
 
     /**

--- a/model/jpa/src/test/java/org/jboss/aerogear/unifiedpush/jpa/PushMessageInformationDaoTest.java
+++ b/model/jpa/src/test/java/org/jboss/aerogear/unifiedpush/jpa/PushMessageInformationDaoTest.java
@@ -175,6 +175,9 @@ public class PushMessageInformationDaoTest {
 
         number = pushMessageInformationDao.getNumberOfPushMessagesForLoginName(loginName);
         assertThat(number).isEqualTo(203);
+
+        // check for all
+        assertThat(pushMessageInformationDao.getNumberOfPushMessagesForApplications()).isEqualTo(203);
     }
 
     @Test
@@ -202,6 +205,8 @@ public class PushMessageInformationDaoTest {
         List<PushMessageInformation> lastActivity = pushMessageInformationDao.findLatestActivity("admin", 3);
         assertThat(lastActivity).hasSize(2);
 
+        lastActivity = pushMessageInformationDao.findLatestActivity(3);
+        assertThat(lastActivity).hasSize(2);
     }
 
     @Test
@@ -209,8 +214,8 @@ public class PushMessageInformationDaoTest {
         // all warnings:
         final List<String> variantIDsWithWarnings = pushMessageInformationDao.findVariantIDsWithWarnings();
 
-        assertThat(variantIDsWithWarnings).hasSize(3);
-        assertThat(variantIDsWithWarnings).contains("231543432432", "23154343243333", "231543432434");
+        assertThat(variantIDsWithWarnings).hasSize(4);
+        assertThat(variantIDsWithWarnings).contains("213", "231543432432", "23154343243333", "231543432434");
     }
 
     @Test


### PR DESCRIPTION
Done for: [AGPUSH-1455](https://issues.jboss.org/browse/AGPUSH-1455)

The admin related queries do not need the IN(), since that is just doing all :-) 

But using the IN() slows down the query 