### PR TITLE
Adds custom Miredot tags to javadoc tool

### DIFF
--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -158,6 +158,25 @@
                     </analysis>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <!-- Adds custom Miredot tags (required for JDK 8 DocLint: http://openjdk.java.net/jeps/172) -->
+                    <tags>
+                        <tag>
+                            <name>statuscode</name>
+                            <placement>m</placement>
+                            <head>Status codes:</head>
+                        </tag>
+                        <tag>
+                            <name>responseheader</name>
+                            <placement>m</placement>
+                            <head>Response headers:</head>
+                        </tag>
+                    </tags>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Required for JEP 172 (DocLint) in JDK 8 [1]. See https://github.com/aerogear/aerogear-unifiedpush-server/pull/664#issuecomment-193685347 for details.

This maven configuration adds custom MireDot tags in a simple way. The problem now, that multiple tags [2] will be separated by comma (,). It looks like this: 
![Screenshot](http://img.prntscr.com/img?url=http://i.imgur.com/Y1VSrEy.png)

If we want to put each tag on a new line, we have to implement custom `Taglet`s [3] for this purpose and keep them in our project.

[1] http://openjdk.java.net/jeps/172
[2] https://github.com/aerogear/aerogear-unifiedpush-server/blob/master/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/installations/InstallationRegistrationEndpoint.java#L139-L145
[3] http://docs.oracle.com/javase/8/docs/technotes/guides/javadoc/taglet/overview.html

@matzew @sebastienblanc WDYT? Is it enough? Or we are going to implement `Taglet`s?