### PR TITLE
Enabling setting the finalName of the dist build with a property

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -26,6 +26,9 @@
     <artifactId>unifiedpush-dist</artifactId>
     <name>UnifiedPush Server Distribution Package</name>
     <packaging>pom</packaging>
+    <properties>
+        <finalName>aerogear-unifiedpush-server-${project.version}</finalName>
+    </properties>
 
     <build>
         <plugins>
@@ -142,7 +145,7 @@
                             <descriptors>
                                 <descriptor>src/main/assembly/assembly.xml</descriptor>
                             </descriptors>
-                            <finalName>aerogear-unifiedpush-server-${project.version}</finalName>
+                            <finalName>${finalName}</finalName>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
This lets us name the zip from dist from the command line.

To test :
 * mvn clean install
 * cd dist
 * mvn clean install -DfinalName=unifiedpush
 * check that there is a unifiedpush-dist.zip & tgz file in target 