### PR TITLE
making 'developer' default role for new users

### DIFF
--- a/servers/auth-server/src/main/webapp/WEB-INF/ups-realm.json
+++ b/servers/auth-server/src/main/webapp/WEB-INF/ups-realm.json
@@ -14,6 +14,7 @@
     "loginTheme": "aerogear",
     "updateProfileOnInitialSocialLogin": false,
     "requiredCredentials": [ "password" ],
+    "defaultRoles": [ "developer" ],
     "users" : [
         {
             "username" : "admin",


### PR DESCRIPTION
For convenience, when creating new users, the default role should be our developer role!