### PR TITLE
Add Firefox Variant to support Push API in Mozilla Firefox

### DIFF
--- a/admin-ui/app/components/app-detail/include/analytics.js
+++ b/admin-ui/app/components/app-detail/include/analytics.js
@@ -72,6 +72,7 @@ angular.module('upsConsole')
         case 'windows_mpns': return 'Windows';
         case 'windows_wns': return 'Windows';
         case 'android': return 'Android';
+        case 'firefox': return 'Firefox';
         default: return variant.type;
       }
     }

--- a/admin-ui/app/components/app-detail/include/variantDetail.html
+++ b/admin-ui/app/components/app-detail/include/variantDetail.html
@@ -20,6 +20,9 @@
 <p ng-if="variant.type == 'windows_mpns'">Microsoft's Push Notification Service (MPNS) in Windows Phone will be used.
   <i>This type of Push Network is deprecated and will be removed in future versions</i>.
 </p>
+<p ng-if="variant.type == 'firefox'">Mozilla Push Service (MPS) in Firefox will be used.
+  <i>This is experimental support of Push API for Firefox</i>.
+</p>
 
 
 <!--
@@ -98,6 +101,12 @@
   <dt>Network Type:</dt>
   <dd>
     SimplePush<br/>
+  </dd>
+</dl>
+<dl class="dl-horizontal" ng-if="variant.type == 'firefox'">
+  <dt>Network Type:</dt>
+  <dd>
+    Mozilla Push Service<br/>
   </dd>
 </dl>
 

--- a/admin-ui/app/components/bootstrap/bootstrap.html
+++ b/admin-ui/app/components/bootstrap/bootstrap.html
@@ -169,6 +169,21 @@
     </div>
   </div>
 
+  <div class="form-group" ng-if="bootstrap.allowCreate('firefox')">
+    <label class="col-sm-3 control-label sr-only">Firefox</label>
+    <div class="col-sm-9">
+      <div class="checkbox">
+        <label>
+          <input type="checkbox" ng-model="bootstrap.types.firefox">
+              <span class="ups-has-icon ups-variant-firefox">
+                <strong>Firefox (experimental)</strong><br>
+                using Mozilla Push Service
+              </span>
+        </label>
+      </div>
+    </div>
+  </div>
+
   <div ng-if="bootstrap.types.adm">
     <div class="form-group">
       <label class="col-sm-3 control-label" for="admClientId"></label>

--- a/admin-ui/app/components/bootstrap/bootstrap.js
+++ b/admin-ui/app/components/bootstrap/bootstrap.js
@@ -11,7 +11,8 @@ angular.module('upsConsole')
       simplePush : {},
       windows_wns: {},
       windows_mpns: {},
-      adm: {}
+      adm: {},
+      firefox: {}
     };
 
     this.allowCreate = function( variantType ) {

--- a/admin-ui/app/dialogs/create-variant.html
+++ b/admin-ui/app/dialogs/create-variant.html
@@ -107,6 +107,21 @@
       </div>
     </div>
 
+    <div class="form-group" ng-if="isNew && allowCreate('firefox')">
+      <label class="col-sm-3 control-label sr-only" for="optionsFirefox">Firefox</label>
+      <div class="col-sm-9">
+        <div class="radio">
+          <label>
+            <input type="radio" name="variantType" id="optionsFirefox" value="firefox" ng-model="variant.type" ng-required="true">
+                <span class="ups-has-icon ups-variant-firefox">
+                  <strong>Firefox (experimental)</strong><br>
+                  using Mozilla Push Service
+                </span>
+          </label>
+        </div>
+      </div>
+    </div>
+
     <div ng-show="variant.type">
 
       <div ng-show="variant.type == 'android'">
@@ -208,6 +223,13 @@
             Client Secret<br>
             <input type="text" placeholder="e.g. 5da448c2f31700a466fbc9d33d33942b043a27596" id="admclientSecret" class="form-control" ng-model="variant.clientSecret" ng-required="variant.type == 'adm'">
           </div>
+        </div>
+      </div>
+
+      <div ng-show="variant.type == 'firefox'">
+        <div class="form-group">
+          <label class="col-sm-3 control-label">Push Network</label>
+          <div class="col-sm-7"><strong>No configuration needed</strong></div>
         </div>
       </div>
 

--- a/admin-ui/app/scripts/app.js
+++ b/admin-ui/app/scripts/app.js
@@ -71,7 +71,7 @@
     });
   });
 
-  app.constant('allVariantTypes', ['android', 'ios', 'windows_mpns', 'windows_wns', 'simplePush', 'adm']);
+  app.constant('allVariantTypes', ['android', 'ios', 'windows_mpns', 'windows_wns', 'simplePush', 'adm', 'firefox']);
 
   app.value('allowCreateVariant', function( app, variantType ) {
     return true;

--- a/admin-ui/app/scripts/directives.js
+++ b/admin-ui/app/scripts/directives.js
@@ -151,7 +151,8 @@ angular.module('upsConsole')
           windows_mpns: { name: 'Windows',    snippets: ['dotnet', 'cordova', 'push_config'] },
           windows_wns:  { name: 'Windows',    snippets: ['dotnet', 'cordova', 'push_config'] },
           simplePush:   { name: 'SimplePush', snippets: ['cordova', 'push_config'] },
-          adm:          { name: 'ADM',        snippets: ['adm'] }
+          adm:          { name: 'ADM',        snippets: ['adm'] },
+          firefox:      { name: 'Firefox',    snippets: ['push_config'] }
         };
         $scope.state = {
           activeSnippet: $scope.typeEnum[$scope.variant.type].snippets[0]

--- a/admin-ui/app/scripts/services/variantModal.js
+++ b/admin-ui/app/scripts/services/variantModal.js
@@ -162,6 +162,9 @@ angular.module('upsConsole').factory('variantModal', function ($modal, $q, varia
     case 'adm':
       properties = properties.concat(['clientId', 'clientSecret']);
       break;
+    case 'firefox':
+      properties = properties.concat([]);
+      break;
     default:
       throw 'Unknown variant type ' + variant.type;
     }

--- a/admin-ui/app/styles/main.less
+++ b/admin-ui/app/styles/main.less
@@ -559,6 +559,7 @@ h2 span{
 .ups-variant-windows_mpns:before, .ups-variant-windows_mpns span:before{background-position:           center -120px}
 .ups-variant-windows_wns:before, .ups-variant-windows_wns span:before{background-position:           center -120px}
 .ups-variant-simplePush:before, .ups-variant-simplePush span:before{background-position:             center -160px}
+.ups-variant-firefox:before, .ups-variant-firefox span:before{background-position:             center -160px}
 .ups-variant-adm:before, .ups-variant-adm span:before{background-position:             center -200px}
 
 

--- a/configuration/jms-setup-wildfly.cli
+++ b/configuration/jms-setup-wildfly.cli
@@ -35,6 +35,11 @@ batch
 /subsystem=messaging-activemq/server=default/jms-queue=WNSTokenBatchQueue:add(entries=[queue/WNSTokenBatchQueue])
 /subsystem=messaging-activemq/server=default/address-setting=jms.queue.WNSTokenBatchQueue:add(address-full-policy=FAIL, max-size-bytes=40000)
 
+/subsystem=messaging-activemq/server=default/jms-queue=FirefoxPushMessageQueue:add(entries=[queue/FirefoxPushMessageQueue])
+/subsystem=messaging-activemq/server=default/address-setting=jms.queue.FirefoxPushMessageQueue:add(redelivery-delay=1500, redelivery-multiplier=1.5, max-redelivery-delay=5000, max-delivery-attempts=-1)
+/subsystem=messaging-activemq/server=default/jms-queue=FirefoxTokenBatchQueue:add(entries=[queue/FirefoxTokenBatchQueue])
+/subsystem=messaging-activemq/server=default/address-setting=jms.queue.FirefoxTokenBatchQueue:add(address-full-policy=FAIL, max-size-bytes=40000)
+
 
 
 /subsystem=messaging-activemq/server=default/jms-queue=MetricsQueue:add(entries=[queue/MetricsQueue])

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/FirefoxVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/FirefoxVariantEndpoint.java
@@ -1,0 +1,147 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright Red Hat, Inc., and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.aerogear.unifiedpush.rest.registry.applications;
+
+import com.qmino.miredot.annotations.ReturnType;
+import org.jboss.aerogear.unifiedpush.api.FirefoxVariant;
+import org.jboss.aerogear.unifiedpush.api.PushApplication;
+
+import javax.validation.ConstraintViolationException;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+@Path("/applications/{pushAppID}/firefox")
+public class FirefoxVariantEndpoint extends AbstractVariantEndpoint {
+
+    /**
+     * Add Firefox Variant
+     *
+     * @param firefoxVariant    new {@link FirefoxVariant}
+     * @param pushApplicationID id of {@link PushApplication}
+     * @return                  created {@link FirefoxVariant}
+     *
+     * @statuscode 201 The Firefox Variant created successfully
+     * @statuscode 400 The format of the client request was incorrect
+     * @statuscode 404 The requested PushApplication resource does not exist
+     */
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @ReturnType("org.jboss.aerogear.unifiedpush.api.FirefoxVariant")
+    public Response registerFirefoxVariant(
+            FirefoxVariant firefoxVariant,
+            @PathParam("pushAppID") String pushApplicationID,
+            @Context UriInfo uriInfo) {
+
+        // find the root push app
+        PushApplication pushApp = getSearch().findByPushApplicationIDForDeveloper(pushApplicationID);
+
+        if (pushApp == null) {
+            return Response.status(Response.Status.NOT_FOUND)
+                    .entity("Could not find requested PushApplicationEntity")
+                    .build();
+        }
+
+        // some validation
+        try {
+            validateModelClass(firefoxVariant);
+        } catch (ConstraintViolationException cve) {
+
+            // Build and return the 400 (Bad Request) response
+            Response.ResponseBuilder builder = createBadRequestResponse(cve.getConstraintViolations());
+
+            return builder.build();
+        }
+
+        // store the Firefox variant:
+        variantService.addVariant(firefoxVariant);
+        // add Firefox variant, and merge:
+        pushAppService.addVariant(pushApp, firefoxVariant);
+
+        return Response.created(uriInfo.getAbsolutePathBuilder().path(firefoxVariant.getVariantID()).build())
+                .entity(firefoxVariant)
+                .build();
+    }
+
+    /**
+     * List Firefox Variants for Push Application
+     *
+     * @param pushApplicationID id of {@link PushApplication}
+     * @return                  list of {@link FirefoxVariant}s
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @ReturnType("java.util.Set<org.jboss.aerogear.unifiedpush.api.FirefoxVariant>")
+    public Response listAllFirefoxVariationsForPushApp(@PathParam("pushAppID") String pushApplicationID) {
+        final PushApplication application = getSearch().findByPushApplicationIDForDeveloper(pushApplicationID);
+        return Response.ok(getVariantsByType(application, FirefoxVariant.class)).build();
+    }
+
+    /**
+     * Update Firefox Variant
+     *
+     * @param id                        id of {@link PushApplication}
+     * @param firefoxID                 id of {@link FirefoxVariant}
+     * @param updatedFirefoxApplication new info of {@link FirefoxVariant}
+     *
+     * @statuscode 200 The Firefox Variant updated successfully
+     * @statuscode 400 The format of the client request was incorrect
+     * @statuscode 404 The requested Firefox Variant resource does not exist
+     */
+    @PUT
+    @Path("/{firefoxID}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @ReturnType("org.jboss.aerogear.unifiedpush.api.FirefoxVariant")
+    public Response updateFirefoxVariant(
+            @PathParam("pushAppID") String id,
+            @PathParam("firefoxID") String firefoxID,
+            FirefoxVariant updatedFirefoxApplication) {
+
+        FirefoxVariant firefoxVariant = (FirefoxVariant) variantService.findByVariantID(firefoxID);
+        if (firefoxVariant != null) {
+
+            // some validation
+            try {
+                validateModelClass(updatedFirefoxApplication);
+            } catch (ConstraintViolationException cve) {
+
+                // Build and return the 400 (Bad Request) response
+                Response.ResponseBuilder builder = createBadRequestResponse(cve.getConstraintViolations());
+
+                return builder.build();
+            }
+
+            // apply updated data:
+            firefoxVariant.setName(updatedFirefoxApplication.getName());
+            firefoxVariant.setDescription(updatedFirefoxApplication.getDescription());
+            variantService.updateVariant(firefoxVariant);
+            return Response.ok(firefoxVariant).build();
+        }
+
+        return Response.status(Response.Status.NOT_FOUND).entity("Could not find requested Variant").build();
+    }
+}

--- a/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/FirefoxVariant.java
+++ b/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/FirefoxVariant.java
@@ -1,0 +1,29 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright Red Hat, Inc., and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.aerogear.unifiedpush.api;
+
+/**
+ * The Firefox variant class encapsulates Mozilla Push Service (MPS) specific behavior.
+ */
+public class FirefoxVariant extends Variant {
+    private static final long serialVersionUID = 1142847851407493017L;
+
+    @Override
+    public VariantType getType() {
+        return VariantType.FIREFOX;
+    }
+}

--- a/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/Installation.java
+++ b/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/Installation.java
@@ -70,6 +70,7 @@ public class Installation extends BaseModel {
      * <li> APNs: <code>deviceToken</code>
      * <li> GCM: <code>registrationId</code>
      * <li> SimplePush: <code>pushEndpoint</code>
+     * <li> Firefox: <code>endpoint</code>
      * </ul>
      *
      * @param deviceToken unique string to identify an Installation with its PushNetwork

--- a/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/VariantType.java
+++ b/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/VariantType.java
@@ -51,8 +51,12 @@ public enum VariantType {
     /**
      * The type identifier for our Amazon Device Messaging (ADM) variants.
      */
-    ADM("adm");
+    ADM("adm"),
 
+    /**
+     * The type identifier for our Firefox / Mozilla Push Service (MPS) variants.
+     */
+    FIREFOX("firefox_mps");
 
     private final String typeName;
 

--- a/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/validation/DeviceTokenValidator.java
+++ b/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/validation/DeviceTokenValidator.java
@@ -56,6 +56,12 @@ public class DeviceTokenValidator implements ConstraintValidator<DeviceTokenChec
      */
     private static final Pattern ADM_DEVICE_TOKEN = Pattern.compile("(?i)[0-9a-z\\-_.]{100,}");
 
+    /**
+     * Pattern for Firefox is harder to define that is why we kept it lenient it is at least 100 characters long and can
+     * consist of digits, alphas, - , _ and . and all have one of these separators
+     */
+    private static final Pattern FIREFOX_DEVICE_TOKEN = Pattern.compile("(?i)[0-9a-z\\-_.]{100,}");
+
     @Override
     public void initialize(DeviceTokenCheck constraintAnnotation) {
     }
@@ -92,6 +98,8 @@ public class DeviceTokenValidator implements ConstraintValidator<DeviceTokenChec
                 return SIMPLE_PUSH_DEVICE_TOKEN.matcher(deviceToken).matches();
             case ADM:
                 return ADM_DEVICE_TOKEN.matcher(deviceToken).matches();
+            case FIREFOX:
+                return FIREFOX_DEVICE_TOKEN.matcher(deviceToken).matches();
         }
         return false;
     }

--- a/model/jpa/src/main/resources/META-INF/orm.xml
+++ b/model/jpa/src/main/resources/META-INF/orm.xml
@@ -119,6 +119,10 @@ http://java.sun.com/xml/ns/persistence/orm_2_0.xsd"
             </basic>
         </attributes>
     </entity>
+    <entity class="FirefoxVariant" access="FIELD">
+        <table name="firefox_variant"/>
+        <discriminator-value>firefoxVariant</discriminator-value>
+    </entity>
     <entity class="org.jboss.aerogear.unifiedpush.api.WindowsWNSVariant" access="FIELD">
         <table name="windows_wns_variant"/>
         <discriminator-value>windows_wns</discriminator-value>

--- a/model/jpa/src/test/java/org/jboss/aerogear/unifiedpush/jpa/InstallationDaoTest.java
+++ b/model/jpa/src/test/java/org/jboss/aerogear/unifiedpush/jpa/InstallationDaoTest.java
@@ -16,26 +16,11 @@
  */
 package org.jboss.aerogear.unifiedpush.jpa;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
-import javax.inject.Inject;
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceException;
-import javax.validation.ConstraintViolation;
-import javax.validation.ConstraintViolationException;
-
 import net.jakubholy.dbunitexpress.EmbeddedDbTesterRule;
-
 import org.jboss.aerogear.unifiedpush.api.AdmVariant;
 import org.jboss.aerogear.unifiedpush.api.AndroidVariant;
 import org.jboss.aerogear.unifiedpush.api.Category;
+import org.jboss.aerogear.unifiedpush.api.FirefoxVariant;
 import org.jboss.aerogear.unifiedpush.api.Installation;
 import org.jboss.aerogear.unifiedpush.api.SimplePushVariant;
 import org.jboss.aerogear.unifiedpush.api.Variant;
@@ -57,6 +42,20 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceException;
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
 
 @RunWith(Arquillian.class)
 public class InstallationDaoTest {
@@ -500,6 +499,32 @@ public class InstallationDaoTest {
         variant.setGoogleKey("12");
         variant.setProjectNumber("12");
 
+        // when
+        deviceTokenTest(installation, variant);
+    }
+    
+    @Test(expected = ConstraintViolationException.class)
+    public void shouldNotSaveWhenFirefoxTokenInvalid() {
+        // given
+        final Installation installation = new Installation();
+        installation.setDeviceToken("!invalid!");
+        
+        final FirefoxVariant variant = new FirefoxVariant();
+        variant.setName("Firefox Variant Name");
+        
+        // when
+        deviceTokenTest(installation, variant);
+    }
+    
+    @Test
+    public void shouldSaveWhenFirefoxTokenValid() {
+        // given
+        final Installation installation = new Installation();
+        installation.setDeviceToken("gAAAAABXlQW2uvaJJk3Q6hey1cj2PjZYtGaDcY82DffVUF1OiV4Eu6SA1lds8jzKgZCR9JjIbioyv5jKwZQo2n6UxT8yRU3Es1qM2Fxmdv-p0cqGBhh4CjT5QNzlBAFRJ0OTLvisXB8e");
+    
+        final FirefoxVariant variant = new FirefoxVariant();
+        variant.setName("Firefox Variant Name");
+        
         // when
         deviceTokenTest(installation, variant);
     }

--- a/push/sender/pom.xml
+++ b/push/sender/pom.xml
@@ -126,6 +126,12 @@
             <version>0.1.0</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>fluent-hc</artifactId>
+            <version>4.3.6</version>
+        </dependency>
+
     </dependencies>
 
     <profiles>

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/configuration/SenderConfigurationProvider.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/configuration/SenderConfigurationProvider.java
@@ -16,14 +16,14 @@
  */
 package org.jboss.aerogear.unifiedpush.message.configuration;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Produces;
-
 import org.jboss.aerogear.unifiedpush.api.VariantType;
 import org.jboss.aerogear.unifiedpush.message.sender.SenderType;
 import org.jboss.aerogear.unifiedpush.system.ConfigurationUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
 
 /**
  * Loads and stores configuration for specific Push Networks.
@@ -73,6 +73,11 @@ public class SenderConfigurationProvider {
     @Produces @ApplicationScoped @SenderType(VariantType.WINDOWS_WNS)
     public SenderConfiguration produceWindowsWnsConfiguration() {
         return loadConfigurationFor(VariantType.WINDOWS_WNS, new SenderConfiguration(10, 1000));
+    }
+    
+    @Produces @ApplicationScoped @SenderType(VariantType.FIREFOX)
+    public SenderConfiguration produceFirefoxConfiguration() {
+        return loadConfigurationFor(VariantType.FIREFOX, new SenderConfiguration(10, 1000));
     }
 
     private SenderConfiguration loadConfigurationFor(VariantType type, SenderConfiguration defaultConfiguration) {

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/jms/MessageHolderWithTokensProducer.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/jms/MessageHolderWithTokensProducer.java
@@ -52,6 +52,9 @@ public class MessageHolderWithTokensProducer extends AbstractJMSMessageProducer 
 
     @Resource(mappedName = "java:/queue/WNSTokenBatchQueue")
     private Queue wnsTokenBatchQueue;
+    
+    @Resource(mappedName = "java:/queue/FirefoxTokenBatchQueue")
+    private Queue firefoxTokenBatchQueue;
 
     public void queueMessageVariantForProcessing(@Observes @DispatchToQueue MessageHolderWithTokens msg) {
         String deduplicationId = String.format("%s-%s", msg.getPushMessageInformation().getId(), msg.getSerialId());
@@ -72,6 +75,8 @@ public class MessageHolderWithTokensProducer extends AbstractJMSMessageProducer 
                 return mpnsTokenBatchQueue;
             case WINDOWS_WNS:
                 return wnsTokenBatchQueue;
+            case FIREFOX:
+                return firefoxTokenBatchQueue;
             default:
                 throw new IllegalStateException("Unknown variant type queue");
         }

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/jms/MessageHolderWithVariantsProducer.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/jms/MessageHolderWithVariantsProducer.java
@@ -53,6 +53,9 @@ public class MessageHolderWithVariantsProducer extends AbstractJMSMessageProduce
 
     @Resource(mappedName = "java:/queue/WNSPushMessageQueue")
     private Queue wnsPushMessageQueue;
+    
+    @Resource(mappedName = "java:/queue/FirefoxPushMessageQueue")
+    private Queue firefoxPushMessageQueue;
 
     public void queueMessageVariantForProcessing(@Observes @DispatchToQueue MessageHolderWithVariants msg) {
         sendTransacted(selectQueue(msg.getVariantType()), msg);
@@ -72,6 +75,8 @@ public class MessageHolderWithVariantsProducer extends AbstractJMSMessageProduce
                 return mpnsPushMessageQueue;
             case WINDOWS_WNS:
                 return wnsPushMessageQueue;
+            case FIREFOX:
+                return firefoxPushMessageQueue;
             default:
                 throw new IllegalStateException("Unknown variant type queue");
         }

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/FirefoxPushNotificationSender.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/FirefoxPushNotificationSender.java
@@ -1,0 +1,67 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright Red Hat, Inc., and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.aerogear.unifiedpush.message.sender;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.fluent.Request;
+import org.apache.http.util.EntityUtils;
+import org.jboss.aerogear.unifiedpush.api.Variant;
+import org.jboss.aerogear.unifiedpush.api.VariantType;
+import org.jboss.aerogear.unifiedpush.message.UnifiedPushMessage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+
+@SenderType(VariantType.FIREFOX)
+public class FirefoxPushNotificationSender implements PushNotificationSender {
+    
+    private final Logger logger = LoggerFactory.getLogger(FirefoxPushNotificationSender.class);
+    
+    private static final String MPS_URL = "https://updates.push.services.mozilla.com/wpush/v1/";
+
+    @Override
+    public void sendPushMessage(Variant variant, Collection<String> clientIdentifiers, UnifiedPushMessage pushMessage,
+            String pushMessageInformationId, NotificationSenderCallback senderCallback) {
+        
+        final int ttl = pushMessage.getConfig().getTimeToLive();
+
+        int successCount = 0;
+        for (String token : clientIdentifiers) {
+            try {
+                HttpResponse response = Request.Post(MPS_URL + token)
+                        .addHeader("TTL", String.valueOf(ttl))
+                        .execute()
+                        .returnResponse();
+                int statusCode = response.getStatusLine().getStatusCode();
+                if (statusCode == HttpStatus.SC_CREATED) {
+                    senderCallback.onSuccess();
+                    successCount++;
+                } else {
+                    String content = EntityUtils.toString(response.getEntity());
+                    logger.error("Error sending payload to MPS. Response status {}, content: {}", statusCode, content);
+                    senderCallback.onError(content);
+                }
+            } catch (Exception e) {
+                logger.error("Error sending push message to MPS", e);
+                senderCallback.onError(e.getMessage());
+            }
+        }
+        logger.info("Sent push notification to MPS Server for {} tokens of {}", successCount, clientIdentifiers.size());
+    }
+}

--- a/push/sender/src/test/resources/jms-cleanup-wildfly.cli
+++ b/push/sender/src/test/resources/jms-cleanup-wildfly.cli
@@ -35,6 +35,11 @@ batch
 /subsystem=messaging-activemq/server=default/jms-queue=WNSTokenBatchQueue:remove()
 /subsystem=messaging-activemq/server=default/address-setting=jms.queue.WNSTokenBatchQueue:remove()
 
+/subsystem=messaging-activemq/server=default/jms-queue=FirefoxPushMessageQueue:remove()
+/subsystem=messaging-activemq/server=default/address-setting=jms.queue.FirefoxPushMessageQueue:remove()
+/subsystem=messaging-activemq/server=default/jms-queue=FirefoxTokenBatchQueue:remove()
+/subsystem=messaging-activemq/server=default/address-setting=jms.queue.FirefoxTokenBatchQueue:remove()
+
 
 
 /subsystem=messaging-activemq/server=default/jms-queue=MetricsQueue:remove()

--- a/servers/ups-wildfly/src/main/webapp/WEB-INF/jboss-ejb3.xml
+++ b/servers/ups-wildfly/src/main/webapp/WEB-INF/jboss-ejb3.xml
@@ -140,6 +140,25 @@
                 </activation-config-property>
             </activation-config>
         </message-driven>
+        <message-driven>
+            <ejb-name>FirefoxPushMessageConsumer</ejb-name>
+            <ejb-class>org.jboss.aerogear.unifiedpush.message.jms.MessageHolderWithVariantsConsumer</ejb-class>
+            <transaction-type>Container</transaction-type>
+            <activation-config>
+                <activation-config-property>
+                    <activation-config-property-name>destination</activation-config-property-name>
+                    <activation-config-property-value>queue/FirefoxPushMessageQueue</activation-config-property-value>
+                </activation-config-property>
+                <activation-config-property>
+                    <activation-config-property-name>destinationType</activation-config-property-name>
+                    <activation-config-property-value>javax.jms.Queue</activation-config-property-value>
+                </activation-config-property>
+                <activation-config-property>
+                    <activation-config-property-name>acknowledgeMode</activation-config-property-name>
+                    <activation-config-property-value>Auto-acknowledge</activation-config-property-value>
+                </activation-config-property>
+            </activation-config>
+        </message-driven>
         
         <!-- Token Batch Queue MDBs -->
         <message-driven>
@@ -277,6 +296,25 @@
                 <activation-config-property>
                     <activation-config-property-name>maxSession</activation-config-property-name>
                     <activation-config-property-value>15</activation-config-property-value>
+                </activation-config-property>
+            </activation-config>
+        </message-driven>
+        <message-driven>
+            <ejb-name>FirefoxTokenBatchConsumer</ejb-name>
+            <ejb-class>org.jboss.aerogear.unifiedpush.message.jms.MessageHolderWithTokensConsumer</ejb-class>
+            <transaction-type>Container</transaction-type>
+            <activation-config>
+                <activation-config-property>
+                    <activation-config-property-name>destination</activation-config-property-name>
+                    <activation-config-property-value>queue/FirefoxTokenBatchQueue</activation-config-property-value>
+                </activation-config-property>
+                <activation-config-property>
+                    <activation-config-property-name>destinationType</activation-config-property-name>
+                    <activation-config-property-value>javax.jms.Queue</activation-config-property-value>
+                </activation-config-property>
+                <activation-config-property>
+                    <activation-config-property-name>acknowledgeMode</activation-config-property-name>
+                    <activation-config-property-value>Auto-acknowledge</activation-config-property-value>
                 </activation-config-property>
             </activation-config>
         </message-driven>


### PR DESCRIPTION
It works with my previous example for Chrome Push API without modifications: https://github.com/aerogear/aerogear-js-cookbook/pull/13

Ready for code review, but some tasks are not completed:
* Push message encryption to support PushMessageData (will discuss it in mailing list);
* Tests

@matzew @sebastienblanc could you look at this, please? Especially at front-end part, worrying that I miss something.