### PR TITLE
AGPUSH-1512: workaround: recount receivers in UPS Console

### DIFF
--- a/admin-ui/app/scripts/endpoints/metricsEndpoint.js
+++ b/admin-ui/app/scripts/endpoints/metricsEndpoint.js
@@ -17,9 +17,16 @@ upsServices.factory('metricsEndpoint', function ($resource, $q) {
       var deferred = $q.defer();
       this.application({id: applicationId, page: pageNo - 1, per_page: perPage, sort:'desc', search: searchString}, function (data, responseHeaders) {
         angular.forEach(data, function (metric) {
-          angular.forEach(metric.variantInformations, function (variant) {
-            if (!variant.deliveryStatus) {
+          metric.totalVariants = metric.variantInformations.length;
+          metric.servedVariants = 0;
+          metric.totalReceivers = 0;
+          angular.forEach(metric.variantInformations, function (variantMetric) {
+            metric.totalReceivers += variantMetric.receivers;
+            if (!variantMetric.deliveryStatus) {
               metric.deliveryFailed = true;
+            }
+            if (variantMetric.servedBatches === variantMetric.totalBatches) {
+              metric.servedVariants += 1;
             }
           });
         });


### PR DESCRIPTION
@sebastienblanc could you please test this?

This is workaround that should do a math of serverVariants/totalVariants/receivers on client.

https://issues.jboss.org/browse/AGPUSH-1512