### PR TITLE
Changing Push Message Type to TEXT instead of VARCHAR

### DIFF
--- a/dist/README.md
+++ b/dist/README.md
@@ -1,10 +1,9 @@
 # AeroGear UnifiedPush Server - Release Bundle
 
 The content of this archive contains:
-* database configuration files and modules for WildFly and JBoss AS7.1.1
-* WAR files for Keycloak and the UnifiedPush Server (for WildFly and JBoss AS7.1.1)
+* database configuration files and modules for WildFly and JBoss EAP 6.x
+* WAR files for Keycloak and the UnifiedPush Server (for WildFly and JBoss EAP 6.x)
 * source JAR files of the UnifiedPush Server for debugging.
 
-
 To learn more about how to configure and install the UnifiedPush Server please visit our user guide:
-http://aerogear.org/docs/unifiedpush/ups_userguide/
+http://aerogear.org/push

--- a/migrator/src/main/resources/liquibase/1.0.0.Final/initial-mysql.xml
+++ b/migrator/src/main/resources/liquibase/1.0.0.Final/initial-mysql.xml
@@ -127,7 +127,7 @@
             <column name="pushApplicationId" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="rawJsonMessage" type="VARCHAR(4500)"/>
+            <column name="rawJsonMessage" type="LONGTEXT"/>
             <column name="submitDate" type="DATETIME"/>
             <column name="totalReceivers" type="BIGINT">
                 <constraints nullable="false"/>

--- a/migrator/src/main/resources/liquibase/1.0.0.Final/initial-pgsql.xml
+++ b/migrator/src/main/resources/liquibase/1.0.0.Final/initial-pgsql.xml
@@ -128,7 +128,7 @@
             <column name="pushapplicationid" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="rawjsonmessage" type="VARCHAR(4500)"/>
+            <column name="rawjsonmessage" type="LONGTEXT"/>
             <column name="submitdate" type="DATETIME"/>
             <column name="totalreceivers" type="BIGINT">
                 <constraints nullable="false"/>

--- a/migrator/src/main/resources/liquibase/1.1.0-Final/2015-07-08-normalize-push-message-information.xml
+++ b/migrator/src/main/resources/liquibase/1.1.0-Final/2015-07-08-normalize-push-message-information.xml
@@ -49,7 +49,7 @@
         <preConditions onFail="MARK_RAN">
             <columnExists tableName="push_message_info" columnName="rawjsonmessage"/>
         </preConditions>
-        <renameColumn tableName="push_message_info" oldColumnName="rawjsonmessage" newColumnName="raw_json_message" columnDataType="LONGTEXT"/>
+        <renameColumn tableName="push_message_info" oldColumnName="rawjsonmessage" newColumnName="raw_json_message" columnDataType="VARCHAR(4500)"/>
     </changeSet>
     <changeSet id="05" author="qmx" dbms="mysql">
         <preConditions onFail="MARK_RAN">

--- a/migrator/src/main/resources/liquibase/1.1.0-Final/2015-07-08-normalize-push-message-information.xml
+++ b/migrator/src/main/resources/liquibase/1.1.0-Final/2015-07-08-normalize-push-message-information.xml
@@ -43,7 +43,7 @@
         <preConditions onFail="MARK_RAN">
             <columnExists tableName="push_message_info" columnName="rawJsonMessage"/>
         </preConditions>
-        <renameColumn tableName="push_message_info" oldColumnName="rawJsonMessage" newColumnName="raw_json_message" columnDataType="LONGTEXT"/>
+        <renameColumn tableName="push_message_info" oldColumnName="rawJsonMessage" newColumnName="raw_json_message" columnDataType="VARCHAR(4500)"/>
     </changeSet>
     <changeSet id="04" author="qmx" dbms="postgresql">
         <preConditions onFail="MARK_RAN">

--- a/migrator/src/main/resources/liquibase/1.1.0-Final/2015-07-08-normalize-push-message-information.xml
+++ b/migrator/src/main/resources/liquibase/1.1.0-Final/2015-07-08-normalize-push-message-information.xml
@@ -43,13 +43,13 @@
         <preConditions onFail="MARK_RAN">
             <columnExists tableName="push_message_info" columnName="rawJsonMessage"/>
         </preConditions>
-        <renameColumn tableName="push_message_info" oldColumnName="rawJsonMessage" newColumnName="raw_json_message" columnDataType="VARCHAR(4500)"/>
+        <renameColumn tableName="push_message_info" oldColumnName="rawJsonMessage" newColumnName="raw_json_message" columnDataType="LONGTEXT"/>
     </changeSet>
     <changeSet id="04" author="qmx" dbms="postgresql">
         <preConditions onFail="MARK_RAN">
             <columnExists tableName="push_message_info" columnName="rawjsonmessage"/>
         </preConditions>
-        <renameColumn tableName="push_message_info" oldColumnName="rawjsonmessage" newColumnName="raw_json_message" columnDataType="VARCHAR(4500)"/>
+        <renameColumn tableName="push_message_info" oldColumnName="rawjsonmessage" newColumnName="raw_json_message" columnDataType="LONGTEXT"/>
     </changeSet>
     <changeSet id="05" author="qmx" dbms="mysql">
         <preConditions onFail="MARK_RAN">

--- a/model/jpa/src/test/java/org/jboss/aerogear/unifiedpush/jpa/PushMessageInformationDaoTest.java
+++ b/model/jpa/src/test/java/org/jboss/aerogear/unifiedpush/jpa/PushMessageInformationDaoTest.java
@@ -257,7 +257,7 @@ public class PushMessageInformationDaoTest {
     public void testLongRawJsonPayload() {
         PushMessageInformation largePushMessageInformation = new PushMessageInformation();
         largePushMessageInformation.setPushApplicationId("231231231");
-        largePushMessageInformation.setRawJsonMessage(TestUtils.longString(4500));
+        largePushMessageInformation.setRawJsonMessage(TestUtils.longString(10000));
         pushMessageInformationDao.create(largePushMessageInformation);
     }
 
@@ -265,7 +265,7 @@ public class PushMessageInformationDaoTest {
     public void testTooLongRawJsonPayload() {
         PushMessageInformation largePushMessageInformation = new PushMessageInformation();
         largePushMessageInformation.setPushApplicationId("231231231");
-        largePushMessageInformation.setRawJsonMessage(TestUtils.longString(4501));
+        largePushMessageInformation.setRawJsonMessage(TestUtils.longString(10000));
         pushMessageInformationDao.create(largePushMessageInformation);
         flushAndClear();
     }

--- a/model/jpa/testData/create_db_content.ddl
+++ b/model/jpa/testData/create_db_content.ddl
@@ -71,7 +71,7 @@ CREATE TABLE push_message_info (
   client_identifier  VARCHAR(255)  DEFAULT NULL,
   ip_address         VARCHAR(255)  DEFAULT NULL,
   push_application_id VARCHAR(255) NOT NULL,
-  raw_json_message    LONGTEXT DEFAULT NULL,
+  raw_json_message    CLOB DEFAULT NULL,
   submit_date        DATE          DEFAULT NULL,
   total_receivers    BIGINT       NOT NULL,
   app_open_counter    BIGINT      DEFAULT 0,

--- a/model/jpa/testData/create_db_content.ddl
+++ b/model/jpa/testData/create_db_content.ddl
@@ -71,7 +71,7 @@ CREATE TABLE push_message_info (
   client_identifier  VARCHAR(255)  DEFAULT NULL,
   ip_address         VARCHAR(255)  DEFAULT NULL,
   push_application_id VARCHAR(255) NOT NULL,
-  raw_json_message    VARCHAR(4500) DEFAULT NULL,
+  raw_json_message    LONGTEXT DEFAULT NULL,
   submit_date        DATE          DEFAULT NULL,
   total_receivers    BIGINT       NOT NULL,
   app_open_counter    BIGINT      DEFAULT 0,


### PR DESCRIPTION
The type VARCHAR that is used in database for sending push messages is not good because it does not support unicode characters and users cannot send messages in some languages to their clients. (For example: Arabic, Persian, Urdu, etc)
The options are using NVARCHAR, TEXT and LONGTEXT.
I changed the database column type to LONGTEXT since I am sending push messages to different users that are found from my own database from multiple queries with a complicated logic.
One of my push messages contained almost 40 million characters, including more than 20k user device tokens.

I also changed hibernate settings to let the database exceed the limit of 4500 characters.

After doing the changes, it both supports unicode characters and long texts.
