### PR TITLE
Fix: squid:S2293, The operator ("<>") should be used.

### DIFF
--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/AbstractBaseEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/AbstractBaseEndpoint.java
@@ -63,7 +63,7 @@ public abstract class AbstractBaseEndpoint {
         // in case of an invalid model, we throw a ConstraintViolationException, containing the violations:
         if (!violations.isEmpty()) {
             throw new ConstraintViolationException(
-                    new HashSet<ConstraintViolation<?>>(violations));
+                    new HashSet<>(violations));
         }
     }
 

--- a/migrator/src/main/java/org/jboss/aerogear/unifiedpush/migrator/CategoriesMigration.java
+++ b/migrator/src/main/java/org/jboss/aerogear/unifiedpush/migrator/CategoriesMigration.java
@@ -72,7 +72,7 @@ public class CategoriesMigration implements CustomTaskChange {
             }
 
             ResultSet rs = conn.createStatement().executeQuery("select distinct categories from Installation_categories");
-            List<String> categories = new ArrayList<String>();
+            List<String> categories = new ArrayList<>();
             while (rs.next()) {
                 String category = rs.getString(1);
                 categories.add(category);

--- a/migrator/src/main/java/org/jboss/aerogear/unifiedpush/migrator/CertificateBlobToBase64.java
+++ b/migrator/src/main/java/org/jboss/aerogear/unifiedpush/migrator/CertificateBlobToBase64.java
@@ -40,7 +40,7 @@ public class CertificateBlobToBase64 implements CustomSqlChange {
 
     @Override
     public SqlStatement[] generateStatements(Database database) throws CustomChangeException {
-        List<SqlStatement> statements = new ArrayList<SqlStatement>();
+        List<SqlStatement> statements = new ArrayList<>();
 
         Connection conn = ((JdbcConnection) (database.getConnection())).getWrappedConnection();
 

--- a/migrator/src/main/java/org/jboss/aerogear/unifiedpush/migrator/GetRidOfApiKeysMigration.java
+++ b/migrator/src/main/java/org/jboss/aerogear/unifiedpush/migrator/GetRidOfApiKeysMigration.java
@@ -32,7 +32,7 @@ public class GetRidOfApiKeysMigration implements CustomTaskChange {
         Connection conn = ((JdbcConnection) (database.getConnection())).getWrappedConnection();
         try {
             conn.setAutoCommit(false);
-            List<InstallationData> list = new ArrayList<InstallationData>();
+            List<InstallationData> list = new ArrayList<>();
             String query = "select installation.id as installation_id," +
                     " installation.variant_id as installation_variant_id," +
                     " variant.id as variant_id," +

--- a/migrator/src/test/java/org/jboss/aerogear/unifiedpush/migrator/EmbeddedMysqlDatabase.java
+++ b/migrator/src/test/java/org/jboss/aerogear/unifiedpush/migrator/EmbeddedMysqlDatabase.java
@@ -38,7 +38,7 @@ public class EmbeddedMysqlDatabase {
         FileUtils.deleteQuietly(baseDir);
         int port = getFreePort();
 
-        Map<String, String> databaseOptions = new HashMap<String, String>();
+        Map<String, String> databaseOptions = new HashMap<>();
         databaseOptions.put(MysqldResourceI.PORT, Integer.toString(port));
 
         mysqldResource = new MysqldResource(baseDir);

--- a/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/PushApplication.java
+++ b/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/PushApplication.java
@@ -47,7 +47,7 @@ public class PushApplication extends BaseModel {
     @Size(min = 1, max = 255)
     private String developer;
 
-    private List<Variant> variants = new ArrayList<Variant>();
+    private List<Variant> variants = new ArrayList<>();
 
     /**
      * The name of the application.

--- a/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/PushMessageInformation.java
+++ b/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/PushMessageInformation.java
@@ -46,7 +46,7 @@ public class PushMessageInformation extends BaseModel {
     private Integer servedVariants = 0;
     private Integer totalVariants = 0;
 
-    private Set<VariantMetricInformation> variantInformations = new HashSet<VariantMetricInformation>();
+    private Set<VariantMetricInformation> variantInformations = new HashSet<>();
 
     /**
      * The raw JSON payload of the push message request

--- a/model/api/src/test/java/org/jboss/aerogear/unifiedpush/api/InstallationTest.java
+++ b/model/api/src/test/java/org/jboss/aerogear/unifiedpush/api/InstallationTest.java
@@ -35,7 +35,7 @@ public class InstallationTest {
 
         deviceInstallation.setDeviceType("iPhone");
         deviceInstallation.setAlias("matzew");
-        final HashSet<Category> categories = new HashSet<Category>();
+        final HashSet<Category> categories = new HashSet<>();
         categories.add(sports);
         categories.add(soccer);
         deviceInstallation.setCategories(categories);

--- a/model/jpa/src/main/java/org/jboss/aerogear/unifiedpush/jpa/dao/impl/JPACategoryDao.java
+++ b/model/jpa/src/main/java/org/jboss/aerogear/unifiedpush/jpa/dao/impl/JPACategoryDao.java
@@ -26,7 +26,7 @@ public class JPACategoryDao extends JPABaseDao<Category, Integer> implements Cat
 
     @Override
     public List<Category> findByNames(List<String> names) {
-        List<Category> categoryList = new ArrayList<Category>();
+        List<Category> categoryList = new ArrayList<>();
         if(!names.isEmpty()){
             categoryList = entityManager.createQuery("select c from Category c where c.name in :names", Category.class)
                     .setParameter("names", names).getResultList();

--- a/model/jpa/src/main/java/org/jboss/aerogear/unifiedpush/jpa/dao/impl/JPAInstallationDao.java
+++ b/model/jpa/src/main/java/org/jboss/aerogear/unifiedpush/jpa/dao/impl/JPAInstallationDao.java
@@ -57,7 +57,7 @@ public class JPAInstallationDao extends JPABaseDao<Installation, String> impleme
 
 
         final StringBuilder jpqlBase = new StringBuilder(FIND_INSTALLATIONS);
-        final Map<String, Object> parameters = new LinkedHashMap<String, Object>();
+        final Map<String, Object> parameters = new LinkedHashMap<>();
         parameters.put("variantID", variantID);
         if (developer != null) {
             jpqlBase.append(" AND v.developer = :developer");
@@ -80,7 +80,7 @@ public class JPAInstallationDao extends JPABaseDao<Installation, String> impleme
         List<Installation> resultList = setParameters(query, parameters).getResultList();
         Long count = setParameters(countQuery, parameters).getSingleResult();
 
-        return new PageResult<Installation, Count>(resultList, new Count(count));
+        return new PageResult<>(resultList, new Count(count));
     }
 
     private <X> TypedQuery<X> setParameters(TypedQuery<X> query, Map<String, Object> parameters) {

--- a/model/jpa/src/main/java/org/jboss/aerogear/unifiedpush/jpa/dao/impl/JPAPushApplicationDao.java
+++ b/model/jpa/src/main/java/org/jboss/aerogear/unifiedpush/jpa/dao/impl/JPAPushApplicationDao.java
@@ -52,7 +52,7 @@ public class JPAPushApplicationDao extends JPABaseDao<PushApplication, String> i
                 .setFirstResult(page * pageSize).setMaxResults(pageSize)
                 .setParameter("developer", loginName).getResultList();
 
-        return new PageResult<PushApplication, Count>(entities, new Count(count));
+        return new PageResult<>(entities, new Count(count));
     }
 
 
@@ -82,7 +82,7 @@ public class JPAPushApplicationDao extends JPABaseDao<PushApplication, String> i
                 + "(select v.variantID from PushApplication pa join pa.variants v where pa.pushApplicationID = :pushApplicationID) "
                 + "group by v.type, v.variantID";
 
-        final HashMap<String, Long> results = new HashMap<String, Long>();
+        final HashMap<String, Long> results = new HashMap<>();
 
         for (VariantType type : VariantType.values()) {
             results.put(type.getTypeName(), 0L);
@@ -129,7 +129,7 @@ public class JPAPushApplicationDao extends JPABaseDao<PushApplication, String> i
         List<PushApplication> entities = entityManager.createQuery("select pa " + select, PushApplication.class)
                 .setFirstResult(page * pageSize).setMaxResults(pageSize).getResultList();
 
-        return new PageResult<PushApplication, Count>(entities, new Count(count));
+        return new PageResult<>(entities, new Count(count));
     }
 
     @Override

--- a/model/jpa/src/main/java/org/jboss/aerogear/unifiedpush/jpa/dao/impl/JPAPushMessageInformationDao.java
+++ b/model/jpa/src/main/java/org/jboss/aerogear/unifiedpush/jpa/dao/impl/JPAPushMessageInformationDao.java
@@ -81,7 +81,7 @@ public class JPAPushMessageInformationDao extends JPABaseDao<PushMessageInformat
         }
         MessageMetrics messageMetrics = (MessageMetrics) metricsQuery.getSingleResult();
 
-        return new PageResult<PushMessageInformation, MessageMetrics>(pushMessageInformationList, messageMetrics);
+        return new PageResult<>(pushMessageInformationList, messageMetrics);
     }
 
     @Override

--- a/model/jpa/src/test/java/org/jboss/aerogear/unifiedpush/jpa/InstallationDaoTest.java
+++ b/model/jpa/src/test/java/org/jboss/aerogear/unifiedpush/jpa/InstallationDaoTest.java
@@ -112,7 +112,7 @@ public class InstallationDaoTest {
         Installation one = installationDao.findInstallationForVariantByDeviceToken(androidVariantID, DEVICE_TOKEN_1);
         assertThat(one.getDeviceToken()).isEqualTo(DEVICE_TOKEN_1);
 
-        final Set<String> tokenz = new HashSet<String>();
+        final Set<String> tokenz = new HashSet<>();
         tokenz.add(DEVICE_TOKEN_1);
         tokenz.add("foobar223");
         List<Installation> list = installationDao.findInstallationsForVariantByDeviceTokens(androidVariantID, tokenz);
@@ -203,7 +203,7 @@ public class InstallationDaoTest {
 
     @Test
     public void findAndDeleteOneInstallation() {
-        final Set<String> tokenz = new HashSet<String>();
+        final Set<String> tokenz = new HashSet<>();
         tokenz.add(DEVICE_TOKEN_1);
         tokenz.add("foobar223");
         List<Installation> list = installationDao.findInstallationsForVariantByDeviceTokens(androidVariantID, tokenz);
@@ -220,7 +220,7 @@ public class InstallationDaoTest {
 
     @Test
     public void findAndDeleteTwoInstallations() {
-        final Set<String> tokenz = new HashSet<String>();
+        final Set<String> tokenz = new HashSet<>();
         tokenz.add(DEVICE_TOKEN_1);
         tokenz.add(DEVICE_TOKEN_2);
         List<Installation> list = installationDao.findInstallationsForVariantByDeviceTokens(androidVariantID, tokenz);
@@ -251,11 +251,11 @@ public class InstallationDaoTest {
 
         final Installation installation = new Installation();
         installation.setDeviceToken("http://test");
-        installation.setCategories(new HashSet<Category>(Arrays.asList(new Category("one"), new Category("two"))));
+        installation.setCategories(new HashSet<>(Arrays.asList(new Category("one"), new Category("two"))));
 
         final Installation installation2 = new Installation();
         installation2.setDeviceToken("http://test2");
-        installation2.setCategories(new HashSet<Category>(Arrays.asList(new Category("one"), new Category("three"))));
+        installation2.setCategories(new HashSet<>(Arrays.asList(new Category("one"), new Category("three"))));
 
         installation.setVariant(variant);
         installation2.setVariant(variant);
@@ -519,7 +519,7 @@ public class InstallationDaoTest {
         android1.setAlias("foo@bar.org");
         android1.setDeviceToken(DEVICE_TOKEN_1);
         android1.setDeviceType("Android Phone");
-        final Set<Category> categoriesOne = new HashSet<Category>();
+        final Set<Category> categoriesOne = new HashSet<>();
         final Category category = entityManager.createQuery("from Category where name = :name", Category.class)
                 .setParameter("name", "soccer").getSingleResult();
         categoriesOne.add(category);
@@ -652,7 +652,7 @@ public class InstallationDaoTest {
     private List<String> findAllDeviceTokenForVariantIDByCriteria(String variantID, List<String> categories, List<String> aliases, List<String> deviceTypes, boolean oldGCM) {
         try {
             ResultsStream<String> tokenStream = installationDao.findAllDeviceTokenForVariantIDByCriteria(variantID, categories, aliases, deviceTypes, Integer.MAX_VALUE, null, oldGCM).executeQuery();
-            List<String> list = new ArrayList<String>();
+            List<String> list = new ArrayList<>();
             while (tokenStream.next()) {
                 list.add(tokenStream.get());
             }

--- a/push/model/src/main/java/org/jboss/aerogear/unifiedpush/message/Message.java
+++ b/push/model/src/main/java/org/jboss/aerogear/unifiedpush/message/Message.java
@@ -43,7 +43,7 @@ public class Message implements Serializable {
     private int badge = -1;
 
     @JsonProperty("user-data")
-    private Map<String, Object> userData = new HashMap<String, Object>();
+    private Map<String, Object> userData = new HashMap<>();
 
     @JsonProperty("simple-push")
     private String simplePush;

--- a/push/model/src/main/java/org/jboss/aerogear/unifiedpush/message/UnifiedPushMessage.java
+++ b/push/model/src/main/java/org/jboss/aerogear/unifiedpush/message/UnifiedPushMessage.java
@@ -124,7 +124,7 @@ public class UnifiedPushMessage implements Serializable {
      */
     public String toStrippedJsonString() {
         try {
-            final HashMap<String, Object> json = new LinkedHashMap<String, Object>();
+            final HashMap<String, Object> json = new LinkedHashMap<>();
             json.put("alert", this.message.getAlert());
             json.put("priority", this.message.getPriority().toString());
             if (this.getMessage().getBadge()>0) {
@@ -150,7 +150,7 @@ public class UnifiedPushMessage implements Serializable {
      */
     public String toMinimizedJsonString() {
         try {
-            final HashMap<String, Object> json = new LinkedHashMap<String, Object>();
+            final HashMap<String, Object> json = new LinkedHashMap<>();
             json.put("alert", this.message.getAlert());
             if (this.getMessage().getBadge()>0) {
                 json.put("badge", Integer.toString(this.getMessage().getBadge()));
@@ -158,7 +158,7 @@ public class UnifiedPushMessage implements Serializable {
             json.put("config", this.config);
 
             // we strip down the criteria too, as alias/category can be quite long, based on use-case
-            final HashMap<String, Object> shrinkedCriteriaJSON = new LinkedHashMap<String, Object>();
+            final HashMap<String, Object> shrinkedCriteriaJSON = new LinkedHashMap<>();
             shrinkedCriteriaJSON.put("variants", this.criteria.getVariants());
             shrinkedCriteriaJSON.put("deviceType", this.criteria.getDeviceTypes());
             json.put("criteria", shrinkedCriteriaJSON);

--- a/push/model/src/main/java/org/jboss/aerogear/unifiedpush/message/windows/Windows.java
+++ b/push/model/src/main/java/org/jboss/aerogear/unifiedpush/message/windows/Windows.java
@@ -32,8 +32,8 @@ public class Windows implements Serializable {
     private BadgeType badge;
     private TileType tileType;
     private ToastType toastType;
-    private List<String> images = new ArrayList<String>();
-    private List<String> textFields = new ArrayList<String>();
+    private List<String> images = new ArrayList<>();
+    private List<String> textFields = new ArrayList<>();
     private String page;
 
     public Type getType() {

--- a/push/model/src/test/java/org/jboss/aerogear/unifiedpush/message/UnifiedPushMessageTest.java
+++ b/push/model/src/test/java/org/jboss/aerogear/unifiedpush/message/UnifiedPushMessageTest.java
@@ -59,7 +59,7 @@ public class UnifiedPushMessageTest {
         message.getWindows().setTileType(TileType.TileWideBlockAndText01);
         message.getApns().setContentAvailable(true);
 
-        final HashMap<String, Object> data = new HashMap<String, Object>();
+        final HashMap<String, Object> data = new HashMap<>();
         data.put("key", "value");
         data.put("key2", "other value");
         message.setUserData(data);
@@ -105,13 +105,13 @@ public class UnifiedPushMessageTest {
     @Test
     public void createBroadcastMessage() throws IOException {
 
-        final Map<String, Object> container = new LinkedHashMap<String, Object>();
-        final Map<String, Object> messageObject = new LinkedHashMap<String, Object>();
+        final Map<String, Object> container = new LinkedHashMap<>();
+        final Map<String, Object> messageObject = new LinkedHashMap<>();
 
         messageObject.put("alert", "Howdy");
         messageObject.put("sound", "default");
         messageObject.put("badge", 2);
-        Map<String, String> data = new HashMap<String, String>();
+        Map<String, String> data = new HashMap<>();
         data.put("someKey", "someValue");
         messageObject.put("user-data", data);
 
@@ -143,13 +143,13 @@ public class UnifiedPushMessageTest {
     @Test
     public void createBroadcastMessageWithSimplePush() throws IOException {
 
-        final Map<String, Object> container = new LinkedHashMap<String, Object>();
-        final Map<String, Object> messageObject = new LinkedHashMap<String, Object>();
+        final Map<String, Object> container = new LinkedHashMap<>();
+        final Map<String, Object> messageObject = new LinkedHashMap<>();
 
         messageObject.put("alert", "Howdy");
         messageObject.put("sound", "default");
         messageObject.put("badge", 2);
-        Map<String, String> data = new HashMap<String, String>();
+        Map<String, String> data = new HashMap<>();
         data.put("someKey", "someValue");
         messageObject.put("user-data", data);
 
@@ -178,13 +178,13 @@ public class UnifiedPushMessageTest {
     @Test(expected = UnrecognizedPropertyException.class)
     public void createBroadcastMessageWithIncorrectSimplePush() throws IOException {
 
-        final Map<String, Object> container = new LinkedHashMap<String, Object>();
-        final Map<String, Object> messageObject = new LinkedHashMap<String, Object>();
+        final Map<String, Object> container = new LinkedHashMap<>();
+        final Map<String, Object> messageObject = new LinkedHashMap<>();
 
         messageObject.put("alert", "Howdy");
         messageObject.put("sound", "default");
         messageObject.put("badge", 2);
-        Map<String, String> data = new HashMap<String, String>();
+        Map<String, String> data = new HashMap<>();
         data.put("someKey", "someValue");
         messageObject.put("user-data", data);
 
@@ -198,12 +198,12 @@ public class UnifiedPushMessageTest {
     @Test
     public void noBadgePayload() throws IOException {
 
-        final Map<String, Object> container = new LinkedHashMap<String, Object>();
-        final Map<String, Object> messageObject = new LinkedHashMap<String, Object>();
+        final Map<String, Object> container = new LinkedHashMap<>();
+        final Map<String, Object> messageObject = new LinkedHashMap<>();
 
         messageObject.put("alert", "Howdy");
         messageObject.put("sound", "default");
-        Map<String, String> data = new HashMap<String, String>();
+        Map<String, String> data = new HashMap<>();
         data.put("someKey", "someValue");
         messageObject.put("user-data", data);
 
@@ -219,14 +219,14 @@ public class UnifiedPushMessageTest {
     @Test
     public void contentAvailable() throws IOException {
 
-        final Map<String, Object> container = new LinkedHashMap<String, Object>();
-        final Map<String, Object> messageObject = new LinkedHashMap<String, Object>();
-        final Map<String, Object> apnsObject = new LinkedHashMap<String, Object>();
+        final Map<String, Object> container = new LinkedHashMap<>();
+        final Map<String, Object> messageObject = new LinkedHashMap<>();
+        final Map<String, Object> apnsObject = new LinkedHashMap<>();
 
         messageObject.put("alert", "Howdy");
         messageObject.put("sound", "default");
 
-        Map<String, String> data = new HashMap<String, String>();
+        Map<String, String> data = new HashMap<>();
         data.put("someKey", "someValue");
         messageObject.put("user-data", data);
 
@@ -245,12 +245,12 @@ public class UnifiedPushMessageTest {
     @Test
     public void noContentAvailable() throws IOException {
 
-        final Map<String, Object> container = new LinkedHashMap<String, Object>();
-        final Map<String, Object> messageObject = new LinkedHashMap<String, Object>();
+        final Map<String, Object> container = new LinkedHashMap<>();
+        final Map<String, Object> messageObject = new LinkedHashMap<>();
 
         messageObject.put("alert", "Howdy");
         messageObject.put("sound", "default");
-        Map<String, String> data = new HashMap<String, String>();
+        Map<String, String> data = new HashMap<>();
         data.put("someKey", "someValue");
         messageObject.put("user-data", data);
 
@@ -266,13 +266,13 @@ public class UnifiedPushMessageTest {
 
     @Test
     public void testAliasCriteria() throws IOException {
-        final Map<String, Object> container = new LinkedHashMap<String, Object>();
-        final Map<String, Object> messageObject = new LinkedHashMap<String, Object>();
+        final Map<String, Object> container = new LinkedHashMap<>();
+        final Map<String, Object> messageObject = new LinkedHashMap<>();
 
         messageObject.put("alert", "Howdy");
         messageObject.put("sound", "default");
         messageObject.put("badge", 2);
-        Map<String, String> data = new HashMap<String, String>();
+        Map<String, String> data = new HashMap<>();
         data.put("someKey", "someValue");
         messageObject.put("user-data", data);
 
@@ -280,7 +280,7 @@ public class UnifiedPushMessageTest {
         messageObject.put("simple-push", "version=123");
 
         // criteria:
-        Map<String, Object> criteria = new HashMap<String, Object>();
+        Map<String, Object> criteria = new HashMap<>();
         criteria.put("alias", Arrays.asList("foo@bar.org"));
         container.put("criteria", criteria);
 
@@ -293,9 +293,9 @@ public class UnifiedPushMessageTest {
 
     @Test
     public void testAction() throws IOException{
-        final Map<String, Object> container = new LinkedHashMap<String, Object>();
-        final Map<String, Object> messageObject = new LinkedHashMap<String, Object>();
-        final Map<String, Object> apnsObject = new LinkedHashMap<String, Object>();
+        final Map<String, Object> container = new LinkedHashMap<>();
+        final Map<String, Object> messageObject = new LinkedHashMap<>();
+        final Map<String, Object> apnsObject = new LinkedHashMap<>();
 
         apnsObject.put("action", "View");
 
@@ -311,9 +311,9 @@ public class UnifiedPushMessageTest {
 
     @Test
     public void testUrlArgs() throws IOException {
-        final Map<String, Object> container = new LinkedHashMap<String, Object>();
-        final Map<String, Object> messageObject = new LinkedHashMap<String, Object>();
-        final Map<String, Object> apnsObject = new LinkedHashMap<String, Object>();
+        final Map<String, Object> container = new LinkedHashMap<>();
+        final Map<String, Object> messageObject = new LinkedHashMap<>();
+        final Map<String, Object> apnsObject = new LinkedHashMap<>();
         final String[] urlArgs = { "Arg1", "Arg2" };
 
         apnsObject.put("title", "I'm a Title");
@@ -330,9 +330,9 @@ public class UnifiedPushMessageTest {
 
     @Test
     public void testActionCategory() throws IOException {
-        final Map<String, Object> container = new LinkedHashMap<String, Object>();
-        final Map<String, Object> messageObject = new LinkedHashMap<String, Object>();
-        final Map<String, Object> apnsObject = new LinkedHashMap<String, Object>();
+        final Map<String, Object> container = new LinkedHashMap<>();
+        final Map<String, Object> messageObject = new LinkedHashMap<>();
+        final Map<String, Object> apnsObject = new LinkedHashMap<>();
 
         apnsObject.put("action-category", "POSTS");
         messageObject.put("alert", "Howdy");
@@ -346,9 +346,9 @@ public class UnifiedPushMessageTest {
 
     @Test
     public void testLocalizedKey() throws IOException {
-        final Map<String, Object> container = new LinkedHashMap<String, Object>();
-        final Map<String, Object> messageObject = new LinkedHashMap<String, Object>();
-        final Map<String, Object> apnsObject = new LinkedHashMap<String, Object>();
+        final Map<String, Object> container = new LinkedHashMap<>();
+        final Map<String, Object> messageObject = new LinkedHashMap<>();
+        final Map<String, Object> apnsObject = new LinkedHashMap<>();
 
         apnsObject.put("localized-key", "myLocalizedKey");
         messageObject.put("alert", "Howdy");
@@ -362,9 +362,9 @@ public class UnifiedPushMessageTest {
 
     @Test
     public void testLocalizedArguments() throws IOException {
-        final Map<String, Object> container = new LinkedHashMap<String, Object>();
-        final Map<String, Object> messageObject = new LinkedHashMap<String, Object>();
-        final Map<String, Object> apnsObject = new LinkedHashMap<String, Object>();
+        final Map<String, Object> container = new LinkedHashMap<>();
+        final Map<String, Object> messageObject = new LinkedHashMap<>();
+        final Map<String, Object> apnsObject = new LinkedHashMap<>();
         String[] arguments = {"Jambon","ham"};
         apnsObject.put("localized-arguments", arguments);
         messageObject.put("alert", "Howdy");
@@ -378,9 +378,9 @@ public class UnifiedPushMessageTest {
 	
     @Test
     public void testLocalizedTitleKey() throws IOException {
-        final Map<String, Object> container = new LinkedHashMap<String, Object>();
-        final Map<String, Object> messageObject = new LinkedHashMap<String, Object>();
-        final Map<String, Object> apnsObject = new LinkedHashMap<String, Object>();
+        final Map<String, Object> container = new LinkedHashMap<>();
+        final Map<String, Object> messageObject = new LinkedHashMap<>();
+        final Map<String, Object> apnsObject = new LinkedHashMap<>();
 
         apnsObject.put("localized-title-key", "myLocalizedTitle");
         messageObject.put("alert", "Howdy");
@@ -394,9 +394,9 @@ public class UnifiedPushMessageTest {
 
     @Test
     public void testLocalizedTitleArguments() throws IOException {
-        final Map<String, Object> container = new LinkedHashMap<String, Object>();
-        final Map<String, Object> messageObject = new LinkedHashMap<String, Object>();
-        final Map<String, Object> apnsObject = new LinkedHashMap<String, Object>();
+        final Map<String, Object> container = new LinkedHashMap<>();
+        final Map<String, Object> messageObject = new LinkedHashMap<>();
+        final Map<String, Object> apnsObject = new LinkedHashMap<>();
         String[] arguments = {"Jambon","ham"};
         apnsObject.put("localized-title-arguments", arguments);
         messageObject.put("alert", "Howdy");
@@ -410,13 +410,13 @@ public class UnifiedPushMessageTest {
 
     @Test
     public void testMultipleAliasCriteria() throws IOException {
-        final Map<String, Object> container = new LinkedHashMap<String, Object>();
-        final Map<String, Object> messageObject = new LinkedHashMap<String, Object>();
+        final Map<String, Object> container = new LinkedHashMap<>();
+        final Map<String, Object> messageObject = new LinkedHashMap<>();
 
         messageObject.put("alert", "Howdy");
         messageObject.put("sound", "default");
         messageObject.put("badge", 2);
-        Map<String, String> data = new HashMap<String, String>();
+        Map<String, String> data = new HashMap<>();
         data.put("someKey", "someValue");
         messageObject.put("user-data", data);
 
@@ -424,7 +424,7 @@ public class UnifiedPushMessageTest {
         messageObject.put("simple-push", "version=123");
 
         // criteria:
-        Map<String, Object> criteria = new HashMap<String, Object>();
+        Map<String, Object> criteria = new HashMap<>();
         criteria.put("alias", Arrays.asList("foo@bar.org", "bar@foo.com"));
         container.put("criteria", criteria);
 
@@ -438,13 +438,13 @@ public class UnifiedPushMessageTest {
 
     @Test
     public void testDeviceTypeCriteria() throws IOException {
-        final Map<String, Object> container = new LinkedHashMap<String, Object>();
-        final Map<String, Object> messageObject = new LinkedHashMap<String, Object>();
+        final Map<String, Object> container = new LinkedHashMap<>();
+        final Map<String, Object> messageObject = new LinkedHashMap<>();
 
         messageObject.put("alert", "Howdy");
         messageObject.put("sound", "default");
         messageObject.put("badge", 2);
-        Map<String, String> data = new HashMap<String, String>();
+        Map<String, String> data = new HashMap<>();
         data.put("someKey", "someValue");
         messageObject.put("user-data", data);
 
@@ -452,7 +452,7 @@ public class UnifiedPushMessageTest {
         messageObject.put("simple-push", "version=123");
 
         // criteria:
-        Map<String, Object> criteria = new HashMap<String, Object>();
+        Map<String, Object> criteria = new HashMap<>();
         criteria.put("deviceType", Arrays.asList("iPad"));
         container.put("criteria", criteria);
 
@@ -465,8 +465,8 @@ public class UnifiedPushMessageTest {
 
     @Test
     public void testDeviceTypesCriteria() throws IOException {
-        final Map<String, Object> container = new LinkedHashMap<String, Object>();
-        final Map<String, Object> messageObject = new LinkedHashMap<String, Object>();
+        final Map<String, Object> container = new LinkedHashMap<>();
+        final Map<String, Object> messageObject = new LinkedHashMap<>();
 
         messageObject.put("alert", "Howdy");
         messageObject.put("sound", "default");
@@ -476,7 +476,7 @@ public class UnifiedPushMessageTest {
         messageObject.put("simple-push", "version=123");
 
         // criteria:
-        Map<String, Object> criteria = new HashMap<String, Object>();
+        Map<String, Object> criteria = new HashMap<>();
         criteria.put("deviceType", Arrays.asList("iPad", "Android"));
         container.put("criteria", criteria);
 
@@ -490,8 +490,8 @@ public class UnifiedPushMessageTest {
 
     @Test
     public void testCategoriesCriteria() throws IOException {
-        final Map<String, Object> container = new LinkedHashMap<String, Object>();
-        final Map<String, Object> messageObject = new LinkedHashMap<String, Object>();
+        final Map<String, Object> container = new LinkedHashMap<>();
+        final Map<String, Object> messageObject = new LinkedHashMap<>();
 
         messageObject.put("alert", "Howdy");
         messageObject.put("sound", "default");
@@ -500,7 +500,7 @@ public class UnifiedPushMessageTest {
         container.put("message", messageObject);
 
         // criteria:
-        Map<String, Object> criteria = new HashMap<String, Object>();
+        Map<String, Object> criteria = new HashMap<>();
         criteria.put("categories", Arrays.asList("football"));
         container.put("criteria", criteria);
 
@@ -513,8 +513,8 @@ public class UnifiedPushMessageTest {
 
     @Test
     public void testMultipleCategoriesCriteria() throws IOException {
-        final Map<String, Object> container = new LinkedHashMap<String, Object>();
-        final Map<String, Object> messageObject = new LinkedHashMap<String, Object>();
+        final Map<String, Object> container = new LinkedHashMap<>();
+        final Map<String, Object> messageObject = new LinkedHashMap<>();
 
         messageObject.put("alert", "Howdy");
         messageObject.put("sound", "default");
@@ -523,7 +523,7 @@ public class UnifiedPushMessageTest {
         container.put("message", messageObject);
 
         // criteria:
-        Map<String, Object> criteria = new HashMap<String, Object>();
+        Map<String, Object> criteria = new HashMap<>();
         criteria.put("categories", Arrays.asList("soccer", "olympics"));
         container.put("criteria", criteria);
 
@@ -537,8 +537,8 @@ public class UnifiedPushMessageTest {
 
     @Test
     public void testVariantsCriteria() throws IOException {
-        final Map<String, Object> container = new LinkedHashMap<String, Object>();
-        final Map<String, Object> messageObject = new LinkedHashMap<String, Object>();
+        final Map<String, Object> container = new LinkedHashMap<>();
+        final Map<String, Object> messageObject = new LinkedHashMap<>();
 
         messageObject.put("alert", "Howdy");
         messageObject.put("sound", "default");
@@ -547,7 +547,7 @@ public class UnifiedPushMessageTest {
         container.put("message", messageObject);
 
         // criteria:
-        Map<String, Object> criteria = new HashMap<String, Object>();
+        Map<String, Object> criteria = new HashMap<>();
         criteria.put("variants", Arrays.asList("abc-123-def-456"));
         container.put("criteria", criteria);
 
@@ -560,8 +560,8 @@ public class UnifiedPushMessageTest {
 
     @Test
     public void testMultipleVariantsCriteria() throws IOException {
-        final Map<String, Object> container = new LinkedHashMap<String, Object>();
-        final Map<String, Object> messageObject = new LinkedHashMap<String, Object>();
+        final Map<String, Object> container = new LinkedHashMap<>();
+        final Map<String, Object> messageObject = new LinkedHashMap<>();
 
         messageObject.put("alert", "Howdy");
         messageObject.put("sound", "default");
@@ -570,7 +570,7 @@ public class UnifiedPushMessageTest {
         container.put("message", messageObject);
 
         // criteria:
-        Map<String, Object> criteria = new HashMap<String, Object>();
+        Map<String, Object> criteria = new HashMap<>();
         criteria.put("variants", Arrays.asList("abc-123-def-456", "456-abc-123-def-bar"));
         container.put("criteria", criteria);
 
@@ -584,13 +584,13 @@ public class UnifiedPushMessageTest {
 
     @Test
     public void testAllCriteria() throws IOException {
-        final Map<String, Object> container = new LinkedHashMap<String, Object>();
-        final Map<String, Object> messageObject = new LinkedHashMap<String, Object>();
+        final Map<String, Object> container = new LinkedHashMap<>();
+        final Map<String, Object> messageObject = new LinkedHashMap<>();
 
         messageObject.put("alert", "Howdy");
         messageObject.put("sound", "default");
         messageObject.put("badge", 2);
-        Map<String, String> data = new HashMap<String, String>();
+        Map<String, String> data = new HashMap<>();
         data.put("someKey", "someValue");
         messageObject.put("user-data", data);
 
@@ -598,7 +598,7 @@ public class UnifiedPushMessageTest {
         messageObject.put("simple-push", "version=123");
 
         // criteria:
-        Map<String, Object> criteria = new HashMap<String, Object>();
+        Map<String, Object> criteria = new HashMap<>();
         criteria.put("variants", Arrays.asList("abc-123-def-456", "456-abc-123-def-bar"));
         criteria.put("categories", Arrays.asList("soccer", "olympics"));
         criteria.put("deviceType", Arrays.asList("iPad", "Android"));
@@ -628,8 +628,8 @@ public class UnifiedPushMessageTest {
 
     @Test(expected = JsonMappingException.class)
     public void testVariantCriteriaParseError() throws IOException {
-        final Map<String, Object> container = new LinkedHashMap<String, Object>();
-        Map<String, Object> criteria = new HashMap<String, Object>();
+        final Map<String, Object> container = new LinkedHashMap<>();
+        Map<String, Object> criteria = new HashMap<>();
         criteria.put("variants", "abc-123-def-456");
         container.put("criteria", criteria);
         parsePushMessage(container);
@@ -638,21 +638,21 @@ public class UnifiedPushMessageTest {
     @Test
     public void testMessageToStrippedJson() throws IOException, URISyntaxException {
         //given
-        final Map<String, Object> container = new LinkedHashMap<String, Object>();
-        final Map<String, Object> messageObject = new LinkedHashMap<String, Object>();
-        final Map<String, Object> apnsObject = new LinkedHashMap<String, Object>();
+        final Map<String, Object> container = new LinkedHashMap<>();
+        final Map<String, Object> messageObject = new LinkedHashMap<>();
+        final Map<String, Object> apnsObject = new LinkedHashMap<>();
 
         messageObject.put("alert", "HELLO!");
         messageObject.put("sound", "default");
         messageObject.put("badge", 2);
-        Map<String, Object> data = new HashMap<String, Object>();
+        Map<String, Object> data = new HashMap<>();
         data.put("key", "value");
         data.put("key2", "value");
         messageObject.put("user-data", data);
         apnsObject.put("action-category", "category");
         apnsObject.put("content-available", "true");
         messageObject.put("simple-push", "version=123");
-        Map<String, Object> windows = new HashMap<String, Object>();
+        Map<String, Object> windows = new HashMap<>();
         windows.put("type", "tile");
         windows.put("tileType", "TileWideBlockAndText01");
         windows.put("page", "cordova");
@@ -675,21 +675,21 @@ public class UnifiedPushMessageTest {
     @Test
     public void testMessageToJson() throws IOException, URISyntaxException {
         //given
-        final Map<String, Object> container = new LinkedHashMap<String, Object>();
-        final Map<String, Object> messageObject = new LinkedHashMap<String, Object>();
-        final Map<String, Object> apnsObject = new LinkedHashMap<String, Object>();
+        final Map<String, Object> container = new LinkedHashMap<>();
+        final Map<String, Object> messageObject = new LinkedHashMap<>();
+        final Map<String, Object> apnsObject = new LinkedHashMap<>();
 
         messageObject.put("alert", "HELLO!");
         messageObject.put("sound", "default");
         messageObject.put("badge", 2);
-        Map<String, Object> data = new HashMap<String, Object>();
+        Map<String, Object> data = new HashMap<>();
         data.put("key", "value");
         data.put("key2", "value");
         messageObject.put("user-data", data);
         apnsObject.put("action-category", "category");
         apnsObject.put("content-available", "true");
         messageObject.put("simple-push", "version=123");
-        Map<String, Object> windows = new HashMap<String, Object>();
+        Map<String, Object> windows = new HashMap<>();
         windows.put("type", "tile");
         windows.put("tileType", "TileWideBlockAndText01");
         windows.put("page", "cordova");

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/holder/MessageHolderWithVariants.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/holder/MessageHolderWithVariants.java
@@ -71,7 +71,7 @@ public class MessageHolderWithVariants extends AbstractMessageHolder implements 
     public MessageHolderWithVariants(PushMessageInformation pushMessageInformation, UnifiedPushMessage unifiedPushMessage, VariantType variantType, Collection<Variant> variants, int lastSerialId, String lastTokenFromPreviousBatch) {
         super(pushMessageInformation, unifiedPushMessage);
         this.variantType = variantType;
-        this.variants = new ArrayList<Variant>(variants);
+        this.variants = new ArrayList<>(variants);
         this.lastSerialId = lastSerialId;
         this.lastTokenFromPreviousBatch = lastTokenFromPreviousBatch;
     }

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/jms/MetricCollectionTrigger.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/jms/MetricCollectionTrigger.java
@@ -50,7 +50,7 @@ public class MetricCollectionTrigger {
     /**
      * Stores pushMessageInformationIds for the push messages that the metrics collection process was already started for
      */
-    private static final Set<String> METRICS_PROCESSING_STARTED_FOR_IDS = Collections.newSetFromMap(new ConcurrentHashMap<String, Boolean>());
+    private static final Set<String> METRICS_PROCESSING_STARTED_FOR_IDS = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
     @Inject @DispatchToQueue
     private Event<MetricsProcessingStartedEvent> broadcastMetricsProcessingStarted;

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/FCMPushNotificationSender.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/FCMPushNotificationSender.java
@@ -48,7 +48,7 @@ public class FCMPushNotificationSender implements PushNotificationSender {
     // collection of error codes we check for in the FCM response
     // in order to clean-up invalid or incorrect device tokens
     private static final Set<String> FCM_ERROR_CODES =
-            new HashSet<String>(Arrays.asList(
+            new HashSet<>(Arrays.asList(
                     Constants.ERROR_INVALID_REGISTRATION,  // Bad registration_id.
                     Constants.ERROR_NOT_REGISTERED,        // The user has uninstalled the application or turned off notifications.
                     Constants.ERROR_MISMATCH_SENDER_ID)    // incorrect token, from a different project/sender ID
@@ -71,7 +71,7 @@ public class FCMPushNotificationSender implements PushNotificationSender {
             return;
         }
 
-        final List<String> pushTargets = new ArrayList<String>(tokens);
+        final List<String> pushTargets = new ArrayList<>(tokens);
         final AndroidVariant androidVariant = (AndroidVariant) variant;
 
         // payload builder:
@@ -172,7 +172,7 @@ public class FCMPushNotificationSender implements PushNotificationSender {
         final List<Result> results = multicastResult.getResults();
 
         // storage for all the invalid registration IDs:
-        final Set<String> inactiveTokens = new HashSet<String>();
+        final Set<String> inactiveTokens = new HashSet<>();
 
         // read the results:
         for (int i = 0; i < results.size(); i++) {

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/WNSPushNotificationSender.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/WNSPushNotificationSender.java
@@ -65,8 +65,8 @@ public class WNSPushNotificationSender implements PushNotificationSender {
         final WindowsWNSVariant windowsVariant = (WindowsWNSVariant) variant;
         WnsService wnsService = new WnsService(windowsVariant.getSid(), windowsVariant.getClientSecret(), false);
 
-        Set<String> expiredClientIdentifiers = new HashSet<String>(clientIdentifiers.size());
-        ArrayList<String> channelUris = new ArrayList<String>(clientIdentifiers);
+        Set<String> expiredClientIdentifiers = new HashSet<>(clientIdentifiers.size());
+        ArrayList<String> channelUris = new ArrayList<>(clientIdentifiers);
         Message message = pushMessage.getMessage();
         try {
         	WnsNotificationRequestOptional optional = new WnsNotificationRequestOptional();
@@ -150,7 +150,7 @@ public class WNSPushNotificationSender implements PushNotificationSender {
 
     private void createMessage(Message message, String type, WnsAbstractBuilder builder) {
         Windows windows = message.getWindows();
-        List<String> param = new ArrayList<String>(windows.getImages());
+        List<String> param = new ArrayList<>(windows.getImages());
         param.add(message.getAlert());
         param.addAll(windows.getTextFields());
 

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/serviceHolder/AbstractServiceHolder.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/serviceHolder/AbstractServiceHolder.java
@@ -37,7 +37,7 @@ import org.jboss.aerogear.unifiedpush.message.util.JmsClient;
  */
 public abstract class AbstractServiceHolder<T> {
 
-    private final ConcurrentHashMap<Key, ConcurrentLinkedQueue<DisposableReference<T>>> queueMap = new ConcurrentHashMap<Key, ConcurrentLinkedQueue<DisposableReference<T>>>();
+    private final ConcurrentHashMap<Key, ConcurrentLinkedQueue<DisposableReference<T>>> queueMap = new ConcurrentHashMap<>();
 
     private final int instanceLimit;
     private final long instanceAcquiringTimeoutInMillis;
@@ -151,7 +151,7 @@ public abstract class AbstractServiceHolder<T> {
                 returnServiceSlotToQueue(pushMessageInformationId, variantID);
             };
         };
-        DisposableReference<T> disposableReference = new DisposableReference<T>(service, destroyAndReturnServiceSlot);
+        DisposableReference<T> disposableReference = new DisposableReference<>(service, destroyAndReturnServiceSlot);
         serviceDisposalScheduler.scheduleForDisposal(disposableReference, serviceDisposalDelayInMillis);
         getCache(pushMessageInformationId, variantID).add(disposableReference);
     }
@@ -183,7 +183,7 @@ public abstract class AbstractServiceHolder<T> {
     private ConcurrentLinkedQueue<DisposableReference<T>> getOrCreateQueue(Key key) {
         ConcurrentLinkedQueue<DisposableReference<T>> queue = queueMap.get(key);
         if (queue == null) {
-            queue = queueMap.putIfAbsent(key, new ConcurrentLinkedQueue<DisposableReference<T>>());
+            queue = queueMap.putIfAbsent(key, new ConcurrentLinkedQueue<>());
             queue = queueMap.get(key);
         }
         return queue;

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/serviceHolder/DisposableReference.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/serviceHolder/DisposableReference.java
@@ -37,7 +37,7 @@ public class DisposableReference<T> {
      * @param destroyer the service destroyer
      */
     public DisposableReference(T instance, ServiceDestroyer<T> destroyer) {
-        this.reference = new AtomicReference<T>(instance);
+        this.reference = new AtomicReference<>(instance);
         this.destroyer = destroyer;
     }
 

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/util/HealthNetworkServiceImpl.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/util/HealthNetworkServiceImpl.java
@@ -47,7 +47,7 @@ public class HealthNetworkServiceImpl implements HealthNetworkService {
 
     private static final String GCM_SEND_ENDPOINT = Constants.GCM_SEND_ENDPOINT.substring("https://".length(), Constants.GCM_SEND_ENDPOINT.indexOf('/', "https://".length()));
     public static final String WNS_SEND_ENDPOINT = "db3.notify.windows.com";
-    private static final List<PushNetwork> PUSH_NETWORKS = new ArrayList<PushNetwork>(Arrays.asList(
+    private static final List<PushNetwork> PUSH_NETWORKS = new ArrayList<>(Arrays.asList(
             new PushNetwork[]{
                     new PushNetwork("Google Cloud Messaging", GCM_SEND_ENDPOINT, 443),
                     new PushNetwork("Apple Push Network Sandbox", Utilities.SANDBOX_GATEWAY_HOST, Utilities.SANDBOX_GATEWAY_PORT),

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/util/JmsClient.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/util/JmsClient.java
@@ -212,7 +212,7 @@ public class JmsClient {
 
         private Serializable message;
         private boolean transacted = false;
-        private Map<String, Object> properties = new LinkedHashMap<String, Object>();
+        private Map<String, Object> properties = new LinkedHashMap<>();
         private int autoAcknowledgeMode = Session.AUTO_ACKNOWLEDGE;
 
         public JmsSender(Serializable message) {

--- a/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/message/TestNotificationRouter.java
+++ b/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/message/TestNotificationRouter.java
@@ -150,7 +150,7 @@ public class TestNotificationRouter {
 
     @RequestScoped
     public static class VariantTypesHolder {
-        private Set<VariantType> variantTypes = new HashSet<VariantType>();
+        private Set<VariantType> variantTypes = new HashSet<>();
 
         public void addVariantType(VariantType variantType) {
             this.variantTypes.add(variantType);
@@ -161,7 +161,7 @@ public class TestNotificationRouter {
     }
 
     private Set<VariantType> variants(VariantType... types) {
-        return new HashSet<VariantType>(Arrays.asList(types));
+        return new HashSet<>(Arrays.asList(types));
     }
 
 

--- a/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/message/jms/TestMessageHolderWithTokens.java
+++ b/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/message/jms/TestMessageHolderWithTokens.java
@@ -67,7 +67,7 @@ public class TestMessageHolderWithTokens {
     public void setUp() {
         information = new PushMessageInformation();
         message = new UnifiedPushMessage();
-        deviceTokens = new ArrayList<String>();
+        deviceTokens = new ArrayList<>();
         delivered = new CountDownLatch(5);
     }
 

--- a/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/message/jms/TestMessageRedelivery.java
+++ b/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/message/jms/TestMessageRedelivery.java
@@ -81,7 +81,7 @@ public class TestMessageRedelivery {
     public void setUp() {
         information = new PushMessageInformation();
         message = new UnifiedPushMessage();
-        deviceTokens = new ArrayList<String>();
+        deviceTokens = new ArrayList<>();
     }
 
     @Test

--- a/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/message/jms/TestTriggerMetricCollectionDeduplication.java
+++ b/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/message/jms/TestTriggerMetricCollectionDeduplication.java
@@ -56,7 +56,7 @@ public class TestTriggerMetricCollectionDeduplication extends AbstractJMSTest {
     @Resource(mappedName = "java:/queue/TriggerMetricCollectionQueue")
     private Queue triggerMetricCollectionQueue;
 
-    private static final ConcurrentLinkedQueue<TriggerMetricCollectionEvent> receivedTriggers = new ConcurrentLinkedQueue<TriggerMetricCollectionEvent>();
+    private static final ConcurrentLinkedQueue<TriggerMetricCollectionEvent> receivedTriggers = new ConcurrentLinkedQueue<>();
     private static final CountDownLatch firstMessageLatch = new CountDownLatch(1);
     private static String messageId;
 

--- a/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/message/sender/WNSPushNotificationSenderTest.java
+++ b/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/message/sender/WNSPushNotificationSenderTest.java
@@ -34,7 +34,7 @@ public class WNSPushNotificationSenderTest {
     public void shouldWorkWithEmptyNullUserData() {
         //given
         Message message = getUnifiedPushMessage();
-        message.setUserData(new HashMap<String, Object>());
+        message.setUserData(new HashMap<>());
 
         //when
         WnsToast toastMessage = sender.createSimpleToastMessage(message);
@@ -121,7 +121,7 @@ public class WNSPushNotificationSenderTest {
 
     private Message getUnifiedPushMessage() {
         Message message = new Message();
-        Map<String, Object> data = new HashMap<String, Object>();
+        Map<String, Object> data = new HashMap<>();
         data.put("key", "value");
         data.put("ke2", "value2");
         message.getWindows().setPage("/Root.xaml");

--- a/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/message/serviceHolder/TestAbstractServiceHolder.java
+++ b/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/message/serviceHolder/TestAbstractServiceHolder.java
@@ -33,14 +33,14 @@ public class TestAbstractServiceHolder {
 
     @Test
     public void test_that_get_nulls_the_reference() throws InterruptedException {
-        DisposableReference<Object> disposableReference = new DisposableReference<Object>(instance, mockDestroyer);
+        DisposableReference<Object> disposableReference = new DisposableReference<>(instance, mockDestroyer);
         assertEquals(instance, disposableReference.get());
         assertNull(disposableReference.get());;
     }
 
     @Test
     public void test_that_disposal_nulls_the_reference() throws InterruptedException {
-        DisposableReference<Object> disposableReference = new DisposableReference<Object>(instance, mockDestroyer);
+        DisposableReference<Object> disposableReference = new DisposableReference<>(instance, mockDestroyer);
         disposableReference.dispose();
         assertNull(disposableReference.get());;
     }
@@ -53,7 +53,7 @@ public class TestAbstractServiceHolder {
                 latch.countDown();
             };
         };
-        DisposableReference<Object> disposableReference = new DisposableReference<Object>(instance, serviceDestroyer);
+        DisposableReference<Object> disposableReference = new DisposableReference<>(instance, serviceDestroyer);
         scheduler.scheduleForDisposal(disposableReference, 1000);
         latch.await();
         assertNull(disposableReference.get());
@@ -69,7 +69,7 @@ public class TestAbstractServiceHolder {
             };
         };
         for (int i = 0; i < numberOfInstances; i++) {
-            scheduler.scheduleForDisposal(new DisposableReference<Object>(instance, serviceDestroyer), 1000);
+            scheduler.scheduleForDisposal(new DisposableReference<>(instance, serviceDestroyer), 1000);
         }
         latch.await();
     }
@@ -84,7 +84,7 @@ public class TestAbstractServiceHolder {
             };
         };
         for (int i = 0; i < numberOfInstances; i++) {
-            scheduler.scheduleForDisposal(new DisposableReference<Object>(instance, serviceDestroyer), 100); // delay  is lesser than termination timeout
+            scheduler.scheduleForDisposal(new DisposableReference<>(instance, serviceDestroyer), 100); // delay  is lesser than termination timeout
         }
         scheduler.terminate();
         assertEquals("all instances should be terminated gracefully", numberOfInstances, numberOfInstancesTerminatedGracefully.get());

--- a/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/message/serviceHolder/TestAbstractServiceHolderClustered.java
+++ b/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/message/serviceHolder/TestAbstractServiceHolderClustered.java
@@ -141,7 +141,7 @@ public class TestAbstractServiceHolderClustered {
     @Test @OperateOnDeployment("war-2") @InSequence(5)
     public void testReturnAndLease() throws InterruptedException {
         returnServiceSlot(5);
-        Set<Integer> leased = new HashSet<Integer>(Arrays.asList(borrowServiceSlot(), borrowServiceSlot()));
+        Set<Integer> leased = new HashSet<>(Arrays.asList(borrowServiceSlot(), borrowServiceSlot()));
         assertTrue("leased tokens should contain 1", leased.contains(1));
         assertTrue("leased tokens should contain 5", leased.contains(5));
         assertEquals("the borrow operation should fail when no slots are available", 0, borrowServiceSlot());

--- a/service/src/main/java/org/jboss/aerogear/unifiedpush/service/impl/HealthServiceImpl.java
+++ b/service/src/main/java/org/jboss/aerogear/unifiedpush/service/impl/HealthServiceImpl.java
@@ -47,6 +47,6 @@ public class HealthServiceImpl implements HealthDBService {
             details.setResult(e.getMessage());
         }
         details.stop();
-        return new AsyncResult<HealthDetails>(details);
+        return new AsyncResult<>(details);
     }
 }

--- a/service/src/main/java/org/jboss/aerogear/unifiedpush/service/impl/health/HealthStatus.java
+++ b/service/src/main/java/org/jboss/aerogear/unifiedpush/service/impl/health/HealthStatus.java
@@ -28,7 +28,7 @@ public class HealthStatus {
     private static final String ERROR_MESSAGE = "There are %d errors found";
 
     private Status status = Status.OK;
-    private List<HealthDetails> details = new ArrayList<HealthDetails>();
+    private List<HealthDetails> details = new ArrayList<>();
 
     public void add(HealthDetails healthDetails) {
         if (status.ordinal() < healthDetails.getTestStatus().ordinal()) {

--- a/service/src/main/java/org/jboss/aerogear/unifiedpush/service/util/FCMTopicManager.java
+++ b/service/src/main/java/org/jboss/aerogear/unifiedpush/service/util/FCMTopicManager.java
@@ -58,7 +58,7 @@ public class FCMTopicManager {
             deviceInfo = get(url);
         } catch (IOException e) {
             logger.debug("Couldn't get list of subscribed topics from Instance ID service.");
-            return new HashSet<String>(0);
+            return new HashSet<>(0);
         }
         JSONParser parser = new JSONParser();
         JSONObject info;
@@ -66,7 +66,7 @@ public class FCMTopicManager {
             info = (JSONObject) parser.parse(deviceInfo);
         } catch (ParseException e) {
             logger.debug("Couldn't parse list of subscribed topics from Instance ID service.");
-            return new HashSet<String>(0);
+            return new HashSet<>(0);
         }
         JSONObject rel = (JSONObject) info.get("rel");
         JSONObject topics = (JSONObject) rel.get("topics");

--- a/service/src/test/java/org/jboss/aerogear/unifiedpush/service/ClientInstallationServiceTest.java
+++ b/service/src/test/java/org/jboss/aerogear/unifiedpush/service/ClientInstallationServiceTest.java
@@ -102,7 +102,7 @@ public class ClientInstallationServiceTest extends AbstractBaseServiceTest {
         Installation device = new Installation();
         String deviceToken = generateFakedDeviceTokenString().toUpperCase();
         device.setDeviceToken(deviceToken);
-        final Set<Category> categories = new HashSet<Category>(Arrays.asList(new Category("football"), new Category("football")));
+        final Set<Category> categories = new HashSet<>(Arrays.asList(new Category("football"), new Category("football")));
         device.setCategories(categories);
         clientInstallationService.addInstallation(androidVariant, device);
 
@@ -115,7 +115,7 @@ public class ClientInstallationServiceTest extends AbstractBaseServiceTest {
         String deviceToken = generateFakedDeviceTokenString();
         device.setDeviceToken(deviceToken);
 
-        Set<Category> categories = new HashSet<Category>(Arrays.asList(new Category("football"), new Category("soccer")));
+        Set<Category> categories = new HashSet<>(Arrays.asList(new Category("football"), new Category("soccer")));
         device.setCategories(categories);
 
         device.setVariant(androidVariant);
@@ -127,7 +127,7 @@ public class ClientInstallationServiceTest extends AbstractBaseServiceTest {
         device = new Installation();
         deviceToken = generateFakedDeviceTokenString().toUpperCase();
         device.setDeviceToken(deviceToken);
-        categories = new HashSet<Category>(Arrays.asList(new Category("lame"), new Category("football")));
+        categories = new HashSet<>(Arrays.asList(new Category("lame"), new Category("football")));
         device.setCategories(categories);
         clientInstallationService.addInstallation(androidVariant, device);
         assertThat(clientInstallationService.findInstallationForVariantByDeviceToken(androidVariant.getVariantID(),deviceToken).getCategories()).hasSize(2);
@@ -145,7 +145,7 @@ public class ClientInstallationServiceTest extends AbstractBaseServiceTest {
         String deviceToken = generateFakedDeviceTokenString();
         device.setDeviceToken(deviceToken);
 
-        Set<Category> categories = new HashSet<Category>(Arrays.asList(new Category("football"), new Category("soccer")));
+        Set<Category> categories = new HashSet<>(Arrays.asList(new Category("football"), new Category("soccer")));
         device.setCategories(categories);
 
         device.setVariant(androidVariant);
@@ -156,7 +156,7 @@ public class ClientInstallationServiceTest extends AbstractBaseServiceTest {
         // same device, with slightly different metadata
         device = new Installation();
         device.setDeviceToken(deviceToken);
-        categories = new HashSet<Category>(Arrays.asList(new Category("football")));
+        categories = new HashSet<>(Arrays.asList(new Category("football")));
         device.setCategories(categories);
         clientInstallationService.addInstallation(androidVariant, device);
         assertThat(clientInstallationService.findInstallationForVariantByDeviceToken(androidVariant.getVariantID(),deviceToken).getCategories()).hasSize(1);
@@ -181,7 +181,7 @@ public class ClientInstallationServiceTest extends AbstractBaseServiceTest {
 
         device = new Installation();
         device.setDeviceToken(deviceToken);
-        final Set<Category> categories = new HashSet<Category>(Arrays.asList(new Category("football"), new Category("football")));
+        final Set<Category> categories = new HashSet<>(Arrays.asList(new Category("football"), new Category("football")));
         device.setCategories(categories);
 
         clientInstallationService.addInstallation(androidVariant, device);
@@ -213,7 +213,7 @@ public class ClientInstallationServiceTest extends AbstractBaseServiceTest {
 
         // generate some devices with token:
         final int NUMBER_OF_INSTALLATIONS = 5;
-        final List<Installation> devices = new ArrayList<Installation>();
+        final List<Installation> devices = new ArrayList<>();
         for (int i = 0; i < NUMBER_OF_INSTALLATIONS; i++) {
             Installation device = new Installation();
             device.setDeviceToken(generateFakedDeviceTokenString());
@@ -266,7 +266,7 @@ public class ClientInstallationServiceTest extends AbstractBaseServiceTest {
 
         // generate some devices:
         final int NUMBER_OF_INSTALLATIONS = 5;
-        final List<Installation> devices = new ArrayList<Installation>();
+        final List<Installation> devices = new ArrayList<>();
         for (int i = 0; i < NUMBER_OF_INSTALLATIONS; i++) {
             Installation device = new Installation();
             device.setDeviceToken(generateFakedDeviceTokenString());
@@ -291,7 +291,7 @@ public class ClientInstallationServiceTest extends AbstractBaseServiceTest {
 
         // generate some devices:
         final int NUMBER_OF_INSTALLATIONS = 100000;
-        final List<Installation> devices = new ArrayList<Installation>();
+        final List<Installation> devices = new ArrayList<>();
         for (int i = 0; i < NUMBER_OF_INSTALLATIONS; i++) {
             Installation device = new Installation();
             device.setDeviceToken(generateFakedDeviceTokenString());
@@ -310,7 +310,7 @@ public class ClientInstallationServiceTest extends AbstractBaseServiceTest {
         String deviceToken = generateFakedDeviceTokenString();
         device.setDeviceToken(deviceToken);
 
-        final Set<Category> categories = new HashSet<Category>(Arrays.asList(new Category("football"), new Category("soccer")));
+        final Set<Category> categories = new HashSet<>(Arrays.asList(new Category("football"), new Category("soccer")));
         device.setCategories(categories);
 
         device.setVariant(androidVariant);
@@ -328,7 +328,7 @@ public class ClientInstallationServiceTest extends AbstractBaseServiceTest {
         device.setDeviceToken(deviceToken);
         device.setAlias("root");
 
-        final Set<Category> categories = new HashSet<Category>(Arrays.asList(new Category("football"), new Category("soccer")));
+        final Set<Category> categories = new HashSet<>(Arrays.asList(new Category("football"), new Category("soccer")));
         device.setCategories(categories);
 
         device.setVariant(androidVariant);
@@ -346,7 +346,7 @@ public class ClientInstallationServiceTest extends AbstractBaseServiceTest {
         device.setDeviceToken(deviceToken);
         device.setAlias("root");
 
-        final Set<Category> categories = new HashSet<Category>(Arrays.asList(new Category("football"), new Category("soccer")));
+        final Set<Category> categories = new HashSet<>(Arrays.asList(new Category("football"), new Category("soccer")));
         device.setCategories(categories);
 
         device.setVariant(androidVariant);
@@ -370,21 +370,21 @@ public class ClientInstallationServiceTest extends AbstractBaseServiceTest {
 
         Installation device1 = new Installation();
         device1.setDeviceToken(generateFakedDeviceTokenString());
-        Set<Category> categories = new HashSet<Category>(Arrays.asList(new Category("football"), new Category("soccer")));
+        Set<Category> categories = new HashSet<>(Arrays.asList(new Category("football"), new Category("soccer")));
         device1.setCategories(categories);
         device1.setVariant(androidVariant);
         clientInstallationService.addInstallation(androidVariant, device1);
 
         Installation device2 = new Installation();
         device2.setDeviceToken(generateFakedDeviceTokenString());
-        categories = new HashSet<Category>(Arrays.asList(new Category("soccer")));
+        categories = new HashSet<>(Arrays.asList(new Category("soccer")));
         device2.setCategories(categories);
         device2.setVariant(androidVariant);
         clientInstallationService.addInstallation(androidVariant, device2);
 
         Installation device3 = new Installation();
         device3.setDeviceToken(generateFakedDeviceTokenString());
-        categories = new HashSet<Category>(Arrays.asList(new Category("football")));
+        categories = new HashSet<>(Arrays.asList(new Category("football")));
         device3.setCategories(categories);
         device3.setVariant(androidVariant);
         clientInstallationService.addInstallation(androidVariant, device3);
@@ -403,21 +403,21 @@ public class ClientInstallationServiceTest extends AbstractBaseServiceTest {
 
         Installation device1 = new Installation();
         device1.setDeviceToken(generateFakedDeviceTokenString());
-        Set<Category> categories = new HashSet<Category>(Arrays.asList(new Category("football"), new Category("soccer")));
+        Set<Category> categories = new HashSet<>(Arrays.asList(new Category("football"), new Category("soccer")));
         device1.setCategories(categories);
         device1.setVariant(androidVariant);
         clientInstallationService.addInstallation(androidVariant, device1);
 
         Installation device2 = new Installation();
         device2.setDeviceToken(generateFakedDeviceTokenString());
-        categories = new HashSet<Category>(Arrays.asList(new Category("soccer")));
+        categories = new HashSet<>(Arrays.asList(new Category("soccer")));
         device2.setCategories(categories);
         device2.setVariant(androidVariant);
         clientInstallationService.addInstallation(androidVariant, device2);
 
         Installation device3 = new Installation();
         device3.setDeviceToken(generateFakedDeviceTokenString());
-        categories = new HashSet<Category>(Arrays.asList(new Category("football")));
+        categories = new HashSet<>(Arrays.asList(new Category("football")));
         device3.setCategories(categories);
         device3.setVariant(androidVariant);
         clientInstallationService.addInstallation(androidVariant, device3);
@@ -437,25 +437,25 @@ public class ClientInstallationServiceTest extends AbstractBaseServiceTest {
 
         Installation device1 = new Installation();
         device1.setDeviceToken(generateFakedDeviceTokenString());
-        Set<Category> categories = new HashSet<Category>(Arrays.asList(new Category("football"), new Category("soccer")));
+        Set<Category> categories = new HashSet<>(Arrays.asList(new Category("football"), new Category("soccer")));
         device1.setCategories(categories);
         clientInstallationService.addInstallation(androidVariant, device1);
 
         Installation device2 = new Installation();
         device2.setDeviceToken(generateFakedDeviceTokenString());
-        categories = new HashSet<Category>(Arrays.asList(new Category("soccer")));
+        categories = new HashSet<>(Arrays.asList(new Category("soccer")));
         device2.setCategories(categories);
         clientInstallationService.addInstallation(androidVariant, device2);
 
         Installation device3 = new Installation();
         device3.setDeviceToken(generateFakedDeviceTokenString());
-        categories = new HashSet<Category>(Arrays.asList(new Category("football")));
+        categories = new HashSet<>(Arrays.asList(new Category("football")));
         device3.setCategories(categories);
         clientInstallationService.addInstallation(androidVariant, device3);
 
         Installation device4 = new Installation();
         device4.setDeviceToken("01234567891:"+generateFakedDeviceTokenString());
-        categories = new HashSet<Category>(Arrays.asList(new Category("football")));
+        categories = new HashSet<>(Arrays.asList(new Category("football")));
         device4.setCategories(categories);
         clientInstallationService.addInstallation(androidVariant, device4);
 
@@ -512,7 +512,7 @@ public class ClientInstallationServiceTest extends AbstractBaseServiceTest {
     private List<String> findAllDeviceTokenForVariantIDByCriteria(String variantID, List<String> categories, List<String> aliases, List<String> deviceTypes) {
         try {
             ResultsStream<String> tokenStream = clientInstallationService.findAllDeviceTokenForVariantIDByCriteria(variantID, categories, aliases, deviceTypes, Integer.MAX_VALUE, null).executeQuery();
-            List<String> list = new ArrayList<String>();
+            List<String> list = new ArrayList<>();
             while (tokenStream.next()) {
                 list.add(tokenStream.get());
             }
@@ -525,7 +525,7 @@ public class ClientInstallationServiceTest extends AbstractBaseServiceTest {
     private List<String> findAllOldGoogleCloudMessagingDeviceTokenForVariantIDByCriteria(String variantID, List<String> categories, List<String> aliases, List<String> deviceTypes) {
         try {
             ResultsStream<String> tokenStream = clientInstallationService.findAllOldGoogleCloudMessagingDeviceTokenForVariantIDByCriteria(variantID, categories, aliases, deviceTypes, Integer.MAX_VALUE, null).executeQuery();
-            List<String> list = new ArrayList<String>();
+            List<String> list = new ArrayList<>();
             while (tokenStream.next()) {
                 list.add(tokenStream.get());
             }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S2293 - “The diamond operator ("<>") should be used ”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S2293

 Please let me know if you have any questions.
Ayman Elkfrawy.