### PR TITLE
Improved Push Notification logging

### DIFF
--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/sender/PushNotificationSenderEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/sender/PushNotificationSenderEndpoint.java
@@ -104,8 +104,7 @@ public class PushNotificationSenderEndpoint {
 
         // submitted to EJB:
         notificationRouter.submit(pushApplication, message);
-        logger.fine("Message sent by: '" + message.getClientIdentifier() + "'");
-        logger.info("Message submitted to PushNetworks for further processing");
+        logger.fine(String.format("Push Message Request from [%s] API was internally submitted for further processing", message.getClientIdentifier()));
 
         return Response.status(Status.ACCEPTED).entity(EmptyJSON.STRING).build();
     }

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/NotificationRouter.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/NotificationRouter.java
@@ -73,7 +73,7 @@ public class NotificationRouter {
      */
     @TransactionAttribute(TransactionAttributeType.REQUIRED)
     public void submit(PushApplication pushApplication, InternalUnifiedPushMessage message) {
-        logger.info("Processing send request with '" + message.getMessage().toString() + "' payload");
+        logger.fine("Processing send request with '" + message.getMessage().toString() + "' payload");
 
         // collections for all the different variants:
         final VariantMap variants = new VariantMap();
@@ -116,6 +116,7 @@ public class NotificationRouter {
 
         // we split the variants per type since each type may have its own configuration (e.g. batch size)
         for (final Entry<VariantType, List<Variant>> entry : variants.entrySet()) {
+            logger.info(String.format("Internal dispatching of push message for one %s variant", entry.getKey().getTypeName()));
             dispatchVariantMessageEvent.fire(new MessageHolderWithVariants(pushMessageInformation, message, entry.getKey(), entry.getValue()));
         }
     }

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/TokenLoader.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/TokenLoader.java
@@ -108,6 +108,7 @@ public class TokenLoader {
         final List<String> aliases = criteria.getAliases();
         final List<String> deviceTypes = criteria.getDeviceTypes();
 
+        logger.info(String.format("Preparing message delivery and loading tokens for the %s 3rd-party Push Network (for %d variants)", variantType, variants.size()));
         for (Variant variant : variants) {
             ResultsStream<String> tokenStream =
                 clientInstallationService.findAllDeviceTokenForVariantIDByCriteria(variant.getVariantID(), categories, aliases, deviceTypes, configuration.tokensToLoad(), lastTokenFromPreviousBatch)
@@ -126,7 +127,7 @@ public class TokenLoader {
                     }
                     if (tokens.size() > 0) {
                         dispatchTokensEvent.fire(new MessageHolderWithTokens(msg.getPushMessageInformation(), message, variant, tokens, ++serialId));
-                        logger.fine(String.format("Loaded batch #%s for %s variant (%s)", serialId, variant.getType().getTypeName(), variant.getVariantID()));
+                        logger.info(String.format("Loaded batch #%s, containing %d tokens, for %s variant (%s)", serialId, tokens.size() ,variant.getType().getTypeName(), variant.getVariantID()));
 
                         // using combined key of variant and PMI (AGPUSH-1585):
                         batchLoaded.fire(new BatchLoadedEvent(variant.getVariantID()+":"+msg.getPushMessageInformation().getId()));

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/cache/ApnsServiceCache.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/cache/ApnsServiceCache.java
@@ -69,7 +69,7 @@ public class ApnsServiceCache extends AbstractServiceCache<ApnsService> {
 
                     // trigger asynchronous deletion:
                     if (! transformedTokens.isEmpty()) {
-                        logger.info("Deleting '" + inactiveTokens.size() + "' invalid iOS installations");
+                        logger.info("Deleting '" + inactiveTokens.size() + "' inactive iOS installations");
                         clientInstallationService.removeInstallationsForVariantByDeviceTokens(variantID, transformedTokens);
                     }
                 } catch (Exception e) {

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/APNsPushNotificationSender.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/APNsPushNotificationSender.java
@@ -16,15 +16,16 @@
  */
 package org.jboss.aerogear.unifiedpush.message.sender;
 
-import static org.jboss.aerogear.unifiedpush.system.ConfigurationUtils.tryGetIntegerProperty;
-import static org.jboss.aerogear.unifiedpush.system.ConfigurationUtils.tryGetProperty;
-
-import java.io.ByteArrayInputStream;
-import java.util.Collection;
-import java.util.Date;
-
-import javax.inject.Inject;
-
+import com.notnoop.apns.APNS;
+import com.notnoop.apns.ApnsDelegateAdapter;
+import com.notnoop.apns.ApnsNotification;
+import com.notnoop.apns.ApnsService;
+import com.notnoop.apns.ApnsServiceBuilder;
+import com.notnoop.apns.DeliveryError;
+import com.notnoop.apns.EnhancedApnsNotification;
+import com.notnoop.apns.PayloadBuilder;
+import com.notnoop.apns.internal.Utilities;
+import com.notnoop.exceptions.ApnsDeliveryErrorException;
 import org.jboss.aerogear.unifiedpush.api.Variant;
 import org.jboss.aerogear.unifiedpush.api.VariantType;
 import org.jboss.aerogear.unifiedpush.api.iOSVariant;
@@ -39,16 +40,13 @@ import org.jboss.aerogear.unifiedpush.message.exception.SenderResourceNotAvailab
 import org.jboss.aerogear.unifiedpush.service.ClientInstallationService;
 import org.jboss.aerogear.unifiedpush.utils.AeroGearLogger;
 
-import com.notnoop.apns.APNS;
-import com.notnoop.apns.ApnsDelegateAdapter;
-import com.notnoop.apns.ApnsNotification;
-import com.notnoop.apns.ApnsService;
-import com.notnoop.apns.ApnsServiceBuilder;
-import com.notnoop.apns.DeliveryError;
-import com.notnoop.apns.EnhancedApnsNotification;
-import com.notnoop.apns.PayloadBuilder;
-import com.notnoop.apns.internal.Utilities;
-import com.notnoop.exceptions.ApnsDeliveryErrorException;
+import javax.inject.Inject;
+import java.io.ByteArrayInputStream;
+import java.util.Collection;
+import java.util.Date;
+
+import static org.jboss.aerogear.unifiedpush.system.ConfigurationUtils.tryGetIntegerProperty;
+import static org.jboss.aerogear.unifiedpush.system.ConfigurationUtils.tryGetProperty;
 
 @SenderType(VariantType.IOS)
 public class APNsPushNotificationSender implements PushNotificationSender {
@@ -177,7 +175,8 @@ public class APNsPushNotificationSender implements PushNotificationSender {
             Date expireDate = createFutureDateBasedOnTTL(pushMessage.getConfig().getTimeToLive());
             service.push(tokens, apnsMessage, expireDate);
 
-            logger.info("One batch to APNs has been submitted");
+            logger.info(String.format("Sent push notification to the Apple APNs Server for %d tokens",tokens.size()));
+
             apnsServiceCache.queueFreedUpService(pushMessageInformationId, iOSVariant.getVariantID(), service);
             try {
                 service = null; // we don't want a failure in onSuccess stop the APNs service
@@ -250,7 +249,7 @@ public class APNsPushNotificationSender implements PushNotificationSender {
                         ApnsDeliveryErrorException deliveryError = (ApnsDeliveryErrorException) e;
                         if (DeliveryError.INVALID_TOKEN.equals(deliveryError.getDeliveryError())) {
                             final String invalidToken = Utilities.encodeHex(message.getDeviceToken()).toLowerCase();
-                            logger.info("Removing invalid token: " + invalidToken);
+                            logger.info("Removing invalid (not allowed) token: " + invalidToken);
                             clientInstallationService.removeInstallationForVariantByDeviceToken(iOSVariant.getVariantID(), invalidToken);
                         } else {
                             // for now, we just log the other cases

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/AdmPushNotificationSender.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/AdmPushNotificationSender.java
@@ -74,5 +74,7 @@ public class AdmPushNotificationSender implements PushNotificationSender {
                 senderCallback.onError(e.getMessage());
             }
         }
+
+        logger.info(String.format("Sent push notification to Amazon's ADM Server for %d tokens",clientIdentifiers.size()));
     }
 }

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/GCMPushNotificationSender.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/GCMPushNotificationSender.java
@@ -107,7 +107,7 @@ public class GCMPushNotificationSender implements PushNotificationSender {
             // send out a message to a batch of devices...
             processGCM(androidVariant, registrationIDs, gcmMessage, sender);
 
-            logger.info("Message batch to GCM has been submitted");
+            logger.fine("Message batch to GCM has been submitted");
             callback.onSuccess();
 
         } catch (Exception e) {
@@ -122,7 +122,7 @@ public class GCMPushNotificationSender implements PushNotificationSender {
      */
     private void processGCM(AndroidVariant androidVariant, List<String> registrationIDs, Message gcmMessage, Sender sender) throws IOException {
 
-        logger.info("Sending payload for [" + registrationIDs.size() + "] devices to GCM");
+        logger.info(String.format("Sent push notification to GCM Server for %d registrationIDs",registrationIDs.size()));
 
         MulticastResult multicastResult = sender.send(gcmMessage, registrationIDs, 0);
 
@@ -156,6 +156,9 @@ public class GCMPushNotificationSender implements PushNotificationSender {
             final Result result = results.get(i);
 
             final String errorCodeName = result.getErrorCodeName();
+            if (errorCodeName != null) {
+                logger.info(String.format("Processing [%s] error code from GCM response, for registration ID: [%s]", errorCodeName, registrationIDs.get(i)));
+            }
 
             // is there any 'interesting' error code, which requires a clean up of the registration IDs
             if (GCM_ERROR_CODES.contains(errorCodeName)) {
@@ -170,7 +173,7 @@ public class GCMPushNotificationSender implements PushNotificationSender {
         }
 
         // trigger asynchronous deletion:
-        logger.fine("Deleting '" + inactiveTokens.size() + "' invalid Android installations");
+        logger.info(String.format("Based on GCM error response codes, deleting %d invalid Android installations", inactiveTokens.size()));
         clientInstallationService.removeInstallationsForVariantByDeviceTokens(variantID, inactiveTokens);
     }
 }

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/MPNSPushNotificationSender.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/MPNSPushNotificationSender.java
@@ -16,23 +16,26 @@
  */
 package org.jboss.aerogear.unifiedpush.message.sender;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-
 import org.jboss.aerogear.unifiedpush.api.Variant;
 import org.jboss.aerogear.unifiedpush.api.VariantType;
 import org.jboss.aerogear.unifiedpush.message.Message;
 import org.jboss.aerogear.unifiedpush.message.UnifiedPushMessage;
 import org.jboss.aerogear.unifiedpush.message.windows.Windows;
+import org.jboss.aerogear.unifiedpush.utils.AeroGearLogger;
 import org.jboss.aerogear.windows.mpns.MPNS;
 import org.jboss.aerogear.windows.mpns.MpnsNotification;
 import org.jboss.aerogear.windows.mpns.MpnsService;
 import org.jboss.aerogear.windows.mpns.notifications.TileNotification;
 import org.jboss.aerogear.windows.mpns.notifications.ToastNotification;
 
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
 @SenderType(VariantType.WINDOWS_MPNS)
 public class MPNSPushNotificationSender implements PushNotificationSender {
+
+    private final AeroGearLogger logger = AeroGearLogger.getInstance(MPNSPushNotificationSender.class);
 
     @Override
     public void sendPushMessage(Variant variant, Collection<String> clientIdentifiers, UnifiedPushMessage pushMessage, String pushMessageInformationId, NotificationSenderCallback senderCallback) {
@@ -99,6 +102,8 @@ public class MPNSPushNotificationSender implements PushNotificationSender {
         for (String identifier : clientIdentifiers) {
             mpnsService.push(identifier, notification);
         }
+
+        logger.info(String.format("Sent push notification to MPNs for %d tokens",clientIdentifiers.size()));
 
         senderCallback.onSuccess();
     }

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/SimplePushNotificationSender.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/SimplePushNotificationSender.java
@@ -16,19 +16,18 @@
  */
 package org.jboss.aerogear.unifiedpush.message.sender;
 
+import org.jboss.aerogear.unifiedpush.api.Variant;
+import org.jboss.aerogear.unifiedpush.api.VariantType;
+import org.jboss.aerogear.unifiedpush.message.UnifiedPushMessage;
+import org.jboss.aerogear.unifiedpush.utils.AeroGearLogger;
+
+import javax.ws.rs.core.Response.Status;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
-
-import javax.ws.rs.core.Response.Status;
-
-import org.jboss.aerogear.unifiedpush.api.Variant;
-import org.jboss.aerogear.unifiedpush.api.VariantType;
-import org.jboss.aerogear.unifiedpush.message.UnifiedPushMessage;
-import org.jboss.aerogear.unifiedpush.utils.AeroGearLogger;
 
 @SenderType(VariantType.SIMPLE_PUSH)
 public class SimplePushNotificationSender implements PushNotificationSender {
@@ -79,12 +78,15 @@ public class SimplePushNotificationSender implements PushNotificationSender {
                 }
             }
         }
-       if (hasWarning) {
-           callback.onError("Error delivering SimplePush payload");
-       }
-       else {
-           callback.onSuccess();
-       }
+
+        logger.info(String.format("Sent push notification to SimplePush Server for %d  tokens",tokens.size()));
+
+        if (hasWarning) {
+            callback.onError("Error delivering SimplePush payload");
+        }
+        else {
+            callback.onSuccess();
+        }
     }
 
     /*

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/WNSPushNotificationSender.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/WNSPushNotificationSender.java
@@ -95,6 +95,8 @@ public class WNSPushNotificationSender implements PushNotificationSender {
                 responses = wnsService.pushToast(channelUris, optional, createSimpleToastMessage(message));
             }
 
+            logger.info(String.format("Sent push notification to WNS for %d  tokens", channelUris.size()));
+
             for (WnsNotificationResponse response : responses) {
                 if (response.code == HttpServletResponse.SC_GONE) {
                     expiredClientIdentifiers.add(response.channelUri);


### PR DESCRIPTION
Some more detailed logging for Push Notification delivery, done for [AGPUSH-1592](https://issues.jboss.org/browse/AGPUSH-1592)


For instance, here is the flow, with one variant, with the default log-level:
```
14:02:07,955 INFO  [org.jboss.aerogear.unifiedpush.message.NotificationRouter] (default task-62) Internal dispatching of push message for a ios variant
14:02:07,989 INFO  [org.jboss.aerogear.unifiedpush.message.TokenLoader] (Thread-387 (HornetQ-client-global-threads-1246092163)) Preparing message delivery and loading tokens for #1 3rd-party Push Network(s)
14:02:08,018 INFO  [org.jboss.aerogear.unifiedpush.message.TokenLoader] (Thread-387 (HornetQ-client-global-threads-1246092163)) Loaded batch #1, containing 1 tokens, for ios variant (700fe9a3-7a36-45e0-9909-d9563005ea46)
14:02:08,022 INFO  [org.jboss.aerogear.unifiedpush.message.NotificationDispatcher] (Thread-388 (HornetQ-client-global-threads-1246092163)) Received UnifiedPushMessage from JMS queue, will now trigger the Push Notification delivery for the ios variant (700fe9a3-7a36-45e0-9909-d9563005ea46)
14:02:08,855 INFO  [org.jboss.aerogear.unifiedpush.message.sender.APNsPushNotificationSender] (Thread-388 (HornetQ-client-global-threads-1246092163)) Sent push notification to the Apple APNs Server for 1 tokens
```

For two variants, on one PushApplication the default logging looks like:
```
14:06:38,159 INFO  [org.jboss.aerogear.unifiedpush.message.NotificationRouter] (default task-121) Internal dispatching of push message for one android variant
14:06:38,188 INFO  [org.jboss.aerogear.unifiedpush.message.NotificationRouter] (default task-121) Internal dispatching of push message for one ios variant
14:06:38,216 INFO  [org.jboss.aerogear.unifiedpush.message.TokenLoader] (Thread-463 (HornetQ-client-global-threads-1246092163)) Preparing message delivery and loading tokens for the IOS 3rd-party Push Network (for 1 variants)
14:06:38,217 INFO  [org.jboss.aerogear.unifiedpush.message.TokenLoader] (Thread-451 (HornetQ-client-global-threads-1246092163)) Preparing message delivery and loading tokens for the ANDROID 3rd-party Push Network (for 1 variants)
14:06:38,267 INFO  [org.jboss.aerogear.unifiedpush.message.TokenLoader] (Thread-463 (HornetQ-client-global-threads-1246092163)) Loaded batch #1, containing 1 tokens, for ios variant (700fe9a3-7a36-45e0-9909-d9563005ea46)
14:06:38,267 INFO  [org.jboss.aerogear.unifiedpush.message.TokenLoader] (Thread-451 (HornetQ-client-global-threads-1246092163)) Loaded batch #1, containing 1 tokens, for android variant (b5084c8f-bb40-41fe-a2f2-6c153cf3bfd2)
14:06:38,271 INFO  [org.jboss.aerogear.unifiedpush.message.NotificationDispatcher] (Thread-458 (HornetQ-client-global-threads-1246092163)) Received UnifiedPushMessage from JMS queue, will now trigger the Push Notification delivery for the android variant (b5084c8f-bb40-41fe-a2f2-6c153cf3bfd2)
14:06:38,271 INFO  [org.jboss.aerogear.unifiedpush.message.NotificationDispatcher] (Thread-467 (HornetQ-client-global-threads-1246092163)) Received UnifiedPushMessage from JMS queue, will now trigger the Push Notification delivery for the ios variant (700fe9a3-7a36-45e0-9909-d9563005ea46)
14:06:38,282 INFO  [org.jboss.aerogear.unifiedpush.message.sender.GCMPushNotificationSender] (Thread-458 (HornetQ-client-global-threads-1246092163)) Sent push notification to GCM Server for 1 registrationIDs
14:06:38,473 INFO  [org.jboss.aerogear.unifiedpush.message.sender.GCMPushNotificationSender] (Thread-458 (HornetQ-client-global-threads-1246092163)) Processing [InvalidRegistration] error code from GCM response, for registration ID: [APA91bHpbMXepp4odlb20vYOv0gQyNIyFu2X3OXR3TjqR8qecgWivima_UiLPFgUBs_10Nys2TUwUyWlixrIta35NXW-5Z85OdXcbb_3s3p0qaa_a7NpFlaX9GpidK_BdQNMsx2gX8BrE4Uw7s22nPCcEn1U1_mo-T6hcF5unYt965PDwRTRss8]
14:06:38,473 INFO  [org.jboss.aerogear.unifiedpush.message.sender.GCMPushNotificationSender] (Thread-458 (HornetQ-client-global-threads-1246092163)) Based on GCM error response codes, deleting 1 invalid Android installations
14:06:39,420 INFO  [org.jboss.aerogear.unifiedpush.message.sender.APNsPushNotificationSender] (Thread-467 (HornetQ-client-global-threads-1246092163)) Sent push notification to the Apple APNs Server for 1 tokens
```

Note, there is a made-up token here for GCM, and the default log now gives a bit more info that we actually remove a token from the Device Metadata DB...



*TARGETs:* _master_ and _1.1.x_ branches :dart: 

