### PR TITLE
Adding Manifest metadata, including git hash

### DIFF
--- a/servers/auth-server/pom.xml
+++ b/servers/auth-server/pom.xml
@@ -107,8 +107,33 @@
                 <extensions>false</extensions>
                 <configuration>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
+                    <archive>
+                        <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                        </manifest>
+                        <manifestEntries>
+                            <Implementation-Build>${buildNumber}</Implementation-Build>
+                            <Implementation-Build-Time>${maven.build.timestamp}</Implementation-Build-Time>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
+
+            <!-- To make the current git hash, we use the buildnumber-maven-plugin. -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>buildnumber-maven-plugin</artifactId>
+                <version>1.4</version>
+                <executions>
+                    <execution>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>create</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
             <!-- The JBoss AS plugin deploys your apps to a local JBoss AS container -->
             <!-- To use, set the JBOSS_HOME environment variable and run: mvn package jboss-as:deploy -->
             <plugin>

--- a/servers/ups-as7/pom.xml
+++ b/servers/ups-as7/pom.xml
@@ -94,8 +94,33 @@
                 <extensions>false</extensions>
                 <configuration>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
+                    <archive>
+                        <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                        </manifest>
+                        <manifestEntries>
+                            <Implementation-Build>${buildNumber}</Implementation-Build>
+                            <Implementation-Build-Time>${maven.build.timestamp}</Implementation-Build-Time>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
+
+            <!-- To make the current git hash, we use the buildnumber-maven-plugin. -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>buildnumber-maven-plugin</artifactId>
+                <version>1.4</version>
+                <executions>
+                    <execution>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>create</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
             <!-- The JBoss AS plugin deploys your apps to a local JBoss AS container -->
             <!-- To use, set the JBOSS_HOME environment variable and run: mvn package jboss-as:deploy -->
             <plugin>

--- a/servers/ups-wildfly/pom.xml
+++ b/servers/ups-wildfly/pom.xml
@@ -95,8 +95,33 @@
                 <extensions>false</extensions>
                 <configuration>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
+                    <archive>
+                        <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                        </manifest>
+                        <manifestEntries>
+                            <Implementation-Build>${buildNumber}</Implementation-Build>
+                            <Implementation-Build-Time>${maven.build.timestamp}</Implementation-Build-Time>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
+
+            <!-- To make the current git hash, we use the buildnumber-maven-plugin. -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>buildnumber-maven-plugin</artifactId>
+                <version>1.4</version>
+                <executions>
+                    <execution>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>create</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
             <!-- The JBoss AS plugin deploys your apps to a local JBoss AS container -->
             <!-- To use, set the JBOSS_HOME environment variable and run: mvn package jboss-as:deploy -->
             <plugin>


### PR DESCRIPTION
Done for [AGPUSH-1630](https://issues.jboss.org/browse/AGPUSH-1630).

the WAR will now contain a `MANIFEST.MF`file, which looks like:
```
Manifest-Version: 1.0
Implementation-Vendor: JBoss by Red Hat
Implementation-Title: UnifiedPush Server for Wildfly (WAR)
Implementation-Version: 1.1.3-SNAPSHOT
Implementation-Vendor-Id: org.jboss.aerogear.unifiedpush
Built-By: matzew
Build-Jdk: 1.7.0_65
Created-By: Apache Maven 3.3.9
Implementation-Build-Time: 2016-05-13T10:06:52Z
Implementation-Build: d0fd0d7570117f7809837df8e425507047ab7d56
Archiver-Version: Plexus Archiver
```