### PR TITLE
AGPUSH-1513: (workaround) recount receivers in UPS Console

### DIFF
--- a/admin-ui/app/components/app-detail/include/activity.js
+++ b/admin-ui/app/components/app-detail/include/activity.js
@@ -1,5 +1,5 @@
 angular.module('upsConsole')
-  .controller('ActivityController', function ( $log, $interval, $modal, variantModal, $scope, metricsEndpoint ) {
+  .controller('ActivityController', function ( $log, $timeout, $interval, $modal, variantModal, $scope, metricsEndpoint ) {
 
     var self = this;
 
@@ -68,7 +68,10 @@ angular.module('upsConsole')
     // initial load
     refreshUntilAllServed();
 
-    $scope.$on('upsNotificationSent', refreshUntilAllServed);
+    $scope.$on('upsNotificationSent', function() {
+      $timeout(refreshUntilAllServed, 500); // artificial delay - refresh after 0.5sec to ensure server has time to load some batches; prevents situation when totalBatches = 0 for all variants
+      $timeout(refreshUntilAllServed, 3000); // refresh again to be double-sure ;-) note: should be addressed as part of https://issues.jboss.org/browse/AGPUSH-1513
+    });
     $scope.$on('$destroy', function () {
       if (refreshInterval) {
         $interval.cancel(refreshInterval);

--- a/admin-ui/app/scripts/endpoints/metricsEndpoint.js
+++ b/admin-ui/app/scripts/endpoints/metricsEndpoint.js
@@ -17,9 +17,16 @@ upsServices.factory('metricsEndpoint', function ($resource, $q) {
       var deferred = $q.defer();
       this.application({id: applicationId, page: pageNo - 1, per_page: perPage, sort:'desc', search: searchString}, function (data, responseHeaders) {
         angular.forEach(data, function (metric) {
-          angular.forEach(metric.variantInformations, function (variant) {
-            if (!variant.deliveryStatus) {
+          metric.totalVariants = metric.variantInformations.length;
+          metric.servedVariants = 0;
+          metric.totalReceivers = 0;
+          angular.forEach(metric.variantInformations, function (variantMetric) {
+            metric.totalReceivers += variantMetric.receivers;
+            if (!variantMetric.deliveryStatus) {
               metric.deliveryFailed = true;
+            }
+            if (variantMetric.servedBatches === variantMetric.totalBatches) {
+              metric.servedVariants += 1;
             }
           });
         });


### PR DESCRIPTION
@sebastienblanc could you please test this?

This is workaround that should do a math of serverVariants/totalVariants/receivers on client.

https://issues.jboss.org/browse/AGPUSH-1513