### PR TITLE
re-render Sender examples after master secret renewal AGPUSH-1504

### DIFF
--- a/admin-ui/app/scripts/directives.js
+++ b/admin-ui/app/scripts/directives.js
@@ -223,6 +223,8 @@ angular.module('upsConsole')
 
   .directive('upsSenderSnippets', function () {
     return {
+      restrict: 'E',
+      templateUrl: 'directives/ups-sender-snippets.html',
       scope: {
         app: '=',
         activeSnippet: '@'
@@ -232,15 +234,18 @@ angular.module('upsConsole')
         $scope.clipText = $sce.trustAsHtml('Copy to clipboard');
         $scope.contextPath = ContextProvider.contextPath();
         $scope.snippets = senderSnippets;
-        angular.forEach($scope.snippets, function(data, senderType) {
-          if (data.show) {
-            $scope.activeSnippet = $scope.activeSnippet || senderType;
-            SnippetRetriever.get(data.url)
-              .then(function (response) {
-                $scope.snippets[senderType].source = $interpolate(response.data)($scope);
-              });
-          }
-        });
+        function renderSnippets() {
+          angular.forEach($scope.snippets, function(data, senderType) {
+            if (data.show) {
+              $scope.activeSnippet = $scope.activeSnippet || senderType;
+              SnippetRetriever.get(data.url)
+                .then(function (response) {
+                  $scope.snippets[senderType].source = $interpolate(response.data)($scope);
+                });
+            }
+          });
+        }
+        renderSnippets();
         $scope.copySnippet = function() {
           return $scope.snippets[$scope.activeSnippet].source;
         };
@@ -250,9 +255,10 @@ angular.module('upsConsole')
             $scope.clipText = 'Copy to clipboard';
           }, 1000);
         };
-      },
-      restrict: 'E',
-      templateUrl: 'directives/ups-sender-snippets.html'
+        $scope.$watch('app.masterSecret', function() {
+          renderSnippets();
+        });
+      }
     };
   })
 


### PR DESCRIPTION
https://issues.jboss.org/browse/AGPUSH-1504

How to test this?

* Renew master secret on Sender API tab
* check that masterSecret was updated in the sender examples bellow