### PR TITLE
Update UPS to Keycloak 1.7.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.jboss.aerogear</groupId>
         <artifactId>aerogear-parent</artifactId>
         <!-- NOTE: if updated for version of UPS dependencies, please update the 'aerogear.bom.version' as well -->
-        <version>0.2.18</version>
+        <version>0.2.18-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jboss.aerogear.unifiedpush</groupId>
@@ -175,7 +175,7 @@
         <jboss-as-maven-plugin.version>7.5.Final</jboss-as-maven-plugin.version>
         <wildfly-maven-plugin.version>1.0.2.Final</wildfly-maven-plugin.version>
 
-        <aerogear.bom.version>0.2.18</aerogear.bom.version>
+        <aerogear.bom.version>0.2.18-SNAPSHOT</aerogear.bom.version>
 
         <!-- Override versions of AeroGear BOMs-->
         <junit.version>4.11</junit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <groupId>org.jboss.aerogear</groupId>
         <artifactId>aerogear-parent</artifactId>
         <!-- NOTE: if updated for version of UPS dependencies, please update the 'aerogear.bom.version' as well -->
-        <version>0.2.18-SNAPSHOT</version>
+        <version>0.2.19-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jboss.aerogear.unifiedpush</groupId>
@@ -175,7 +175,7 @@
         <jboss-as-maven-plugin.version>7.5.Final</jboss-as-maven-plugin.version>
         <wildfly-maven-plugin.version>1.0.2.Final</wildfly-maven-plugin.version>
 
-        <aerogear.bom.version>0.2.18-SNAPSHOT</aerogear.bom.version>
+        <aerogear.bom.version>0.2.19-SNAPSHOT</aerogear.bom.version>
 
         <!-- Override versions of AeroGear BOMs-->
         <junit.version>4.11</junit.version>

--- a/servers/auth-server/pom.xml
+++ b/servers/auth-server/pom.xml
@@ -60,6 +60,14 @@
             <artifactId>keycloak-model-jpa</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-connections-infinispan</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-model-sessions-infinispan</artifactId>
         </dependency>

--- a/servers/auth-server/src/main/java/org/jboss/aerogear/unifiedpush/keycloak/UpsKeycloakApplication.java
+++ b/servers/auth-server/src/main/java/org/jboss/aerogear/unifiedpush/keycloak/UpsKeycloakApplication.java
@@ -36,8 +36,8 @@ public class UpsKeycloakApplication extends KeycloakApplication {
     }
 
     @Override
-    protected void setupDefaultRealm(String contextPath) {
-        super.setupDefaultRealm(contextPath);
+    public   void importRealmResources(ServletContext contextPath) {
+        super.importRealmResources(contextPath);
 
         KeycloakSession session = sessionFactory.create();
         session.getTransaction().begin();

--- a/servers/auth-server/src/main/resources/META-INF/keycloak-server.json
+++ b/servers/auth-server/src/main/resources/META-INF/keycloak-server.json
@@ -22,6 +22,10 @@
         "provider": "basic"
     },
 
+    "userSessionPersister": {
+        "provider": "jpa"
+    },
+    
     "theme": {
         "default": "keycloak",
         "welcomeTheme": "aerogear",


### PR DESCRIPTION
See: https://issues.jboss.org/browse/AGPUSH-1528

Requirements:

- Merge https://github.com/aerogear/aerogear-parent/pull/54 first or just clone and run maven install

Some of dependencies like Keycloak connections for Infinispan, are not mandatory, but I decided to include in case of us wanting some clustering features.