### PR TITLE
Removing verbose and meaning less Android/GCM errors from the log

### DIFF
--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/GCMPushNotificationSender.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/GCMPushNotificationSender.java
@@ -112,7 +112,7 @@ public class GCMPushNotificationSender implements PushNotificationSender {
 
         } catch (Exception e) {
             // GCM exceptions:
-            logger.severe("Error sending payload to GCM server", e);
+            logger.severe("Error sending payload to GCM server");
             callback.onError("Error sending payload to GCM server");
         }
     }


### PR DESCRIPTION
If things go wrong for GCM - the underlying lib from google goes nuts, like:

```
Error sending payload to GCM server: java.lang.IllegalArgumentException: argument cannot be null
	at com.google.android.gcm.server.Sender.nonNull(Sender.java:553) [gcm-server-1.0.2.jar:]
	at com.google.android.gcm.server.Sender.getString(Sender.java:534) [gcm-server-1.0.2.jar:]
	at com.google.android.gcm.server.Sender.sendNoRetry(Sender.java:365) [gcm-server-1.0.2.jar:]
	at com.google.android.gcm.server.Sender.send(Sender.java:261) [gcm-server-1.0.2.jar:]
```

yes - does not really tell anything - since we log and capture the failure, I'd like to remove the verbosity on the log