### PR TITLE
Keycloak & UPS decoupling

### DIFF
--- a/admin-ui/app/index.html
+++ b/admin-ui/app/index.html
@@ -154,9 +154,10 @@
 <script src="bower_components/google-code-prettify/bin/prettify.min.js"></script>
 <script src="bower_components/zeroclipboard/dist/ZeroClipboard.min.js"></script>
 <script src="bower_components/ng-clip/src/ngClip.js"></script>
+<script src="bower_components/keycloak/dist/keycloak.min.js"></script>
+
 <!-- endbuild -->
 
-<script src="/auth/js/keycloak.js"></script>
 
 <!-- build:js({.tmp,app}) scripts/scripts.js -->
 <script src="scripts/app.js"></script>

--- a/admin-ui/app/scripts/controllers/AppController.js
+++ b/admin-ui/app/scripts/controllers/AppController.js
@@ -38,7 +38,7 @@ angular.module('upsConsole')
     };
 
     this.goToAccountManagement = function() {
-      window.location = Auth.keycloak.authServerUrl + '/realms/aerogear/account?referrer=unified-push-server-js';
+      window.location = Auth.keycloak.authServerUrl + '/realms/' + Auth.keycloak.realm + '/account?referrer=unified-push-server-js';
     };
 
     this.havePendingRequests = function() {

--- a/admin-ui/app/scripts/keycloak-init.js
+++ b/admin-ui/app/scripts/keycloak-init.js
@@ -8,7 +8,7 @@
   var app = angular.module('upsConsole');
 
   angular.element(document).ready(function () {
-    var keycloak = new Keycloak('config/admin-ui-keycloak.json');
+    var keycloak = new Keycloak('rest/keycloak/config');
     auth.loggedIn = false;
 
     keycloak.init({ onLoad: 'login-required' }).success(function () {
@@ -17,7 +17,7 @@
       auth.logout = function() {
         auth.loggedIn = false;
         auth.keycloak = null;
-        window.location = keycloak.authServerUrl + '/realms/aerogear/tokens/logout?redirect_uri=' + window.location.href;
+        window.location = keycloak.authServerUrl + '/realms/' + keycloak.realm + '/tokens/logout?redirect_uri=' + window.location.href;
       };
       app.factory('Auth', function () {
         return auth;

--- a/admin-ui/bower.json
+++ b/admin-ui/bower.json
@@ -17,7 +17,8 @@
     "ng-idle": "1.0.4",
     "google-code-prettify": "1.0.4",
     "ng-clip": "0.2.6",
-    "angular-c3": "0.0.7"
+    "angular-c3": "0.0.7",
+    "keycloak": "1.7.0"
   },
   "devDependencies": {
     "angular-mocks": "1.4.0",

--- a/bin/keycloak-setup.sh
+++ b/bin/keycloak-setup.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+# Function for usage instructions
+function usage()
+{
+cat << EOF >&2
+
+Setup Keycloak for usage with UnifiedPush Server
+
+Before you begin:
+
+    Please make sure to have WILDFLY_HOME environment variable properly configured
+
+    Example: export WILDFLY_HOME=/path/to/your/keycloak/server/installation
+             export JBOSS_HOME=$WILDFLY_HOME (not mandatory)
+
+Usage:
+    $(basename $0) [options]
+
+Example:
+    $(basename $0) --ups-host=https://ups-host:8083 --realm-import=ups-realm-template.json
+
+Options:
+    -s, --ups-host          UnifiedPush HTTP server host
+    -i, --realm-import      Import Realm file
+    -o, --offset            Port offset from WildFly
+    -h, --help              Help
+EOF
+}
+
+# read the options
+TEMP=`getopt -o s:o:i: --long ups-host:,wildfly-offset:,realm-import: -n 'keycloak-setup.sh' -- "$@"`
+eval set -- "$TEMP"
+
+if [ $# -eq 1 ] ; then
+    usage;
+    exit 1
+fi
+
+# extract options and their arguments into variables.
+while true ; do
+    case "$1" in
+        -s|--ups-host)
+          case "$2" in
+            "") shift 2 ;;
+                *) UPS_HOST=$2 ; shift 2;;
+          esac ;;
+        -o|--wildfly-offset)
+          case "$2" in
+            "") shift 2 ;;
+                *) WILDFLY_OFFSET=$2 ; shift 2;;
+          esac ;;
+        -i|--realm-import)
+          case "$2" in
+            "") shift 2 ;;
+                *) REALM_JSON_FILE=$2 ; break;;
+          esac ;;
+
+      --) shift; break;;
+      *) "Internal error!"; echo $1 ; usage; exit 1 ;;
+
+    esac
+done
+
+if [[ ! -z "$UPS_HOST" && ! -z "$REALM_JSON_FILE" ]]; then
+
+    IFS=,
+    UPS_HOST_ARRAY=($UPS_HOST)
+    JSON_FILE_ARRAY=($REALM_JSON_FILE)
+
+    for key in "${!UPS_HOST_ARRAY[@]}"; do
+      sed -i "s|dummyhost|${UPS_HOST_ARRAY[$key]}|g" ${JSON_FILE_ARRAY[$key]}
+    done
+
+    IFS=
+
+    if [ ! "$WILDFLY_OFFSET" ]; then
+        $WILDFLY_HOME/bin/standalone.sh -Dkeycloak.import=$REALM_JSON_FILE
+    else
+        $WILDFLY_HOME/bin/standalone.sh -Djboss.socket.binding.port-offset=$WILDFLY_OFFSET -Dkeycloak.import=$REALM_JSON_FILE
+    fi
+else
+    usage;
+fi
+
+

--- a/bin/ups-realm-template.json
+++ b/bin/ups-realm-template.json
@@ -1,0 +1,89 @@
+
+{
+    "realm": "aerogear",
+    "enabled": true,
+    "accessTokenLifespan": 60,
+    "accessCodeLifespan": 60,
+    "accessCodeLifespanUserAction": 300,
+    "ssoSessionIdleTimeout": 600,
+    "ssoSessionMaxLifespan": 36000,
+    "sslRequired": "external",
+    "registrationAllowed": false,
+    "social": false,
+    "adminTheme": "aerogear",
+    "accountTheme": "aerogear",
+    "loginTheme": "aerogear",
+    "updateProfileOnInitialSocialLogin": false,
+    "requiredCredentials": [ "password" ],
+    "defaultRoles": [ "developer" ],
+    "users" : [
+        {
+            "username" : "admin",
+            "enabled": true,
+            "credentials" : [
+                { "type" : "password",
+                    "value" : "123" }
+            ],
+            "requiredActions": [
+                "UPDATE_PASSWORD"
+            ],
+            "realmRoles": [ "admin" ],
+            "applicationRoles": {
+               "realm-management": [ "realm-admin" ],
+               "account": [ "manage-account" ]
+            }
+        },
+        {
+            "username" : "developer",
+            "enabled": false,
+            "credentials" : [
+                { "type" : "password",
+                    "value" : "developer" }
+            ],
+            "requiredActions": [
+                "UPDATE_PASSWORD"
+            ],
+            "realmRoles": [ "developer" ],
+            "applicationRoles": {
+                "account": [ "manage-account" ]
+            }
+        }
+    ],
+    "roles" : {
+        "realm" : [
+            {
+                "name": "admin",
+                "description": "Administrator privileges"
+            },
+            {
+                "name": "developer",
+                "description": "Developer privileges"
+            }
+        ]
+    },
+    "scopeMappings": [
+        {
+            "client": "unified-push-server-js",
+            "roles": ["admin", "developer"]
+        }
+    ],
+    "clients": [
+        {
+            "clientId": "unified-push-server",
+            "enabled": true,
+            "bearerOnly": true
+        },
+        {
+            "clientId": "unified-push-server-js",
+            "enabled": true,
+            "publicClient": true,
+            "baseUrl": "dummyhost/ag-push",
+            "redirectUris": [
+                "dummyhost/ag-push/*"
+            ],
+            "webOrigins": [
+                "dummyhost"
+            ]
+        }
+    ]
+}

--- a/bin/ups-setup.sh
+++ b/bin/ups-setup.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+# Function for usage instructions
+function usage()
+{
+cat << EOF >&2
+
+Setup UnifiedPush Server for usage with Keycloak
+
+Before you begin:
+
+    Please make sure to have WILDFLY_HOME environment variable properly configured
+
+    Example: export WILDFLY_HOME=/path/to/your/wildfly/ups/server/installation
+             export JBOSS_HOME=$WILDFLY_HOME (not mandatory)
+
+Usage:
+    $(basename $0) [options]
+
+Example:
+    $(basename $0) --subsystem-setup
+
+    $(basename $0) --ups-host=localhost:9992 --realm=aerogear --auth-server=http://localhost:8083
+
+Options:
+    -s, --ups-host          UnifiedPush server controller host
+    -r, --realm             Realm name
+    -k, --auth-server       Keycloak server
+        --subsystem-setup   Keycloak subsystem setup
+    -h, --help              Help
+EOF
+}
+
+# Function for Keycloak subsystem setup (optional)
+function subsystem_setup()
+{
+    KEYCLOAK_WILDFLY_ADAPTER="keycloak-wildfly-adapter-dist-1.7.0.Final"
+    if [ ! "$WILDFLY_HOME" ]; then
+        printf "Error: Please configure the installation path for WildFly\n"
+        printf "   >>> Ex: WILDFLY_HOME=/path/to/your/wildfly-ups-installation\n"
+    else
+        cd $WILDFLY_HOME
+        curl -O "http://downloads.jboss.org/keycloak/1.7.0.Final/adapters/keycloak-oidc/$KEYCLOAK_WILDFLY_ADAPTER.zip"
+        unzip $KEYCLOAK_WILDFLY_ADAPTER
+    fi
+    exit 0
+}
+
+# read the options
+TEMP=`getopt -o s:r:k:h --long ups-host:,realm:,auth-server:,help,subsystem-setup -n 'ups-setup.sh' -- "$@"`
+eval set -- "$TEMP"
+
+if [ $# -eq 1 ] ; then
+    usage;
+    exit 1
+fi
+
+# extract options and their arguments into variables.
+while true ; do
+    case "$1" in
+        -s|--ups-host)
+          case "$2" in
+            "") shift 2 ;;
+                *) UPS_HOST=$2 ; shift 2 ;;
+          esac ;;
+
+        -r|--realm)
+          case "$2" in
+            "") shift 2 ;;
+                *) REALM_NAME=$2; shift 2 ;;
+          esac ;;
+
+        -k|--auth-server)
+          case "$2" in
+            "") shift 2 ;;
+                *) AUTH_SERVER=$2; shift 2 ;;
+          esac ;;
+
+        --subsystem-setup)
+          subsystem_setup; break;;
+
+        -h|--help)
+          usage; shift;;
+
+      --) shift ; break ;;
+      *) "Internal error!"; usage; exit 1 ;;
+    esac
+done
+
+if [[ ! -z "$UPS_HOST" && ! -z "$REALM_NAME" && ! -z $AUTH_SERVER ]]; then
+
+    $WILDFLY_HOME/bin/jboss-cli.sh -c --controller=$UPS_HOST --command="/system-property=ups.auth.server.url:add(value=$AUTH_SERVER/auth)";
+    $WILDFLY_HOME/bin/jboss-cli.sh -c --controller=$UPS_HOST --command="/system-property=ups.realm.name:add(value=$REALM_NAME)"
+
+else
+    usage;
+fi
+
+
+
+

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/config/KeycloakConfigurationEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/config/KeycloakConfigurationEndpoint.java
@@ -1,0 +1,72 @@
+package org.jboss.aerogear.unifiedpush.rest.config;
+
+import com.google.gson.Gson;
+import com.google.gson.annotations.SerializedName;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.util.logging.Logger;
+
+@Path("/keycloak/config")
+public class KeycloakConfigurationEndpoint {
+
+    private static final Logger LOGGER = Logger.getLogger(KeycloakConfigurationEndpoint.class.getSimpleName());
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response configurationFile() {
+
+        String realmName = System.getProperty("ups.realm.name");
+        String upsAuthServer = System.getProperty("ups.auth.server.url");
+
+        Config config = new Config(realmName, upsAuthServer);
+
+        return Response.ok(new Gson().toJson(config)).build();
+
+    }
+
+    private class Config {
+
+        private String realm = "aerogear";
+        @SerializedName("auth-server-url")
+        private String authServerUrl = "/auth";
+        @SerializedName("ssl-required")
+        private final String sslRequired = "external";
+        @SerializedName("public-client")
+        private final boolean publicClient = true;
+        private final String resource = "unified-push-server-js";
+
+        public Config(String realmName, String authServerUrl) {
+            if(realmName != null && !realm.isEmpty()) {
+                this.realm = realmName;
+            }
+            if(authServerUrl != null && !authServerUrl.isEmpty()) {
+                this.authServerUrl = authServerUrl;
+            }
+        }
+
+        public String getRealm() {
+            return realm;
+        }
+
+        public String getAuthServerUrl() {
+            return authServerUrl;
+        }
+
+        public String getSslRequired() {
+            return sslRequired;
+        }
+
+        public String getResource() {
+            return resource;
+        }
+
+        public boolean isPublicClient() {
+            return publicClient;
+        }
+
+    }
+}

--- a/servers/auth-server/src/main/webapp/WEB-INF/ups-realm.json
+++ b/servers/auth-server/src/main/webapp/WEB-INF/ups-realm.json
@@ -76,9 +76,9 @@
             "name": "unified-push-server-js",
             "enabled": true,
             "publicClient": true,
-            "baseUrl": "/ag-push",
+            "baseUrl": "http://localhost:8082/ag-push",
             "redirectUris": [
-                "/ag-push/*"
+                "http://localhost:8082/ag-push/*"
             ]
         }
     ]

--- a/servers/ups-wildfly/src/main/webapp/WEB-INF/keycloak.json
+++ b/servers/ups-wildfly/src/main/webapp/WEB-INF/keycloak.json
@@ -1,6 +1,6 @@
 {
-  "realm" : "aerogear",
-  "auth-server-url" : "/auth",
+  "realm" : "${ups.realm.name}",
+  "auth-server-url" : "${ups.auth.server.url}",
   "ssl-required" : "external",
   "resource" : "unified-push-server",
   "bearer-only" : true,

--- a/servers/ups-wildfly/src/main/webapp/WEB-INF/web.xml
+++ b/servers/ups-wildfly/src/main/webapp/WEB-INF/web.xml
@@ -8,6 +8,13 @@
 
     <security-constraint>
         <web-resource-collection>
+            <web-resource-name>Configuration Endpoint</web-resource-name>
+            <url-pattern>/rest/keycloak/config</url-pattern>
+        </web-resource-collection>
+    </security-constraint>
+
+    <security-constraint>
+        <web-resource-collection>
             <web-resource-name>Admin</web-resource-name>
             <url-pattern>/rest/*</url-pattern>
         </web-resource-collection>

--- a/servers/ups-wildfly/src/main/webapp/config/admin-ui-keycloak.json
+++ b/servers/ups-wildfly/src/main/webapp/config/admin-ui-keycloak.json
@@ -1,7 +1,0 @@
-{
-    "realm" : "aerogear",
-    "auth-server-url" : "/auth",
-    "ssl-required" : "external",
-    "resource" : "unified-push-server-js",
-    "public-client" : true
-}


### PR DESCRIPTION
Changelog:
  
* Inclusion of Keycloak as bower component
  * Inclusion of usage instructions
  * Setup scripts
    - Shell script for Keycloak setup
    - Enable UPS to be used against whatever realm we want
    - Script to link UPS to Keycloak
  * Inclusion of configuration endpoint
    - Make it available for admin-ui
    - Enable UPS to be used against whatever realm we want
    - Fixes issues with hard coded references
  * Inclusion of Realm configuration template files

Usage instructions
--------------------------------------------------------------------------

The following scenarios were tested against WildFly 9 and Keycloak 1.7.0.Final/1.8.0.CR3

Scenario 1
==========================================================================

### Description

The following setup covers scenarios where people wants to deploy Keycloak and UPS in separated Wildfly instances.

### Keycloak setup

1. Deploy Keycloak following [these instructions](http://keycloak.github.io/docs/userguide/keycloak-server/html/server-installation.html)
2. Import the realm configuration file and start WildFly in a separate port
  ```
  $UPS_HOME/bin/keycloak-setup.sh --ups-host=http://localhost:8082 --wildfly-offset=3 --realm-import=$UPS_HOME/bin/ups-realm-template.json
  ```
3. Keycloak server should start with `aerogear` realm imported

### UPS setup

1. Follow the setup instructions described [here](https://aerogear.org/docs/unifiedpush/ups_userguide/index/#server-installation).

2. Setup the Keycloak subsystem
```
  $UPS_HOME/bin/ups-setup.sh --subsystem-setup
```

3. Start WildFly in a separate port
  ```
  $WILDFLY_HOME/bin/standalone.sh -Djboss.socket.binding.port-offset=2 --server-config=standalone-full.xml
  ```
4. Setup UPS instance to properly be attached to Keycloak instance
  ```
  $UPS_HOME/bin/ups-setup.sh --ups-host=localhost:9992 --realm=aerogear --auth-server=http://localhost:8083
  ```

5. Deploy the UnifiedPush server

Scenario 2
===========================================================================

### Description

The following setup covers scenarios where people wants to have multiple WildFly instances of UPS authenticating against just one server running Keycloak.


One Keycloak instance, multiple UnifiedPush servers

### Keycloak setup

1. Deploy Keycloak following [these instructions](http://keycloak.github.io/docs/userguide/keycloak-server/html/server-installation.html)

2. Create the realm configuration file or just copy from UPS template

```
cp ups-realm-template.json ups-production-realm.json
cp ups-realm-template.json ups-dev-realm.json
```

3. Change the realm name

For example, at `ups-dev-realm.json` change `"realm": "aerogear"` to `"realm": "aerogear-dev"`.

4. Import the realm configuration file and start WildFly in a separate port

```
$UPS_HOME/bin/keycloak-setup.sh --ups-host=http://localhost:8081,http://localhost:8082 --wildfly-offset=3 --realm-import=$UPS_HOME/bin/ups-dev-realm.json,$UPS_HOME/bin/ups-production-realm.json
```

### UPS setup

1. Follow the setup instructions described [here](https://aerogear.org/docs/unifiedpush/ups_userguide/index/#server-installation).

2. Setup the Keycloak subsystem

#### Under WildFly development instance

```
  $UPS_HOME/bin/ups-setup.sh --subsystem-setup
```

#### Under WildFly production instance

```
  $UPS_HOME/bin/ups-setup.sh --subsystem-setup
```

3. Setup UPS instance to properly be attached to Keycloak instance


#### Under WildFly development instance
  ```
  $UPS_HOME/bin/ups-setup.sh --ups-host=localhost:9991 --realm=aerogear-dev --auth-server=http://localhost:8083
  ```

#### Under WildFly production instance

  ```
  $UPS_HOME/bin/ups-setup.sh --ups-host=localhost:9992 --realm=aerogear-production --auth-server=http://localhost:8083
  ```

5. Deploy the UnifiedPush server


Deploying in an already existent realm
==========================================================================

### Description

The following scenarios applies for sittuations where people already have Keycloak deployed and want to have all the setup in a single realm.

#### Note

This is only available on Keycloak 1.8.x.

### Keycloak setup

1. Deploy Keycloak following [these instructions](http://keycloak.github.io/docs/userguide/keycloak-server/html/server-installation.html)

2. Visit http://yourhost/auth/

3. Setup username and password

4. Open the Realm template located at $UPS_HOME/bin and replace `dummyhost`, by your host.

5. Import users, clients and roles with Partial import

![](http://i.imgur.com/im6y6Cg.png)

### UPS setup

1. Follow the setup instructions described [here](https://aerogear.org/docs/unifiedpush/ups_userguide/index/#server-installation).

2. Setup the Keycloak subsystem
```
  $UPS_HOME/bin/ups-setup.sh --subsystem-setup
```

3. Start WildFly in a separate port
  ```
  $WILDFLY_HOME/bin/standalone.sh -Djboss.socket.binding.port-offset=2 --server-config=standalone-full.xml
  ```
4. Setup UPS instance to properly be attached to Keycloak instance
  ```
  $UPS_HOME/bin/ups-setup.sh --ups-host=localhost:9992 --realm=master --auth-server=http://localhost:8083
  ```

5. Deploy the UnifiedPush server