### PR TITLE
Adding GCM token validation with Canonical ID 

### DIFF
--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/GCMPushNotificationSender.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/GCMPushNotificationSender.java
@@ -177,7 +177,7 @@ public class GCMPushNotificationSender implements PushNotificationSender {
                 installation.setDeviceToken(canonicalRegId);
               
                 //update installation with the new token
-                logger.info(String.format("Based on GCM error response codes, updating Android installations with registration id [%s] with new token [%s} ", registrationIDs.get(i), canonicalRegId));
+                logger.info(String.format("Based on returned canonical id from GCM, updating Android installations with registration id [%s] with new token [%s] ", registrationIDs.get(i), canonicalRegId));
                 clientInstallationService.updateInstallation(installation);
               
                 //if the result contains a canonical id, there is no need to remove the current inactive token from data store

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/GCMPushNotificationSender.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/GCMPushNotificationSender.java
@@ -23,6 +23,7 @@ import com.google.android.gcm.server.MulticastResult;
 import com.google.android.gcm.server.Result;
 import com.google.android.gcm.server.Sender;
 
+import org.jboss.aerogear.unifiedpush.api.Installation;
 import org.jboss.aerogear.unifiedpush.api.AndroidVariant;
 import org.jboss.aerogear.unifiedpush.api.Variant;
 import org.jboss.aerogear.unifiedpush.api.VariantType;

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/GCMPushNotificationSender.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/GCMPushNotificationSender.java
@@ -128,6 +128,7 @@ public class GCMPushNotificationSender implements PushNotificationSender {
 
         // after sending, let's identify the inactive/invalid registrationIDs and trigger their deletion:
         cleanupInvalidRegistrationIDsForVariant(androidVariant.getVariantID(), multicastResult, registrationIDs);
+        
     }
 
     /**
@@ -159,19 +160,44 @@ public class GCMPushNotificationSender implements PushNotificationSender {
             if (errorCodeName != null) {
                 logger.info(String.format("Processing [%s] error code from GCM response, for registration ID: [%s]", errorCodeName, registrationIDs.get(i)));
             }
-
-            // is there any 'interesting' error code, which requires a clean up of the registration IDs
-            if (GCM_ERROR_CODES.contains(errorCodeName)) {
-
-                // Ok the result at INDEX 'i' represents a 'bad' registrationID
-
-                // Now use the INDEX of the _that_ result object, and look
-                // for the matching registrationID inside of the List that contains
-                // _all_ the used registration IDs and store it:
-               inactiveTokens.add(registrationIDs.get(i));
+            
+            //after sending, lets find tokens that are inactive from now on and need to be replaced with the new given canonical id.
+            //according to gcm documentation, google refreshes tokens after some time. So the previous tokens will become invalid.
+            //When you send a notification to a registration id which is expired, for the 1st time the message(notification) will be delivered
+            //but you will get a new registration id with the name canonical id. Which mean, the registration id you sent the message to has 
+            //been changed to this canonical id, so change it on your server side as well.
+            
+            //check if current index of result has canonical id
+            String canonicalRegId = result.getCanonicalRegistrationId();
+            if (canonicalRegId != null) {
+                // same device has more than one registration id: update it
+              
+                // find the installation and change its token to new canonical id
+                Installation installation = clientInstallationService.findInstallationForVariantByDeviceToken(variantID,registrationIDs.get(i));
+                installation.setDeviceToken(canonicalRegId);
+              
+                //update installation with the new token
+                logger.info(String.format("Based on GCM error response codes, updating Android installations with registration id [%s] with new token [%s} ", registrationIDs.get(i), canonicalRegId));
+                clientInstallationService.updateInstallation(installation);
+              
+                //if the result contains a canonical id, there is no need to remove the current inactive token from data store
+                
+            }
+            else
+            {
+                // is there any 'interesting' error code, which requires a clean up of the registration IDs
+                if (GCM_ERROR_CODES.contains(errorCodeName)) {
+    
+                    // Ok the result at INDEX 'i' represents a 'bad' registrationID
+    
+                    // Now use the INDEX of the _that_ result object, and look
+                    // for the matching registrationID inside of the List that contains
+                    // _all_ the used registration IDs and store it:
+                   inactiveTokens.add(registrationIDs.get(i));
+                }
             }
         }
-
+        
         // trigger asynchronous deletion:
         logger.info(String.format("Based on GCM error response codes, deleting %d invalid Android installations", inactiveTokens.size()));
         clientInstallationService.removeInstallationsForVariantByDeviceTokens(variantID, inactiveTokens);


### PR DESCRIPTION
From GCM docs:

> When you send a notification to a registration id which is expired, for the 1st time the message(notification) will be delivered **but you will get a new registration id with the name canonical id. Which mean, the registration id you sent the message to has been changed to this canonical id, so change it on your server side as well.**
[https://developers.google.com/cloud-messaging/registration](https://developers.google.com/cloud-messaging/registration)

> If a bug in the client app triggers multiple registrations for the same device, it can be hard to reconcile state and the client app might end up with duplicate messages.
Implementing canonical IDs can help you more easily recover from these situations. A canonical registration ID is the registration token of the last registration requested by the client app . This is the ID that the server should use when sending messages to the device.
If you try to send a message using an old registration token, GCM will process the request as usual, but it will include the canonical ID in the registration_id field of the response. **Make sure to replace the registration token stored in your server with this canonical ID, as eventually the old registration token will stop working.**

I submitted a GCM token in aerogear and used it for some time. after that, the token was expired, and it was removed from aerogear database and not replaced with given canonical id.

I checked aerogear code and the feature was not implemented in the sender file, so i updated it:
`org.jboss.aerogear.unifiedpush.message.sender.GCMPushNotificationSender.java`