### PR TITLE
Fix: squid:S2095, Resources should be closed using try-with-resource

### DIFF
--- a/migrator/src/main/java/org/jboss/aerogear/unifiedpush/migrator/CertificateBlobToBase64.java
+++ b/migrator/src/main/java/org/jboss/aerogear/unifiedpush/migrator/CertificateBlobToBase64.java
@@ -31,6 +31,7 @@ import java.io.InputStream;
 import java.sql.Blob;
 import java.sql.Connection;
 import java.sql.ResultSet;
+import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
@@ -42,11 +43,11 @@ public class CertificateBlobToBase64 implements CustomSqlChange {
     public SqlStatement[] generateStatements(Database database) throws CustomChangeException {
         List<SqlStatement> statements = new ArrayList<>();
 
-        Connection conn = ((JdbcConnection) (database.getConnection())).getWrappedConnection();
+        try(Connection conn = ((JdbcConnection) (database.getConnection())).getWrappedConnection();
+            Statement stmt = conn.createStatement();
+            ResultSet resultSet = stmt.executeQuery("SELECT id, certificate from ios_variant");) {
 
-        try {
             conn.setAutoCommit(false);
-            ResultSet resultSet = conn.createStatement().executeQuery("SELECT id, certificate from ios_variant");
             while (resultSet.next()) {
                 String id = resultSet.getString("id");
                 Blob blob = resultSet.getBlob("certificate");

--- a/migrator/src/main/java/org/jboss/aerogear/unifiedpush/migrator/GetRidOfApiKeysMigration.java
+++ b/migrator/src/main/java/org/jboss/aerogear/unifiedpush/migrator/GetRidOfApiKeysMigration.java
@@ -29,17 +29,17 @@ public class GetRidOfApiKeysMigration implements CustomTaskChange {
 
     @Override
     public void execute(Database database) throws CustomChangeException {
-        Connection conn = ((JdbcConnection) (database.getConnection())).getWrappedConnection();
-        try {
-            conn.setAutoCommit(false);
-            List<InstallationData> list = new ArrayList<>();
-            String query = "select installation.id as installation_id," +
-                    " installation.variant_id as installation_variant_id," +
-                    " variant.id as variant_id," +
-                    " variant.api_key as variant_api_key" +
-                    " from installation join variant on installation.variant_id = variant.api_key";
+        String query = "select installation.id as installation_id," +
+                " installation.variant_id as installation_variant_id," +
+                " variant.id as variant_id," +
+                " variant.api_key as variant_api_key" +
+                " from installation join variant on installation.variant_id = variant.api_key";
+        try(Connection conn = ((JdbcConnection) (database.getConnection())).getWrappedConnection();
             PreparedStatement statement = conn.prepareStatement(query);
-            ResultSet rs = statement.executeQuery();
+            ResultSet rs = statement.executeQuery()) {
+
+            conn.setAutoCommit(false);
+            List<InstallationData> list = new ArrayList<InstallationData>();
             while (rs.next()) {
                 String installationId = rs.getString("installation_id");
                 String installationVariantId = rs.getString("installation_variant_id");


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2095 - “Resources should be closed”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2095

Please let me know if you have any questions.
Ayman Elkfrawy.