### PR TITLE
Improve Developer experience

### DIFF
--- a/model/jpa/pom.xml
+++ b/model/jpa/pom.xml
@@ -27,7 +27,7 @@
     <name>UnifiedPush Server Model JPA implementation</name>
 
     <dependencies>
-		
+        
         <dependency>
             <groupId>org.jboss.aerogear.unifiedpush</groupId>
             <artifactId>unifiedpush-model-api</artifactId>
@@ -53,7 +53,16 @@
         </dependency>
 
     </dependencies>
-    
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+    </build>
+
     <profiles>
         <profile>
             <id>test</id>

--- a/model/jpa/src/main/resources/META-INF/persistence.xml
+++ b/model/jpa/src/main/resources/META-INF/persistence.xml
@@ -26,7 +26,7 @@
 
     <properties>
       <property name="hibernate.dialect_resolvers" value="org.jboss.aerogear.unifiedpush.jpa.MysqlDialectResolver"/>
-      <property name="hibernate.hbm2ddl.auto" value="validate"/>
+      <property name="hibernate.hbm2ddl.auto" value="${ups.ddl_value}"/>
       <property name="hibernate.show_sql" value="false"/>
       <property name="hibernate.format_sql" value="true"/>
       <property name="hibernate.transaction.flush_before_completion" value="true"/>

--- a/pom.xml
+++ b/pom.xml
@@ -186,6 +186,7 @@
         <org.jacoco.jacoco-maven-plugin.version>0.6.3.201306030806</org.jacoco.jacoco-maven-plugin.version>
         <ant.contrib.version>20020829</ant.contrib.version>
         <aerogear.crypto.version>0.1.5</aerogear.crypto.version>
+        <ups.ddl_value>update</ups.ddl_value>
     </properties>
 
     <profiles>
@@ -222,6 +223,9 @@
 	                </plugin>
 	            </plugins>
 	        </build>
+            <properties>
+                <ups.ddl_value>validate</ups.ddl_value>
+            </properties>
 		</profile>
 
         <!--
@@ -238,6 +242,9 @@
             <modules>
                 <module>dist</module>
             </modules>
+            <properties>
+                <ups.ddl_value>validate</ups.ddl_value>
+            </properties>
         </profile>
 
         <!--


### PR DESCRIPTION
Adding persistence.xml properties for different DDL values, based on needs. For development (default) the `persistence.xml` will use `update` and for production the file will contain `validate`.

With this change it is no longer needed to run the migrator when deploying the latest from master.

However, for our production profiles (`openshift` and `dist`) the `validate` value will be injected, since in this environment we do need to make sure we have proper migration tool execution