### PR TITLE
If the raw JSON is too long, use a minimized version

### DIFF
--- a/push/model/src/main/java/org/jboss/aerogear/unifiedpush/message/UnifiedPushMessage.java
+++ b/push/model/src/main/java/org/jboss/aerogear/unifiedpush/message/UnifiedPushMessage.java
@@ -112,6 +112,14 @@ public class UnifiedPushMessage implements Serializable {
         this.message = message;
     }
 
+    /**
+     * Returns a JSON representation of the payload. This does not include any pushed data,
+     * just the alert of the message. This also contains the entire criteria object.
+     *
+     * @see #toMinimizedJsonString()
+     *
+     * @return JSON payload
+     */
     public String toStrippedJsonString() {
         try {
             final HashMap<String, Object> json = new LinkedHashMap<String, Object>();
@@ -126,6 +134,35 @@ public class UnifiedPushMessage implements Serializable {
         }
     }
 
+    /**
+     * Returns a minimized JSON representation of the payload. This does not include potentially large objects, like
+     * alias or category from the given criteria.
+     *
+     * @see #toStrippedJsonString()
+     *
+     * @return minizmized JSON payload
+     */
+    public String toMinimizedJsonString() {
+        try {
+            final HashMap<String, Object> json = new LinkedHashMap<String, Object>();
+            json.put("alert", this.message.getAlert());
+            json.put("config", this.config);
+
+            // we strip down the criteria too, as alias/category can be quite long, based on use-case
+            final HashMap<String, Object> shrinkedCriteriaJSON = new LinkedHashMap<String, Object>();
+            shrinkedCriteriaJSON.put("variants", this.criteria.getVariants());
+            shrinkedCriteriaJSON.put("deviceType", this.criteria.getDeviceTypes());
+            json.put("criteria", shrinkedCriteriaJSON);
+
+            return OBJECT_MAPPER.writeValueAsString(json);
+        } catch (JsonProcessingException e) {
+            return "[\"invalid json\"]";
+        } catch (IOException e) {
+            return "[\"invalid json\"]";
+        }
+    }
+
+    // used in java-sender
     public String toJsonString() {
         try {
             return OBJECT_MAPPER.writeValueAsString(this);

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/NotificationRouter.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/NotificationRouter.java
@@ -73,7 +73,7 @@ public class NotificationRouter {
      */
     @TransactionAttribute(TransactionAttributeType.REQUIRED)
     public void submit(PushApplication pushApplication, InternalUnifiedPushMessage message) {
-        logger.info("Processing send request with '" + message.toString() + "' payload");
+        logger.info("Processing send request with '" + message.getMessage().toString() + "' payload");
 
         // collections for all the different variants:
         final VariantMap variants = new VariantMap();
@@ -98,10 +98,17 @@ public class NotificationRouter {
             variants.addAll(pushApplication.getVariants());
         }
 
+        // TODO: Not sure the transformation should be done here...
+        // There are likely better places to check if the metadata is way to long
+        String jsonMessageContent = message.toStrippedJsonString() ;
+        if (jsonMessageContent != null && jsonMessageContent.length() >= 4500) {
+            jsonMessageContent = message.toMinimizedJsonString();
+        }
+
         final PushMessageInformation pushMessageInformation =
                 metricsService.storeNewRequestFrom(
                         pushApplication.getPushApplicationID(),
-                        message.toStrippedJsonString(),
+                        jsonMessageContent,
                         message.getIpAddress(),
                         message.getClientIdentifier(),
                         variants.getVariantCount()


### PR DESCRIPTION
For [AGPUSH-1543](https://issues.jboss.org/browse/AGPUSH-1543) I've added a quick fix to not try to save too long push notification metadata in the database.