### PR TITLE
AGPUSH-1425 - Use NPM for UPS Admin UI sharing

### DIFF
--- a/admin-ui/Gruntfile.js
+++ b/admin-ui/Gruntfile.js
@@ -350,6 +350,39 @@ module.exports = function (grunt) {
           targetDir: 'app/bower-components/'
         }
       }
+    },
+    compress: {
+      main: {
+        options: {
+          archive: 'dist/npm-ups-admin-ui.tgz',
+          mode: 'tgz'
+        },
+        files: [{
+          src: ['.tmp/concat/scripts/modules.js'],
+          dest: 'ups-admin-ui/js',
+          filter: 'isFile',
+          flatten: true,
+          expand: true
+        }, {
+          src: ['.tmp/concat/scripts/scripts.js'],
+          dest: 'ups-admin-ui/js',
+          filter: 'isFile',
+          flatten: true,
+          expand: true
+        }, {
+          src: ['.tmp/ngtemplates/templates.js'],
+          dest: 'ups-admin-ui/js',
+          filter: 'isFile',
+          flatten: true,
+          expand: true
+        }, {
+          src: ['package.json'],
+          dest: 'ups-admin-ui/',
+          filter: 'isFile',
+          flatten: true,
+          expand: true
+        }]
+      }
     }
   });
 
@@ -392,7 +425,8 @@ module.exports = function (grunt) {
     'copy:dist',
     'filerev',
     'copy:nofilerev',
-    'usemin'
+    'usemin',
+    'compress'
   ]);
 
   grunt.registerTask('default', [


### PR DESCRIPTION
Updates to `Gruntfile` to add a compress task - tar's up the script/modules/templates we need in our fh-ngui integration, ready for publishing to npm with `npm publish dist/npm-ups-admin-ui.tgz`