### PR TITLE
AGPUSH-1585 - analytics concurrency issue

### DIFF
--- a/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/message/TestMetricsCollector.java
+++ b/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/message/TestMetricsCollector.java
@@ -16,19 +16,6 @@
  */
 package org.jboss.aerogear.unifiedpush.message;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.mockito.Mockito.when;
-
-import java.util.UUID;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-
-import javax.annotation.Resource;
-import javax.enterprise.event.Observes;
-import javax.inject.Inject;
-import javax.jms.Queue;
-
 import org.jboss.aerogear.unifiedpush.api.PushMessageInformation;
 import org.jboss.aerogear.unifiedpush.api.VariantMetricInformation;
 import org.jboss.aerogear.unifiedpush.dao.PushMessageInformationDao;
@@ -43,6 +30,18 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import javax.annotation.Resource;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+import javax.jms.Queue;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.when;
 
 @RunWith(Arquillian.class)
 public class TestMetricsCollector extends AbstractJMSTest {
@@ -92,11 +91,11 @@ public class TestMetricsCollector extends AbstractJMSTest {
         when(pushMessageInformationDao.find(pushMetric.getId())).thenReturn(pushMetric);
 
         // when
-        send(new BatchLoadedEvent(variantID1)).withProperty("variantID", variantID1).to(batchLoadedQueue);
-        send(new BatchLoadedEvent(variantID1)).withProperty("variantID", variantID1).to(batchLoadedQueue);
-        send(new BatchLoadedEvent(variantID2)).withProperty("variantID", variantID2).to(batchLoadedQueue);
-        send(new AllBatchesLoadedEvent(variantID1)).withProperty("variantID", variantID1).to(allBatchesLoaded);
-        send(new AllBatchesLoadedEvent(variantID2)).withProperty("variantID", variantID2).to(allBatchesLoaded);
+        send(new BatchLoadedEvent(variantID1+":"+pushMetric.getId())).withProperty("variantID", variantID1+":"+pushMetric.getId()).to(batchLoadedQueue);
+        send(new BatchLoadedEvent(variantID1+":"+pushMetric.getId())).withProperty("variantID", variantID1+":"+pushMetric.getId()).to(batchLoadedQueue);
+        send(new BatchLoadedEvent(variantID2+":"+pushMetric.getId())).withProperty("variantID", variantID2+":"+pushMetric.getId()).to(batchLoadedQueue);
+        send(new AllBatchesLoadedEvent(variantID1+":"+pushMetric.getId())).withProperty("variantID", variantID1+":"+pushMetric.getId()).to(allBatchesLoaded);
+        send(new AllBatchesLoadedEvent(variantID2+":"+pushMetric.getId())).withProperty("variantID", variantID2+":"+pushMetric.getId()).to(allBatchesLoaded);
 
         metricsCollector.collectMetrics(variant1Metric1);
         metricsCollector.collectMetrics(variant1Metric2);
@@ -111,10 +110,10 @@ public class TestMetricsCollector extends AbstractJMSTest {
         assertEquals(2, variant1Metric1.getTotalBatches().intValue());
         assertEquals(1, variant2Metric1.getServedBatches().intValue());
         assertEquals(1, variant2Metric1.getTotalBatches().intValue());
-        assertNull(receive().withTimeout(100).withSelector("variantID = '%s'", variantID1).from(batchLoadedQueue));
-        assertNull(receive().withTimeout(100).withSelector("variantID = '%s'", variantID1).from(allBatchesLoaded));
-        assertNull(receive().withTimeout(100).withSelector("variantID = '%s'", variantID2).from(batchLoadedQueue));
-        assertNull(receive().withTimeout(100).withSelector("variantID = '%s'", variantID2).from(allBatchesLoaded));
+        assertNull(receive().withTimeout(100).withSelector("variantID = '%s'", variantID1+":"+pushMetric.getId()).from(batchLoadedQueue));
+        assertNull(receive().withTimeout(100).withSelector("variantID = '%s'", variantID1+":"+pushMetric.getId()).from(allBatchesLoaded));
+        assertNull(receive().withTimeout(100).withSelector("variantID = '%s'", variantID2+":"+pushMetric.getId()).from(batchLoadedQueue));
+        assertNull(receive().withTimeout(100).withSelector("variantID = '%s'", variantID2+":"+pushMetric.getId()).from(allBatchesLoaded));
     }
 
     public void observeVariantCompleted(@Observes VariantCompletedEvent variantCompleted) {


### PR DESCRIPTION
Introducing a robust message key (variant+pushmessageInfo) to have better message selection from the queues on concurrent requests