### PR TITLE
Gcm priority

### DIFF
--- a/admin-ui/app/components/app-detail/app-detail.js
+++ b/admin-ui/app/components/app-detail/app-detail.js
@@ -34,9 +34,11 @@ angular.module('upsConsole')
 
           // default message
           $scope.pushData = {
+            
             'message': {
               'sound': 'default',
               'alert': '',
+              'priority':'normal',
               'simple-push': 'version=' + new Date().getTime()
             },
             'criteria' : {}

--- a/admin-ui/app/dialogs/send-push-notification.html
+++ b/admin-ui/app/dialogs/send-push-notification.html
@@ -14,7 +14,16 @@
       </div>
     </div>
 
-
+      
+    <div class="form-group">
+      <label class="col-sm-3 control-label" for="textInput-modal-markup">Priority</label>
+      <div class="col-sm-9">
+          <select ng-model="pushData.message.priority">
+              <option value="normal">Normal</option>
+              <option value="high">High</option>
+          </select>
+      </div>
+    </div>
 
     <div class="form-group">
       <label class="col-sm-3 control-label" for="textInput-modal-markup">Variants</label>

--- a/push/model/src/main/java/org/jboss/aerogear/unifiedpush/message/Message.java
+++ b/push/model/src/main/java/org/jboss/aerogear/unifiedpush/message/Message.java
@@ -24,9 +24,14 @@ import org.jboss.aerogear.unifiedpush.message.windows.Windows;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
+import org.codehaus.jackson.map.annotate.JsonDeserialize;
+import org.codehaus.jackson.map.annotate.JsonSerialize;
+import static org.jboss.aerogear.unifiedpush.message.Priority.NORMAL;
+import org.jboss.aerogear.unifiedpush.message.json.PriorityDeserializer;
+import org.jboss.aerogear.unifiedpush.message.json.PrioritySerializer;
 
 /**
- * The message part of the UnifiedPush message.
+ * The message part of the Unifieh message.
  *
  * <p>
  * For details have a look at the <a href="http://aerogear.org/docs/specs/aerogear-push-messages/">Message Format Specification</a>.
@@ -43,6 +48,10 @@ public class Message implements Serializable {
     @JsonProperty("simple-push")
     private String simplePush;
 
+    @JsonSerialize(using=PrioritySerializer.class)
+    @JsonDeserialize(using=PriorityDeserializer.class)
+    private Priority priority = NORMAL;
+    
     private String consolidationKey;
 
     private Windows windows = new Windows();
@@ -160,12 +169,21 @@ public class Message implements Serializable {
         this.windows = windows;
     }
 
+    public Priority getPriority() {
+        return priority;
+    }
+
+    public void setPriority(Priority priority) {
+        this.priority = priority;
+    }
+
     @Override
     public String toString() {
         return "Message{" +
                 ", alert='" + alert + '\'' +
                 ", sound='" + sound + '\'' +
                 ", badge=" + badge +
+                ", priority=" + priority +
                 ", consolidationKey=" + consolidationKey +
                 ", user-data=" + userData +
                 ", simple-push='" + simplePush + '\'' +

--- a/push/model/src/main/java/org/jboss/aerogear/unifiedpush/message/Priority.java
+++ b/push/model/src/main/java/org/jboss/aerogear/unifiedpush/message/Priority.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2016 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.aerogear.unifiedpush.message;
+
+/**
+ * This is a high level priority enum which will be translated to priority
+ * values on GCM, APNs, etc.
+ * 
+ */
+public enum Priority {
+
+    NORMAL, HIGH;
+
+    @Override
+    public String toString() {
+        return this.name().toLowerCase();
+    }
+}

--- a/push/model/src/main/java/org/jboss/aerogear/unifiedpush/message/UnifiedPushMessage.java
+++ b/push/model/src/main/java/org/jboss/aerogear/unifiedpush/message/UnifiedPushMessage.java
@@ -126,6 +126,7 @@ public class UnifiedPushMessage implements Serializable {
         try {
             final HashMap<String, Object> json = new LinkedHashMap<String, Object>();
             json.put("alert", this.message.getAlert());
+            json.put("priority", this.message.getPriority().toString());
             if (this.getMessage().getBadge()>0) {
                 json.put("badge", Integer.toString(this.getMessage().getBadge()));
             }

--- a/push/model/src/main/java/org/jboss/aerogear/unifiedpush/message/json/PriorityDeserializer.java
+++ b/push/model/src/main/java/org/jboss/aerogear/unifiedpush/message/json/PriorityDeserializer.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2016 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.aerogear.unifiedpush.message.json;
+
+import java.io.IOException;
+import org.codehaus.jackson.JsonParser;
+import org.codehaus.jackson.JsonProcessingException;
+import org.codehaus.jackson.map.DeserializationContext;
+import org.codehaus.jackson.map.JsonDeserializer;
+import org.jboss.aerogear.unifiedpush.message.Priority;
+
+/**
+ * Class for deserializing Priority enums.
+ * 
+ * @author Summers Pittman
+ */
+public final class PriorityDeserializer extends JsonDeserializer<Priority> {
+
+    @Override
+    public Priority deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+        return Priority.valueOf(jp.getText().toUpperCase());
+    }
+    
+}

--- a/push/model/src/main/java/org/jboss/aerogear/unifiedpush/message/json/PrioritySerializer.java
+++ b/push/model/src/main/java/org/jboss/aerogear/unifiedpush/message/json/PrioritySerializer.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2016 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.aerogear.unifiedpush.message.json;
+
+import java.io.IOException;
+import org.codehaus.jackson.JsonGenerator;
+import org.codehaus.jackson.JsonProcessingException;
+import org.codehaus.jackson.map.JsonSerializer;
+import org.codehaus.jackson.map.SerializerProvider;
+import org.jboss.aerogear.unifiedpush.message.Priority;
+
+/**
+ * 
+ * Class for serializing Priority enums.
+ * 
+ * @author Summers Pittman
+ */
+public final class PrioritySerializer extends JsonSerializer<Priority> {
+
+    @Override
+    public void serialize(Priority value, JsonGenerator jgen, SerializerProvider provider) throws IOException, JsonProcessingException {
+        jgen.writeString(value.toString());
+    }
+    
+}

--- a/push/model/src/test/java/org/jboss/aerogear/unifiedpush/message/UnifiedPushMessageTest.java
+++ b/push/model/src/test/java/org/jboss/aerogear/unifiedpush/message/UnifiedPushMessageTest.java
@@ -87,6 +87,22 @@ public class UnifiedPushMessageTest {
     }
 
     @Test
+    public void testPriorityMapping() throws IOException {
+        final ObjectMapper mapper = new ObjectMapper();
+        Message message = mapper.readValue(getClass().getResourceAsStream("/message-normal-priority.json"), UnifiedPushMessage.class).getMessage();
+        
+        assertEquals(Priority.NORMAL, message.getPriority());
+    }
+    
+    @Test
+    public void testPriorityEnumHighMapping() throws IOException {
+        final ObjectMapper mapper = new ObjectMapper();        
+        Message message = mapper.readValue(getClass().getResourceAsStream("/message-high-priority.json"), UnifiedPushMessage.class).getMessage();
+        
+        assertEquals(Priority.HIGH, message.getPriority());
+    }
+    
+    @Test
     public void createBroadcastMessage() throws IOException {
 
         final Map<String, Object> container = new LinkedHashMap<String, Object>();

--- a/push/model/src/test/resources/message-format.json
+++ b/push/model/src/test/resources/message-format.json
@@ -4,6 +4,7 @@
     "sound": "default",
     "badge": 2,
     "consolidationKey": null,
+    "priority": "normal",
     "windows": {
       "type": "tile",
       "duration": null,

--- a/push/model/src/test/resources/message-high-priority.json
+++ b/push/model/src/test/resources/message-high-priority.json
@@ -1,0 +1,9 @@
+{
+  "message": {
+    "alert": "HELLO!",
+    "sound": "default",
+    "badge": 2,
+    "consolidationKey": null,
+    "priority": "HIGH"
+  }
+}

--- a/push/model/src/test/resources/message-normal-priority.json
+++ b/push/model/src/test/resources/message-normal-priority.json
@@ -1,0 +1,9 @@
+{
+  "message": {
+    "alert": "HELLO!",
+    "sound": "default",
+    "badge": 2,
+    "consolidationKey": null,
+    "priority": "normal"
+  }
+}

--- a/push/model/src/test/resources/message-tojson.json
+++ b/push/model/src/test/resources/message-tojson.json
@@ -1,5 +1,6 @@
 {
   "alert": "HELLO!",
+  "priority": "normal",
   "badge": "2",
   "criteria": {
     "categories": null,

--- a/push/model/src/test/resources/message-tostrippedjson.json
+++ b/push/model/src/test/resources/message-tostrippedjson.json
@@ -1,5 +1,6 @@
 {
   "alert": "HELLO!",
+  "priority": "normal",
   "badge": "2",
   "criteria": {
     "categories": null,

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/GCMPushNotificationSender.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/GCMPushNotificationSender.java
@@ -81,6 +81,11 @@ public class GCMPushNotificationSender implements PushNotificationSender {
         gcmBuilder.addData("alert", message.getAlert());
         gcmBuilder.addData("sound", message.getSound());
         gcmBuilder.addData("badge", "" + message.getBadge());
+        /*
+        The Message defaults to a Normal priority.  High priority is used
+        by GCM to wake up devices in Doze mode as well as apps in AppStandby 
+        mode.  This has no effect on devices older than Android 6.0
+        */
         gcmBuilder.priority(message.getPriority() ==     Priority.HIGH ? 
                                                          Message.Priority.HIGH :
                                                          Message.Priority.NORMAL

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/GCMPushNotificationSender.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/GCMPushNotificationSender.java
@@ -41,6 +41,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import org.jboss.aerogear.unifiedpush.message.Priority;
 
 @SenderType(VariantType.ANDROID)
 public class GCMPushNotificationSender implements PushNotificationSender {
@@ -80,6 +81,10 @@ public class GCMPushNotificationSender implements PushNotificationSender {
         gcmBuilder.addData("alert", message.getAlert());
         gcmBuilder.addData("sound", message.getSound());
         gcmBuilder.addData("badge", "" + message.getBadge());
+        gcmBuilder.priority(message.getPriority() ==     Priority.HIGH ? 
+                                                         Message.Priority.HIGH :
+                                                         Message.Priority.NORMAL
+                           );
 
         // if present, apply the time-to-live metadata:
         int ttl = pushMessage.getConfig().getTimeToLive();

--- a/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/test/archive/UnifiedPushArchiveImpl.java
+++ b/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/test/archive/UnifiedPushArchiveImpl.java
@@ -23,6 +23,7 @@ import org.jboss.aerogear.unifiedpush.message.Config;
 import org.jboss.aerogear.unifiedpush.message.Criteria;
 import org.jboss.aerogear.unifiedpush.message.InternalUnifiedPushMessage;
 import org.jboss.aerogear.unifiedpush.message.Message;
+import org.jboss.aerogear.unifiedpush.message.Priority;
 import org.jboss.aerogear.unifiedpush.message.UnifiedPushMessage;
 import org.jboss.aerogear.unifiedpush.message.jms.AbstractJMSMessageConsumer;
 import org.jboss.aerogear.unifiedpush.message.jms.AbstractJMSMessageListener;
@@ -98,7 +99,7 @@ public class UnifiedPushArchiveImpl extends UnifiedPushArchiveBase {
 
     @Override
     public UnifiedPushArchive withMessageModel() {
-        return addClasses(UnifiedPushMessage.class, InternalUnifiedPushMessage.class, Config.class, Criteria.class, Message.class)
+        return addClasses(UnifiedPushMessage.class, InternalUnifiedPushMessage.class, Config.class, Criteria.class, Message.class, Priority.class)
                 .addPackage(org.jboss.aerogear.unifiedpush.message.windows.Windows.class.getPackage())
                 .addPackage(org.jboss.aerogear.unifiedpush.message.apns.APNs.class.getPackage())
                 .addMavenDependencies("org.codehaus.jackson:jackson-mapper-asl");


### PR DESCRIPTION
See JIRAs https://issues.jboss.org/browse/AGPUSH-1577 and https://issues.jboss.org/browse/AGPUSH-1576

You should be able to send messages in the push console and set the priority bits in the UI and have them reported to the server and GCM.

This also lays the groundwork for adding priority to iOS.