### PR TITLE
Add Webpush Variant to support Push API in Mozilla Firefox and Google Chrome

### DIFF
--- a/admin-ui/app/components/app-detail/include/analytics.js
+++ b/admin-ui/app/components/app-detail/include/analytics.js
@@ -72,6 +72,7 @@ angular.module('upsConsole')
         case 'windows_mpns': return 'Windows';
         case 'windows_wns': return 'Windows';
         case 'android': return 'Android';
+        case 'webPush': return 'WebPush';
         default: return variant.type;
       }
     }

--- a/admin-ui/app/components/app-detail/include/variantDetail.html
+++ b/admin-ui/app/components/app-detail/include/variantDetail.html
@@ -20,6 +20,9 @@
 <p ng-if="variant.type == 'windows_mpns'">Microsoft's Push Notification Service (MPNS) in Windows Phone will be used.
   <i>This type of Push Network is deprecated and will be removed in future versions</i>.
 </p>
+<p ng-if="variant.type == 'webPush'">Mozilla Push Service (MPS) for Firefox will be used.
+  <i>This is experimental support of Push API for web browsers</i>.
+</p>
 
 
 <!--
@@ -98,6 +101,12 @@
   <dt>Network Type:</dt>
   <dd>
     SimplePush<br/>
+  </dd>
+</dl>
+<dl class="dl-horizontal" ng-if="variant.type == 'webPush'">
+  <dt>Network Type:</dt>
+  <dd>
+    WebPush<br/>
   </dd>
 </dl>
 

--- a/admin-ui/app/components/app-detail/include/variantDetail.html
+++ b/admin-ui/app/components/app-detail/include/variantDetail.html
@@ -20,8 +20,8 @@
 <p ng-if="variant.type == 'windows_mpns'">Microsoft's Push Notification Service (MPNS) in Windows Phone will be used.
   <i>This type of Push Network is deprecated and will be removed in future versions</i>.
 </p>
-<p ng-if="variant.type == 'webPush'">Mozilla Push Service (MPS) for Firefox will be used.
-  <i>This is experimental support of Push API for web browsers</i>.
+<p ng-if="variant.type == 'webPush'">Mozilla Push Service (MPS) for Firefox or Firebase Cloud Messaging (FCM) for Google Chrome will be used.<br>
+  <i>This is experimental support of Push API for web browsers.</i>
 </p>
 
 
@@ -107,6 +107,13 @@
   <dt>Network Type:</dt>
   <dd>
     WebPush<br/>
+  </dd>
+  <dt>FCM Server Key:</dt>
+  <dd class="project-number">{{ variant.fcmServerKey }}</dd>
+  <dt>FCM Sender ID:</dt>
+  <dd class="google-key">
+    {{ variant.fcmSenderID }}<br />
+    <button class="btn btn-sm btn-default" ng-click="variants.edit( variant )"><span class="fa fa-pencil"></span> Edit network options</button>
   </dd>
 </dl>
 

--- a/admin-ui/app/components/bootstrap/bootstrap.html
+++ b/admin-ui/app/components/bootstrap/bootstrap.html
@@ -169,6 +169,21 @@
     </div>
   </div>
 
+  <div class="form-group" ng-if="bootstrap.allowCreate('webPush')">
+    <label class="col-sm-3 control-label sr-only">WebPush</label>
+    <div class="col-sm-9">
+      <div class="checkbox">
+        <label>
+          <input type="checkbox" ng-model="bootstrap.types.webPush">
+              <span class="ups-has-icon ups-variant-firefox">
+                <strong>WebPush (experimental)</strong><br>
+                using Mozilla Push Service
+              </span>
+        </label>
+      </div>
+    </div>
+  </div>
+
   <div ng-if="bootstrap.types.adm">
     <div class="form-group">
       <label class="col-sm-3 control-label" for="admClientId"></label>

--- a/admin-ui/app/components/bootstrap/bootstrap.html
+++ b/admin-ui/app/components/bootstrap/bootstrap.html
@@ -177,7 +177,7 @@
           <input type="checkbox" ng-model="bootstrap.types.webPush">
               <span class="ups-has-icon ups-variant-firefox">
                 <strong>WebPush (experimental)</strong><br>
-                using Mozilla Push Service
+                using Mozilla Push Service or Firebase Cloud Messaging
               </span>
         </label>
       </div>

--- a/admin-ui/app/components/bootstrap/bootstrap.js
+++ b/admin-ui/app/components/bootstrap/bootstrap.js
@@ -11,7 +11,8 @@ angular.module('upsConsole')
       simplePush : {},
       windows_wns: {},
       windows_mpns: {},
-      adm: {}
+      adm: {},
+      webPush: {}
     };
 
     this.allowCreate = function( variantType ) {

--- a/admin-ui/app/dialogs/create-variant.html
+++ b/admin-ui/app/dialogs/create-variant.html
@@ -107,6 +107,21 @@
       </div>
     </div>
 
+    <div class="form-group" ng-if="isNew && allowCreate('webPush')">
+      <label class="col-sm-3 control-label sr-only" for="optionsWebPush">WebPush</label>
+      <div class="col-sm-9">
+        <div class="radio">
+          <label>
+            <input type="radio" name="variantType" id="optionsWebPush" value="webPush" ng-model="variant.type" ng-required="true">
+                <span class="ups-has-icon ups-variant-firefox">
+                  <strong>WebPush (experimental)</strong><br>
+                  using Mozilla Push Service
+                </span>
+          </label>
+        </div>
+      </div>
+    </div>
+
     <div ng-show="variant.type">
 
       <div ng-show="variant.type == 'android'">
@@ -208,6 +223,13 @@
             Client Secret<br>
             <input type="text" placeholder="e.g. 5da448c2f31700a466fbc9d33d33942b043a27596" id="admclientSecret" class="form-control" ng-model="variant.clientSecret" ng-required="variant.type == 'adm'">
           </div>
+        </div>
+      </div>
+
+      <div ng-show="variant.type == 'webPush'">
+        <div class="form-group">
+          <label class="col-sm-3 control-label">Push Network</label>
+          <div class="col-sm-7"><strong>No configuration needed</strong></div>
         </div>
       </div>
 

--- a/admin-ui/app/dialogs/create-variant.html
+++ b/admin-ui/app/dialogs/create-variant.html
@@ -115,7 +115,7 @@
             <input type="radio" name="variantType" id="optionsWebPush" value="webPush" ng-model="variant.type" ng-required="true">
                 <span class="ups-has-icon ups-variant-firefox">
                   <strong>WebPush (experimental)</strong><br>
-                  using Mozilla Push Service
+                  using Mozilla Push Service or Firebase Cloud Messaging
                 </span>
           </label>
         </div>
@@ -228,8 +228,16 @@
 
       <div ng-show="variant.type == 'webPush'">
         <div class="form-group">
-          <label class="col-sm-3 control-label">Push Network</label>
-          <div class="col-sm-7"><strong>No configuration needed</strong></div>
+          <label class="col-sm-3 control-label" for="fcmServerKey">Push Network</label>
+          <div class="col-sm-7">FCM Server Key<br>
+            <input type="text" placeholder="e.g. AIza5a448c2f31700a466fbc9d33d33942b043a27596" id="fcmServerKey" class="form-control" ng-model="variant.fcmServerKey" ng-required="variant.type == 'webPush'">
+          </div>
+        </div>
+        <div class="form-group">
+          <label class="col-sm-3 control-label" for="fcmSenderID"></label>
+          <div class="col-sm-7">FCM Sender ID<br>
+            <input type="text" placeholder="e.g. 42" id="fcmSenderID" class="form-control" ng-model="variant.fcmSenderID">
+          </div>
         </div>
       </div>
 

--- a/admin-ui/app/scripts/app.js
+++ b/admin-ui/app/scripts/app.js
@@ -71,7 +71,7 @@
     });
   });
 
-  app.constant('allVariantTypes', ['android', 'ios', 'windows_mpns', 'windows_wns', 'simplePush', 'adm']);
+  app.constant('allVariantTypes', ['android', 'ios', 'windows_mpns', 'windows_wns', 'simplePush', 'adm', 'webPush']);
 
   app.value('allowCreateVariant', function( app, variantType ) {
     return true;

--- a/admin-ui/app/scripts/directives.js
+++ b/admin-ui/app/scripts/directives.js
@@ -151,7 +151,8 @@ angular.module('upsConsole')
           windows_mpns: { name: 'Windows',    snippets: ['dotnet', 'cordova', 'push_config'] },
           windows_wns:  { name: 'Windows',    snippets: ['dotnet', 'cordova', 'push_config'] },
           simplePush:   { name: 'SimplePush', snippets: ['cordova', 'push_config'] },
-          adm:          { name: 'ADM',        snippets: ['adm'] }
+          adm:          { name: 'ADM',        snippets: ['adm'] },
+          webPush:      { name: 'WebPush',    snippets: ['push_config'] }
         };
         $scope.state = {
           activeSnippet: $scope.typeEnum[$scope.variant.type].snippets[0]

--- a/admin-ui/app/scripts/services/variantModal.js
+++ b/admin-ui/app/scripts/services/variantModal.js
@@ -163,7 +163,7 @@ angular.module('upsConsole').factory('variantModal', function ($modal, $q, varia
       properties = properties.concat(['clientId', 'clientSecret']);
       break;
     case 'webPush':
-      properties = properties.concat([]);
+      properties = properties.concat(['fcmServerKey', 'fcmSenderID']);
       break;
     default:
       throw 'Unknown variant type ' + variant.type;

--- a/admin-ui/app/scripts/services/variantModal.js
+++ b/admin-ui/app/scripts/services/variantModal.js
@@ -162,6 +162,9 @@ angular.module('upsConsole').factory('variantModal', function ($modal, $q, varia
     case 'adm':
       properties = properties.concat(['clientId', 'clientSecret']);
       break;
+    case 'webPush':
+      properties = properties.concat([]);
+      break;
     default:
       throw 'Unknown variant type ' + variant.type;
     }

--- a/admin-ui/app/styles/main.less
+++ b/admin-ui/app/styles/main.less
@@ -559,6 +559,7 @@ h2 span{
 .ups-variant-windows_mpns:before, .ups-variant-windows_mpns span:before{background-position:           center -120px}
 .ups-variant-windows_wns:before, .ups-variant-windows_wns span:before{background-position:           center -120px}
 .ups-variant-simplePush:before, .ups-variant-simplePush span:before{background-position:             center -160px}
+.ups-variant-firefox:before, .ups-variant-firefox span:before{background-position:             center -160px}
 .ups-variant-adm:before, .ups-variant-adm span:before{background-position:             center -200px}
 
 

--- a/configuration/jms-setup-wildfly.cli
+++ b/configuration/jms-setup-wildfly.cli
@@ -35,6 +35,11 @@ batch
 /subsystem=messaging-activemq/server=default/jms-queue=WNSTokenBatchQueue:add(entries=[queue/WNSTokenBatchQueue])
 /subsystem=messaging-activemq/server=default/address-setting=jms.queue.WNSTokenBatchQueue:add(address-full-policy=FAIL, max-size-bytes=40000)
 
+/subsystem=messaging-activemq/server=default/jms-queue=WebPushMessageQueue:add(entries=[queue/WebPushMessageQueue])
+/subsystem=messaging-activemq/server=default/address-setting=jms.queue.WebPushMessageQueue:add(redelivery-delay=1500, redelivery-multiplier=1.5, max-redelivery-delay=5000, max-delivery-attempts=-1)
+/subsystem=messaging-activemq/server=default/jms-queue=WebPushTokenBatchQueue:add(entries=[queue/WebPushTokenBatchQueue])
+/subsystem=messaging-activemq/server=default/address-setting=jms.queue.WebPushTokenBatchQueue:add(address-full-policy=FAIL, max-size-bytes=40000)
+
 
 
 /subsystem=messaging-activemq/server=default/jms-queue=MetricsQueue:add(entries=[queue/MetricsQueue])

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/WebPushVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/WebPushVariantEndpoint.java
@@ -1,0 +1,147 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright Red Hat, Inc., and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.aerogear.unifiedpush.rest.registry.applications;
+
+import com.qmino.miredot.annotations.ReturnType;
+import org.jboss.aerogear.unifiedpush.api.WebPushVariant;
+import org.jboss.aerogear.unifiedpush.api.PushApplication;
+
+import javax.validation.ConstraintViolationException;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+@Path("/applications/{pushAppID}/webPush")
+public class WebPushVariantEndpoint extends AbstractVariantEndpoint {
+
+    /**
+     * Add WebPush Variant
+     *
+     * @param webPushVariant    new {@link WebPushVariant}
+     * @param pushApplicationID id of {@link PushApplication}
+     * @return                  created {@link WebPushVariant}
+     *
+     * @statuscode 201 The WebPush Variant created successfully
+     * @statuscode 400 The format of the client request was incorrect
+     * @statuscode 404 The requested PushApplication resource does not exist
+     */
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @ReturnType("org.jboss.aerogear.unifiedpush.api.WebPushVariant")
+    public Response registerWebPushVariant(
+            WebPushVariant webPushVariant,
+            @PathParam("pushAppID") String pushApplicationID,
+            @Context UriInfo uriInfo) {
+
+        // find the root push app
+        PushApplication pushApp = getSearch().findByPushApplicationIDForDeveloper(pushApplicationID);
+
+        if (pushApp == null) {
+            return Response.status(Response.Status.NOT_FOUND)
+                    .entity("Could not find requested PushApplicationEntity")
+                    .build();
+        }
+
+        // some validation
+        try {
+            validateModelClass(webPushVariant);
+        } catch (ConstraintViolationException cve) {
+
+            // Build and return the 400 (Bad Request) response
+            Response.ResponseBuilder builder = createBadRequestResponse(cve.getConstraintViolations());
+
+            return builder.build();
+        }
+
+        // store the WebPush variant:
+        variantService.addVariant(webPushVariant);
+        // add WebPush variant, and merge:
+        pushAppService.addVariant(pushApp, webPushVariant);
+
+        return Response.created(uriInfo.getAbsolutePathBuilder().path(webPushVariant.getVariantID()).build())
+                .entity(webPushVariant)
+                .build();
+    }
+
+    /**
+     * List WebPush Variants for Push Application
+     *
+     * @param pushApplicationID id of {@link PushApplication}
+     * @return                  list of {@link WebPushVariant}s
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @ReturnType("java.util.Set<org.jboss.aerogear.unifiedpush.api.WebPushVariant>")
+    public Response listAllWebPushVariationsForPushApp(@PathParam("pushAppID") String pushApplicationID) {
+        final PushApplication application = getSearch().findByPushApplicationIDForDeveloper(pushApplicationID);
+        return Response.ok(getVariantsByType(application, WebPushVariant.class)).build();
+    }
+
+    /**
+     * Update WebPush Variant
+     *
+     * @param id                        id of {@link PushApplication}
+     * @param webPushID                 id of {@link WebPushVariant}
+     * @param updatedWebPushApplication new info of {@link WebPushVariant}
+     *
+     * @statuscode 200 The WebPush Variant updated successfully
+     * @statuscode 400 The format of the client request was incorrect
+     * @statuscode 404 The requested WebPush Variant resource does not exist
+     */
+    @PUT
+    @Path("/{webPushID}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @ReturnType("org.jboss.aerogear.unifiedpush.api.WebPushVariant")
+    public Response updateWebPushVariation(
+            @PathParam("pushAppID") String id,
+            @PathParam("webPushID") String webPushID,
+            WebPushVariant updatedWebPushApplication) {
+
+        WebPushVariant webPushVariant = (WebPushVariant) variantService.findByVariantID(webPushID);
+        if (webPushVariant != null) {
+
+            // some validation
+            try {
+                validateModelClass(updatedWebPushApplication);
+            } catch (ConstraintViolationException cve) {
+
+                // Build and return the 400 (Bad Request) response
+                Response.ResponseBuilder builder = createBadRequestResponse(cve.getConstraintViolations());
+
+                return builder.build();
+            }
+
+            // apply updated data:
+            webPushVariant.setName(updatedWebPushApplication.getName());
+            webPushVariant.setDescription(updatedWebPushApplication.getDescription());
+            variantService.updateVariant(webPushVariant);
+            return Response.ok(webPushVariant).build();
+        }
+
+        return Response.status(Response.Status.NOT_FOUND).entity("Could not find requested Variant").build();
+    }
+}

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/WebPushVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/WebPushVariantEndpoint.java
@@ -103,9 +103,9 @@ public class WebPushVariantEndpoint extends AbstractVariantEndpoint {
     /**
      * Update WebPush Variant
      *
-     * @param id                        id of {@link PushApplication}
-     * @param webPushID                 id of {@link WebPushVariant}
-     * @param updatedWebPushApplication new info of {@link WebPushVariant}
+     * @param id                    id of {@link PushApplication}
+     * @param webPushID             id of {@link WebPushVariant}
+     * @param updatedWebPushVariant new info of {@link WebPushVariant}
      *
      * @statuscode 200 The WebPush Variant updated successfully
      * @statuscode 400 The format of the client request was incorrect
@@ -119,14 +119,14 @@ public class WebPushVariantEndpoint extends AbstractVariantEndpoint {
     public Response updateWebPushVariation(
             @PathParam("pushAppID") String id,
             @PathParam("webPushID") String webPushID,
-            WebPushVariant updatedWebPushApplication) {
+            WebPushVariant updatedWebPushVariant) {
 
         WebPushVariant webPushVariant = (WebPushVariant) variantService.findByVariantID(webPushID);
         if (webPushVariant != null) {
 
             // some validation
             try {
-                validateModelClass(updatedWebPushApplication);
+                validateModelClass(updatedWebPushVariant);
             } catch (ConstraintViolationException cve) {
 
                 // Build and return the 400 (Bad Request) response
@@ -136,8 +136,12 @@ public class WebPushVariantEndpoint extends AbstractVariantEndpoint {
             }
 
             // apply updated data:
-            webPushVariant.setName(updatedWebPushApplication.getName());
-            webPushVariant.setDescription(updatedWebPushApplication.getDescription());
+            webPushVariant.setName(updatedWebPushVariant.getName());
+            webPushVariant.setDescription(updatedWebPushVariant.getDescription());
+            // update FCM info:
+            webPushVariant.setFcmServerKey(updatedWebPushVariant.getFcmServerKey());
+            webPushVariant.setFcmSenderID(updatedWebPushVariant.getFcmSenderID());
+            
             variantService.updateVariant(webPushVariant);
             return Response.ok(webPushVariant).build();
         }

--- a/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/Installation.java
+++ b/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/Installation.java
@@ -70,6 +70,7 @@ public class Installation extends BaseModel {
      * <li> APNs: <code>deviceToken</code>
      * <li> GCM: <code>registrationId</code>
      * <li> SimplePush: <code>pushEndpoint</code>
+     * <li> WebPush: <code>endpoint</code>
      * </ul>
      *
      * @param deviceToken unique string to identify an Installation with its PushNetwork

--- a/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/VariantType.java
+++ b/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/VariantType.java
@@ -51,8 +51,12 @@ public enum VariantType {
     /**
      * The type identifier for our Amazon Device Messaging (ADM) variants.
      */
-    ADM("adm");
+    ADM("adm"),
 
+    /**
+     * The type identifier for WebPush variants.
+     */
+    WEB_PUSH("webPush");
 
     private final String typeName;
 

--- a/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/WebPushVariant.java
+++ b/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/WebPushVariant.java
@@ -1,0 +1,29 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright Red Hat, Inc., and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.aerogear.unifiedpush.api;
+
+/**
+ * The WebPush variant class encapsulates WebPush specific behavior.
+ */
+public class WebPushVariant extends Variant {
+    private static final long serialVersionUID = 1142847851407493017L;
+
+    @Override
+    public VariantType getType() {
+        return VariantType.WEB_PUSH;
+    }
+}

--- a/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/WebPushVariant.java
+++ b/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/WebPushVariant.java
@@ -16,11 +16,48 @@
  */
 package org.jboss.aerogear.unifiedpush.api;
 
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
 /**
- * The WebPush variant class encapsulates WebPush specific behavior.
+ * The WebPush variant class encapsulates specific behavior for different WebPush providers.
  */
 public class WebPushVariant extends Variant {
     private static final long serialVersionUID = 1142847851407493017L;
+    
+    @NotNull
+    @Size(min = 1, max = 255, message = "Server Key must be max. 255 chars long")
+    private String fcmServerKey;
+    
+    @Size(max = 255, message = "Sender ID must be max. 255 chars long")
+    private String fcmSenderID;
+    
+    /**
+     * The Server Key from the Firebase Cloud Messaging Console of a project which has been enabled for FCM.
+     *
+     @return the Server key
+     */
+    public String getFcmServerKey() {
+        return fcmServerKey;
+    }
+    
+    public void setFcmServerKey(final String fcmServerKey) {
+        this.fcmServerKey = fcmServerKey;
+    }
+    
+    /**
+     * The Sender ID from the Firebase Cloud Messaging Console is <i>not</i> needed for sending push messages,
+     * but it is a convenience to "see" it on the Admin UI as well, since the web applications require it.
+     *
+     * @return the Sender ID
+     */
+    public String getFcmSenderID() {
+        return fcmSenderID;
+    }
+    
+    public void setFcmSenderID(final String fcmSenderID) {
+        this.fcmSenderID = fcmSenderID;
+    }
 
     @Override
     public VariantType getType() {

--- a/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/validation/DeviceTokenValidator.java
+++ b/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/validation/DeviceTokenValidator.java
@@ -56,6 +56,12 @@ public class DeviceTokenValidator implements ConstraintValidator<DeviceTokenChec
      */
     private static final Pattern ADM_DEVICE_TOKEN = Pattern.compile("(?i)[0-9a-z\\-_.]{100,}");
 
+    /**
+     * Pattern for WebPush is harder to define that is why we kept it lenient it is at least 100 characters long and can
+     * consist of digits, alphas, - , _ and . and all have one of these separators
+     */
+    private static final Pattern WEB_PUSH_DEVICE_TOKEN = Pattern.compile("[0-9A-Za-z\\-_.]{100,}");
+
     @Override
     public void initialize(DeviceTokenCheck constraintAnnotation) {
     }
@@ -92,6 +98,8 @@ public class DeviceTokenValidator implements ConstraintValidator<DeviceTokenChec
                 return SIMPLE_PUSH_DEVICE_TOKEN.matcher(deviceToken).matches();
             case ADM:
                 return ADM_DEVICE_TOKEN.matcher(deviceToken).matches();
+            case WEB_PUSH:
+                return WEB_PUSH_DEVICE_TOKEN.matcher(deviceToken).matches();
         }
         return false;
     }

--- a/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/validation/DeviceTokenValidator.java
+++ b/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/validation/DeviceTokenValidator.java
@@ -57,10 +57,9 @@ public class DeviceTokenValidator implements ConstraintValidator<DeviceTokenChec
     private static final Pattern ADM_DEVICE_TOKEN = Pattern.compile("(?i)[0-9a-z\\-_.]{100,}");
 
     /**
-     * Pattern for WebPush is harder to define that is why we kept it lenient it is at least 100 characters long and can
-     * consist of digits, alphas, - , _ and . and all have one of these separators
+     * The WebPush token is an URI. According to the Push API specification, https is required.
      */
-    private static final Pattern WEB_PUSH_DEVICE_TOKEN = Pattern.compile("[0-9A-Za-z\\-_.]{100,}");
+    private static final Pattern WEB_PUSH_DEVICE_TOKEN = Pattern.compile("https?://.{0,2000}");
 
     @Override
     public void initialize(DeviceTokenCheck constraintAnnotation) {

--- a/model/jpa/src/main/resources/META-INF/orm.xml
+++ b/model/jpa/src/main/resources/META-INF/orm.xml
@@ -138,6 +138,14 @@ http://java.sun.com/xml/ns/persistence/orm_2_0.xsd"
     <entity class="WebPushVariant" access="FIELD">
         <table name="webpush_variant"/>
         <discriminator-value>webPush</discriminator-value>
+        <attributes>
+            <basic name="fcmServerKey">
+                <column name="fcm_server_key" length="255" nullable="false"/>
+            </basic>
+            <basic name="fcmSenderID">
+                <column name="fcm_sender_id" length="255"/>
+            </basic>
+        </attributes>
     </entity>
 
 </entity-mappings>

--- a/model/jpa/src/main/resources/META-INF/orm.xml
+++ b/model/jpa/src/main/resources/META-INF/orm.xml
@@ -135,5 +135,9 @@ http://java.sun.com/xml/ns/persistence/orm_2_0.xsd"
         <table name="windows_mpns_variant"/>
         <discriminator-value>windows_mpns</discriminator-value>
     </entity>
+    <entity class="WebPushVariant" access="FIELD">
+        <table name="webpush_variant"/>
+        <discriminator-value>webPush</discriminator-value>
+    </entity>
 
 </entity-mappings>

--- a/model/jpa/src/test/java/org/jboss/aerogear/unifiedpush/jpa/InstallationDaoTest.java
+++ b/model/jpa/src/test/java/org/jboss/aerogear/unifiedpush/jpa/InstallationDaoTest.java
@@ -16,29 +16,14 @@
  */
 package org.jboss.aerogear.unifiedpush.jpa;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
-import javax.inject.Inject;
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceException;
-import javax.validation.ConstraintViolation;
-import javax.validation.ConstraintViolationException;
-
 import net.jakubholy.dbunitexpress.EmbeddedDbTesterRule;
-
 import org.jboss.aerogear.unifiedpush.api.AdmVariant;
 import org.jboss.aerogear.unifiedpush.api.AndroidVariant;
 import org.jboss.aerogear.unifiedpush.api.Category;
 import org.jboss.aerogear.unifiedpush.api.Installation;
 import org.jboss.aerogear.unifiedpush.api.SimplePushVariant;
 import org.jboss.aerogear.unifiedpush.api.Variant;
+import org.jboss.aerogear.unifiedpush.api.WebPushVariant;
 import org.jboss.aerogear.unifiedpush.api.WindowsMPNSVariant;
 import org.jboss.aerogear.unifiedpush.api.WindowsWNSVariant;
 import org.jboss.aerogear.unifiedpush.api.iOSVariant;
@@ -57,6 +42,20 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceException;
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
 
 @RunWith(Arquillian.class)
 public class InstallationDaoTest {
@@ -500,6 +499,32 @@ public class InstallationDaoTest {
         variant.setGoogleKey("12");
         variant.setProjectNumber("12");
 
+        // when
+        deviceTokenTest(installation, variant);
+    }
+    
+    @Test(expected = ConstraintViolationException.class)
+    public void shouldNotSaveWhenWebPushTokenDoesNotUseHttps() {
+        // given
+        final Installation installation = new Installation();
+        installation.setDeviceToken("too_short_invalid_endpoint");
+        
+        final WebPushVariant variant = new WebPushVariant();
+        variant.setName("WebPush Variant Name");
+        
+        // when
+        deviceTokenTest(installation, variant);
+    }
+    
+    @Test
+    public void shouldSaveWhenWebPushTokenValid() {
+        // given
+        final Installation installation = new Installation();
+        installation.setDeviceToken("gAAAAABXlQW2uvaJJk3Q6hey1cj2PjZYtGaDcY82DffVUF1OiV4Eu6SA1lds8jzKgZCR9JjIbioyv5jKwZQo2n6UxT8yRU3Es1qM2Fxmdv-p0cqGBhh4CjT5QNzlBAFRJ0OTLvisXB8e");
+        
+        final WebPushVariant variant = new WebPushVariant();
+        variant.setName("WebPush Variant Name");
+        
         // when
         deviceTokenTest(installation, variant);
     }

--- a/model/jpa/src/test/java/org/jboss/aerogear/unifiedpush/jpa/InstallationDaoTest.java
+++ b/model/jpa/src/test/java/org/jboss/aerogear/unifiedpush/jpa/InstallationDaoTest.java
@@ -507,7 +507,7 @@ public class InstallationDaoTest {
     public void shouldNotSaveWhenWebPushTokenDoesNotUseHttps() {
         // given
         final Installation installation = new Installation();
-        installation.setDeviceToken("too_short_invalid_endpoint");
+        installation.setDeviceToken("http://updates.push.services.mozilla.com/wpush/v1/gAAAAABXlQW2uvaJJk3Q6hey1cj2PjZYtGaDcY82DffVUF1OiV4Eu6SA1lds8jzKgZCR9JjIbioyv5jKwZQo2n6UxT8yRU3Es1qM2Fxmdv-p0cqGBhh4CjT5QNzlBAFRJ0OTLvisXB8e");
         
         final WebPushVariant variant = new WebPushVariant();
         variant.setName("WebPush Variant Name");
@@ -520,10 +520,11 @@ public class InstallationDaoTest {
     public void shouldSaveWhenWebPushTokenValid() {
         // given
         final Installation installation = new Installation();
-        installation.setDeviceToken("gAAAAABXlQW2uvaJJk3Q6hey1cj2PjZYtGaDcY82DffVUF1OiV4Eu6SA1lds8jzKgZCR9JjIbioyv5jKwZQo2n6UxT8yRU3Es1qM2Fxmdv-p0cqGBhh4CjT5QNzlBAFRJ0OTLvisXB8e");
+        installation.setDeviceToken("https://updates.push.services.mozilla.com/wpush/v1/gAAAAABXlQW2uvaJJk3Q6hey1cj2PjZYtGaDcY82DffVUF1OiV4Eu6SA1lds8jzKgZCR9JjIbioyv5jKwZQo2n6UxT8yRU3Es1qM2Fxmdv-p0cqGBhh4CjT5QNzlBAFRJ0OTLvisXB8e");
         
         final WebPushVariant variant = new WebPushVariant();
         variant.setName("WebPush Variant Name");
+        variant.setFcmServerKey("FCM Server Key");
         
         // when
         deviceTokenTest(installation, variant);

--- a/push/sender/pom.xml
+++ b/push/sender/pom.xml
@@ -126,6 +126,12 @@
             <version>0.1.0</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>fluent-hc</artifactId>
+            <version>4.3.6</version>
+        </dependency>
+
     </dependencies>
 
     <profiles>

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/configuration/SenderConfigurationProvider.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/configuration/SenderConfigurationProvider.java
@@ -16,14 +16,14 @@
  */
 package org.jboss.aerogear.unifiedpush.message.configuration;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Produces;
-
 import org.jboss.aerogear.unifiedpush.api.VariantType;
 import org.jboss.aerogear.unifiedpush.message.sender.SenderType;
 import org.jboss.aerogear.unifiedpush.system.ConfigurationUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
 
 /**
  * Loads and stores configuration for specific Push Networks.
@@ -73,6 +73,11 @@ public class SenderConfigurationProvider {
     @Produces @ApplicationScoped @SenderType(VariantType.WINDOWS_WNS)
     public SenderConfiguration produceWindowsWnsConfiguration() {
         return loadConfigurationFor(VariantType.WINDOWS_WNS, new SenderConfiguration(10, 1000));
+    }
+    
+    @Produces @ApplicationScoped @SenderType(VariantType.WEB_PUSH)
+    public SenderConfiguration produceWebPushConfiguration() {
+        return loadConfigurationFor(VariantType.WEB_PUSH, new SenderConfiguration(10, 1000));
     }
 
     private SenderConfiguration loadConfigurationFor(VariantType type, SenderConfiguration defaultConfiguration) {

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/jms/MessageHolderWithTokensProducer.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/jms/MessageHolderWithTokensProducer.java
@@ -16,14 +16,14 @@
  */
 package org.jboss.aerogear.unifiedpush.message.jms;
 
+import org.jboss.aerogear.unifiedpush.api.VariantType;
+import org.jboss.aerogear.unifiedpush.message.holder.MessageHolderWithTokens;
+import org.jboss.aerogear.unifiedpush.message.util.JmsClient;
+
 import javax.annotation.Resource;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 import javax.jms.Queue;
-
-import org.jboss.aerogear.unifiedpush.api.VariantType;
-import org.jboss.aerogear.unifiedpush.message.holder.MessageHolderWithTokens;
-import org.jboss.aerogear.unifiedpush.message.util.JmsClient;
 
 /**
  * Receives CDI event with {@link MessageHolderWithTokens} payload and dispatches this payload to JMS queue selected by a type of the variant specified in payload.
@@ -52,6 +52,9 @@ public class MessageHolderWithTokensProducer extends AbstractJMSMessageProducer 
 
     @Resource(mappedName = "java:/queue/WNSTokenBatchQueue")
     private Queue wnsTokenBatchQueue;
+    
+    @Resource(mappedName = "java:/queue/WebPushTokenBatchQueue")
+    private Queue webPushTokenBatchQueue;
 
     public void queueMessageVariantForProcessing(@Observes @DispatchToQueue MessageHolderWithTokens msg) {
         String deduplicationId = String.format("%s-%s", msg.getPushMessageInformation().getId(), msg.getSerialId());
@@ -72,6 +75,8 @@ public class MessageHolderWithTokensProducer extends AbstractJMSMessageProducer 
                 return mpnsTokenBatchQueue;
             case WINDOWS_WNS:
                 return wnsTokenBatchQueue;
+            case WEB_PUSH:
+                return webPushTokenBatchQueue;
             default:
                 throw new IllegalStateException("Unknown variant type queue");
         }

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/jms/MessageHolderWithVariantsProducer.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/jms/MessageHolderWithVariantsProducer.java
@@ -16,14 +16,14 @@
  */
 package org.jboss.aerogear.unifiedpush.message.jms;
 
+import org.jboss.aerogear.unifiedpush.api.VariantType;
+import org.jboss.aerogear.unifiedpush.message.holder.MessageHolderWithVariants;
+
 import javax.annotation.Resource;
 import javax.ejb.Stateless;
 import javax.enterprise.event.Observes;
 import javax.jms.ConnectionFactory;
 import javax.jms.Queue;
-
-import org.jboss.aerogear.unifiedpush.api.VariantType;
-import org.jboss.aerogear.unifiedpush.message.holder.MessageHolderWithVariants;
 
 /**
  * Receives CDI event with {@link MessageHolderWithVariants} payload and dispatches this payload to JMS queue selected by a type of the variant specified in payload.
@@ -53,6 +53,9 @@ public class MessageHolderWithVariantsProducer extends AbstractJMSMessageProduce
 
     @Resource(mappedName = "java:/queue/WNSPushMessageQueue")
     private Queue wnsPushMessageQueue;
+    
+    @Resource(mappedName = "java:/queue/WebPushMessageQueue")
+    private Queue webPushMessageQueue;
 
     public void queueMessageVariantForProcessing(@Observes @DispatchToQueue MessageHolderWithVariants msg) {
         sendTransacted(selectQueue(msg.getVariantType()), msg);
@@ -72,6 +75,8 @@ public class MessageHolderWithVariantsProducer extends AbstractJMSMessageProduce
                 return mpnsPushMessageQueue;
             case WINDOWS_WNS:
                 return wnsPushMessageQueue;
+            case WEB_PUSH:
+                return webPushMessageQueue;
             default:
                 throw new IllegalStateException("Unknown variant type queue");
         }

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/WebPushNotificationSender.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/WebPushNotificationSender.java
@@ -1,0 +1,67 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright Red Hat, Inc., and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.aerogear.unifiedpush.message.sender;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.fluent.Request;
+import org.apache.http.util.EntityUtils;
+import org.jboss.aerogear.unifiedpush.api.Variant;
+import org.jboss.aerogear.unifiedpush.api.VariantType;
+import org.jboss.aerogear.unifiedpush.message.UnifiedPushMessage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+
+@SenderType(VariantType.WEB_PUSH)
+public class WebPushNotificationSender implements PushNotificationSender {
+    
+    private final Logger logger = LoggerFactory.getLogger(WebPushNotificationSender.class);
+    
+    private static final String MPS_URL = "https://updates.push.services.mozilla.com/wpush/v1/";
+
+    @Override
+    public void sendPushMessage(Variant variant, Collection<String> clientIdentifiers, UnifiedPushMessage pushMessage,
+            String pushMessageInformationId, NotificationSenderCallback senderCallback) {
+        
+        final int ttl = pushMessage.getConfig().getTimeToLive();
+
+        int successCount = 0;
+        for (String endpoint : clientIdentifiers) {
+            try {
+                HttpResponse response = Request.Post(MPS_URL + endpoint)
+                        .addHeader("TTL", String.valueOf(ttl))
+                        .execute()
+                        .returnResponse();
+                int statusCode = response.getStatusLine().getStatusCode();
+                if (statusCode == HttpStatus.SC_CREATED) {
+                    senderCallback.onSuccess();
+                    successCount++;
+                } else {
+                    String content = EntityUtils.toString(response.getEntity());
+                    logger.error("Error sending payload to MPS. Response status {}, content: {}", statusCode, content);
+                    senderCallback.onError(content);
+                }
+            } catch (Exception e) {
+                logger.error("Error sending push message to MPS", e);
+                senderCallback.onError(e.getMessage());
+            }
+        }
+        logger.info("Sent push notification to MPS Server for {} tokens of {}", successCount, clientIdentifiers.size());
+    }
+}

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/WebPushNotificationSender.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/WebPushNotificationSender.java
@@ -16,13 +16,17 @@
  */
 package org.jboss.aerogear.unifiedpush.message.sender;
 
+import org.apache.http.HttpHeaders;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.fluent.Request;
+import org.apache.http.entity.ContentType;
 import org.apache.http.util.EntityUtils;
 import org.jboss.aerogear.unifiedpush.api.Variant;
 import org.jboss.aerogear.unifiedpush.api.VariantType;
+import org.jboss.aerogear.unifiedpush.api.WebPushVariant;
 import org.jboss.aerogear.unifiedpush.message.UnifiedPushMessage;
+import org.json.simple.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,35 +37,111 @@ public class WebPushNotificationSender implements PushNotificationSender {
     
     private final Logger logger = LoggerFactory.getLogger(WebPushNotificationSender.class);
     
-    private static final String MPS_URL = "https://updates.push.services.mozilla.com/wpush/v1/";
+    private enum WebPushProvider {
+        
+        MPS("https://updates.push.services.mozilla.com/wpush/v1/"),
+        FCM("https://fcm.googleapis.com/fcm/send");
+        
+        private final String url;
+        
+        WebPushProvider(String url) {
+            this.url = url;
+        }
+        
+        public String getUrl() {
+            return url;
+        }
+        
+        public static WebPushProvider defineProvider(String endpoint) {
+            if (endpoint.startsWith(MPS.getUrl())) {
+                return MPS;
+            } else {
+                return FCM;
+            }
+        }
+    }
 
     @Override
     public void sendPushMessage(Variant variant, Collection<String> clientIdentifiers, UnifiedPushMessage pushMessage,
             String pushMessageInformationId, NotificationSenderCallback senderCallback) {
         
-        final int ttl = pushMessage.getConfig().getTimeToLive();
+        int ttl = pushMessage.getConfig().getTimeToLive();
+        if (ttl == -1) {
+            ttl = 0;
+        }
 
         int successCount = 0;
         for (String endpoint : clientIdentifiers) {
             try {
-                HttpResponse response = Request.Post(MPS_URL + endpoint)
-                        .addHeader("TTL", String.valueOf(ttl))
+                final WebPushProvider wpp = WebPushProvider.defineProvider(endpoint);
+    
+                final String postUrl = getPostUrl(endpoint, wpp);
+                
+                final Request request = Request
+                        .Post(postUrl)
+                        .addHeader("TTL", String.valueOf(ttl));
+    
+                switch (wpp) {
+                    case MPS:
+                        // nothing to do
+                        break;
+                    case FCM:
+                        final JSONObject jsonObject = new JSONObject();
+                        jsonObject.put("to", extractSubscriptionId(endpoint));
+                        final String body = jsonObject.toJSONString();
+                        
+                        WebPushVariant wpVariant = (WebPushVariant) variant;
+                        request.addHeader(HttpHeaders.AUTHORIZATION, "key=" + wpVariant.getFcmServerKey())
+                                .bodyString(body, ContentType.APPLICATION_JSON);
+                        break;
+                    default:
+                        throw new IllegalArgumentException("Unsupported WebPush provider: " + wpp);
+                }
+                
+                logger.debug("WebPush request to {}: {}", wpp, request);
+                
+                final HttpResponse response = request
                         .execute()
                         .returnResponse();
-                int statusCode = response.getStatusLine().getStatusCode();
-                if (statusCode == HttpStatus.SC_CREATED) {
+                
+                final int statusCode = response.getStatusLine().getStatusCode();
+                if (statusCode >= HttpStatus.SC_OK && statusCode <= HttpStatus.SC_NO_CONTENT) {
                     senderCallback.onSuccess();
                     successCount++;
                 } else {
                     String content = EntityUtils.toString(response.getEntity());
-                    logger.error("Error sending payload to MPS. Response status {}, content: {}", statusCode, content);
+                    logger.error("Error sending payload to {}. Response status {}, content: {}",
+                            wpp, statusCode, content);
                     senderCallback.onError(content);
                 }
             } catch (Exception e) {
-                logger.error("Error sending push message to MPS", e);
+                logger.error("Error sending push message", e);
                 senderCallback.onError(e.getMessage());
             }
         }
-        logger.info("Sent push notification to MPS Server for {} tokens of {}", successCount, clientIdentifiers.size());
+        logger.info("Sent {} web push notification of {}", successCount, clientIdentifiers.size());
+    }
+    
+    private static String getPostUrl(String endpoint, WebPushProvider wpp) {
+        final String postUrl;
+        switch (wpp) {
+            case MPS:
+                postUrl = endpoint;
+                break;
+            case FCM:
+                postUrl = wpp.getUrl();
+                break;
+            default:
+                throw new IllegalArgumentException("Unsupported WebPush provider: " + wpp);
+        }
+        return postUrl;
+    }
+    
+    private static String extractSubscriptionId(String endpoint) {
+        final int idx = endpoint.lastIndexOf('/');
+        if (idx < 0) {
+            throw new IllegalArgumentException("Can not extract subscriptionId from the endpoint: " + endpoint);
+        }
+        return endpoint.substring(idx + 1);
     }
 }

--- a/push/sender/src/test/resources/jms-cleanup-wildfly.cli
+++ b/push/sender/src/test/resources/jms-cleanup-wildfly.cli
@@ -35,6 +35,11 @@ batch
 /subsystem=messaging-activemq/server=default/jms-queue=WNSTokenBatchQueue:remove()
 /subsystem=messaging-activemq/server=default/address-setting=jms.queue.WNSTokenBatchQueue:remove()
 
+/subsystem=messaging-activemq/server=default/jms-queue=WebPushMessageQueue:remove()
+/subsystem=messaging-activemq/server=default/address-setting=jms.queue.WebPushMessageQueue:remove()
+/subsystem=messaging-activemq/server=default/jms-queue=WebPushTokenBatchQueue:remove()
+/subsystem=messaging-activemq/server=default/address-setting=jms.queue.WebPushTokenBatchQueue:remove()
+
 
 
 /subsystem=messaging-activemq/server=default/jms-queue=MetricsQueue:remove()

--- a/servers/ups-wildfly/src/main/webapp/WEB-INF/jboss-ejb3.xml
+++ b/servers/ups-wildfly/src/main/webapp/WEB-INF/jboss-ejb3.xml
@@ -140,6 +140,25 @@
                 </activation-config-property>
             </activation-config>
         </message-driven>
+        <message-driven>
+            <ejb-name>WebPushMessageConsumer</ejb-name>
+            <ejb-class>org.jboss.aerogear.unifiedpush.message.jms.MessageHolderWithVariantsConsumer</ejb-class>
+            <transaction-type>Container</transaction-type>
+            <activation-config>
+                <activation-config-property>
+                    <activation-config-property-name>destination</activation-config-property-name>
+                    <activation-config-property-value>queue/WebPushMessageQueue</activation-config-property-value>
+                </activation-config-property>
+                <activation-config-property>
+                    <activation-config-property-name>destinationType</activation-config-property-name>
+                    <activation-config-property-value>javax.jms.Queue</activation-config-property-value>
+                </activation-config-property>
+                <activation-config-property>
+                    <activation-config-property-name>acknowledgeMode</activation-config-property-name>
+                    <activation-config-property-value>Auto-acknowledge</activation-config-property-value>
+                </activation-config-property>
+            </activation-config>
+        </message-driven>
         
         <!-- Token Batch Queue MDBs -->
         <message-driven>
@@ -277,6 +296,25 @@
                 <activation-config-property>
                     <activation-config-property-name>maxSession</activation-config-property-name>
                     <activation-config-property-value>15</activation-config-property-value>
+                </activation-config-property>
+            </activation-config>
+        </message-driven>
+        <message-driven>
+            <ejb-name>WebPushTokenBatchConsumer</ejb-name>
+            <ejb-class>org.jboss.aerogear.unifiedpush.message.jms.MessageHolderWithTokensConsumer</ejb-class>
+            <transaction-type>Container</transaction-type>
+            <activation-config>
+                <activation-config-property>
+                    <activation-config-property-name>destination</activation-config-property-name>
+                    <activation-config-property-value>queue/WebPushTokenBatchQueue</activation-config-property-value>
+                </activation-config-property>
+                <activation-config-property>
+                    <activation-config-property-name>destinationType</activation-config-property-name>
+                    <activation-config-property-value>javax.jms.Queue</activation-config-property-value>
+                </activation-config-property>
+                <activation-config-property>
+                    <activation-config-property-name>acknowledgeMode</activation-config-property-name>
+                    <activation-config-property-value>Auto-acknowledge</activation-config-property-value>
                 </activation-config-property>
             </activation-config>
         </message-driven>


### PR DESCRIPTION
After discussion in mailing list we decided to try create a Webpush variant for all browsers, which support Push API.

Current version supports sending push notifications just to Firefox.

To add Google Chrome we have to store auth tokens and determine the browser type in `WebpushPushNotificationSender.java`.