### PR TITLE
Update frontend-plugin to 0.0.26

### DIFF
--- a/admin-ui/pom.xml
+++ b/admin-ui/pom.xml
@@ -43,7 +43,7 @@
             <plugin>
                 <groupId>com.github.eirslett</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
-                <version>0.0.16</version>
+                <version>0.0.26</version>
 
                 <configuration>
                     <workingDirectory>./</workingDirectory>


### PR DESCRIPTION
This PR fixes the following error: https://gist.github.com/abstractj/8c0f20e958c1db3c241d

To reproduce the issue against master run:

```
mvn clean install
```

@matzew @lfryc could you please take a look? Seems like a known issue: https://github.com/eirslett/frontend-maven-plugin/issues/179