### PR TITLE
activity screen - do not show blank slate when search is active AGPUSH-1500

### DIFF
--- a/admin-ui/app/components/app-detail/include/activity.html
+++ b/admin-ui/app/components/app-detail/include/activity.html
@@ -1,4 +1,4 @@
-<div ng-if="activity.totalCount > 0">
+<div ng-if="activity.totalCount > 0 || activity.isSearchActive()">
   <h3>Notification activity</h3>
 
   <p>Explore push messages that you have sent to the registered devices.</p>
@@ -29,6 +29,11 @@
     </tr>
     </thead>
     <tbody>
+    <tr class="odd" ng-if="activity.totalCount === 0">
+      <td valign="top" align="center" colspan="8" class="dataTables_empty">
+        <p>No message matches the given search criteria.</p>
+      </td>
+    </tr>
     <tr ng-repeat-start="metric in activity.metrics">
       <td>
         <a href ng-click="metric.$toggled = !metric.$toggled">
@@ -93,7 +98,7 @@
   </div>
 </div><!-- ng-if -->
 
-<div class="blank-slate-pf" ng-if="activity.totalCount == 0">
+<div class="blank-slate-pf" ng-if="activity.totalCount == 0 && !activity.isSearchActive()">
   <div class="blank-slate-pf-icon">
     <i class="fa fa-table"></i>
   </div>
@@ -103,12 +108,7 @@
 
   <div ng-if="appDetail.app.$deviceCount == 0">
     <p>There are no registered device for this application.</p>
-    <div class="blank-slate-pf-main-action">
-      <a href class="btn btn-primary btn-lg" ng-link="appDetail({app: appDetail.app.pushApplicationID, tab: 'variants'})" ng-disabled="!appDetail.app.variants.length">
-        <i class="fa fa-paper-plane"></i>
-        Register a device
-      </a>
-    </div>
+    <p>Check out the documentation on how to get started to <a ups-doc="docs-push-getting-started">register a device</a>.</p>
   </div>
 
   <div ng-if="appDetail.app.$deviceCount != 0">

--- a/admin-ui/app/components/app-detail/include/activity.js
+++ b/admin-ui/app/components/app-detail/include/activity.js
@@ -11,12 +11,17 @@ angular.module('upsConsole')
     this.currentEnd = 0;
     this.perPage = 10;
     this.searchString = '';
+    this.activeSearch = '';
 
     var refreshInterval;
 
+    /**
+     * Fetches new data, reflecting provided page and searchString
+     */
     function fetchMetrics( page, searchString ) {
       return metricsEndpoint.fetchApplicationMetrics(self.app.pushApplicationID, searchString, page, self.perPage)
         .then(function( data ) {
+          self.activeSearch = searchString;
           self.metrics.forEach(function( originalMetric ) {
             data.pushMetrics.some(function ( newMetric ) {
               if (originalMetric.id === newMetric.id && originalMetric.$toggled) {
@@ -43,6 +48,18 @@ angular.module('upsConsole')
         });
     }
 
+    /**
+     * Determines whether search is active - either the user typed search string or the data doesn't reflect the search string yet.
+     *
+     * @return false if searchString if false and data reflects that searchString; true otherwise
+     */
+    this.isSearchActive = function() {
+      return self.searchString || self.activeSearch;
+    };
+
+    /**
+     * Fetches new data on page change
+     */
     this.onPageChange = function ( page ) {
       fetchMetrics( page, self.searchString );
     };

--- a/admin-ui/app/components/app-detail/include/analytics.html
+++ b/admin-ui/app/components/app-detail/include/analytics.html
@@ -94,7 +94,7 @@
 
   <div ng-if="appDetail.app.$deviceCount == 0">
     <p>There are no registered device for this application.</p>
-    Check out the documentation on how to get started to <a ups-doc="docs-push-getting-started">register a device</a>.
+    <p>Check out the documentation on how to get started to <a ups-doc="docs-push-getting-started">register a device</a>.</p>
   </div>
 
   <div ng-if="appDetail.app.$deviceCount != 0">


### PR DESCRIPTION
https://issues.jboss.org/browse/AGPUSH-1500

I've introduced a helper `isSearchActive()` that is now a condition for showing blank slate.

Besides that I've fixed the Register Device button also on Activity page (was fixed before on Analytics: https://github.com/aerogear/aerogear-unifiedpush-server/blob/1.1.x-dev/admin-ui/app/components/app-detail/include/analytics.html#L97 )

:dart: `master` and `1.1.x-dev`
:ship: deployed at https://upsstaging-aerogearz.rhcloud.com/ag-push/ (standard credentials)
:hammer: Testing:

- try Activity tab with no devices registered (blank slate should be shown)
- try Activity  tab with one device registered (blank slate should be shown)
- try Activity tab with a message sent (the activity log table should appear)
- try Activity tab with a message sent, but use search with a non-existent value (activity log table should be visible, but a message "No message matches the given search criteria." will appear - then try to clear search string and a message should appear again) 