### PR TITLE
Adds payload encryption for WebPush variant (v1)

### DIFF
--- a/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/Installation.java
+++ b/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/Installation.java
@@ -42,6 +42,10 @@ public class Installation extends BaseModel {
     @JsonIgnore
     private Variant variant;
 
+    // for WebPushVariant:
+    private String publicKey;
+    private String authSecret;
+
     public boolean isEnabled() {
         return this.enabled;
     }
@@ -171,5 +175,32 @@ public class Installation extends BaseModel {
 
     public void setVariant(Variant variant) {
         this.variant = variant;
+    }
+
+    public String getPublicKey() {
+        return publicKey;
+    }
+
+    /**
+     * A elliptic curve Diffie-Hellman (ECDH) public key from the User Agent for push message encryption.
+     *
+     * @param publicKey the string representation of a public key
+     */
+    public void setPublicKey(String publicKey) {
+        this.publicKey = publicKey;
+    }
+
+    public String getAuthSecret() {
+        return authSecret;
+    }
+
+    /**
+     * The authentication secret ensures that exposure or leakage of the DH public key - which, as a public key,
+     * is not necessarily treated as a secret - does not enable an adversary to generate valid push messages.
+     *
+     * @param authSecret the string representation of an authentication secret
+     */
+    public void setAuthSecret(String authSecret) {
+        this.authSecret = authSecret;
     }
 }

--- a/model/api/src/main/java/org/jboss/aerogear/unifiedpush/dao/InstallationDao.java
+++ b/model/api/src/main/java/org/jboss/aerogear/unifiedpush/dao/InstallationDao.java
@@ -18,6 +18,7 @@ package org.jboss.aerogear.unifiedpush.dao;
 
 import org.jboss.aerogear.unifiedpush.api.Installation;
 import org.jboss.aerogear.unifiedpush.dto.Count;
+import org.jboss.aerogear.unifiedpush.dto.Token;
 
 import java.util.List;
 import java.util.Set;
@@ -59,7 +60,7 @@ public interface InstallationDao extends GenericBaseDao<Installation, String> {
      *
      * @return list of device tokens that matches this filter
      */
-    ResultsStream.QueryBuilder<String> findAllDeviceTokenForVariantIDByCriteria(String variantID, List<String> categories, List<String> aliases, List<String> deviceTypes, int maxResults, String lastTokenFromPreviousBatch, boolean oldGCM);
+    ResultsStream.QueryBuilder<Token> findAllDeviceTokenForVariantIDByCriteria(String variantID, List<String> categories, List<String> aliases, List<String> deviceTypes, int maxResults, String lastTokenFromPreviousBatch, boolean oldGCM);
 
     Set<String> findAllDeviceTokenForVariantID(String variantID);
 

--- a/model/api/src/main/java/org/jboss/aerogear/unifiedpush/dto/Token.java
+++ b/model/api/src/main/java/org/jboss/aerogear/unifiedpush/dto/Token.java
@@ -1,0 +1,82 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright Red Hat, Inc., and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.aerogear.unifiedpush.dto;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+/**
+ * Holds device token information.
+ *
+ * May be extended if a variant requires additional field for sending push message.
+ */
+public class Token implements Serializable, Comparable<Token> {
+
+    private static final long serialVersionUID = -3782844785133457996L;
+
+    private final String endpoint;
+
+    public Token(String endpoint) {
+        this.endpoint = Objects.requireNonNull(endpoint, "endpoint can not be null");
+    }
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    @Override
+    public int compareTo(Token that) {
+        return this.endpoint.compareTo(that.endpoint);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Token token = (Token) o;
+        return Objects.equals(endpoint, token.endpoint);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(endpoint);
+    }
+
+    /**
+     * Transforms collection of {@link Token} objects to collections of strings for backward compatibility.
+     */
+    public static List<String> toEndpoints(Collection<Token> tokens) {
+        return tokens.stream()
+                .map(Token::getEndpoint)
+                .collect(Collectors.toList());
+    }
+
+    public static Set<Token> toTokens(Collection<String> endpoints) {
+        return endpoints.stream()
+                .map(Token::new)
+                .collect(Collectors.toCollection(TreeSet::new));
+    }
+}

--- a/model/api/src/main/java/org/jboss/aerogear/unifiedpush/dto/WebPushToken.java
+++ b/model/api/src/main/java/org/jboss/aerogear/unifiedpush/dto/WebPushToken.java
@@ -1,0 +1,44 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright Red Hat, Inc., and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.aerogear.unifiedpush.dto;
+
+import org.jboss.aerogear.unifiedpush.api.VariantType;
+
+/**
+ * Holds additional information for {@link VariantType#WEB_PUSH} for push message encryption.
+ */
+public final class WebPushToken extends Token {
+
+    private static final long serialVersionUID = 58015315605339296L;
+
+    private final String publicKey;
+    private final String authSercret;
+
+    public WebPushToken(String endpoint, String publicKey, String authSercret) {
+        super(endpoint);
+        this.publicKey = publicKey;
+        this.authSercret = authSercret;
+    }
+
+    public String getPublicKey() {
+        return publicKey;
+    }
+
+    public String getAuthSercret() {
+        return authSercret;
+    }
+}

--- a/model/jpa/src/main/resources/org/jboss/aerogear/unifiedpush/api/Installation.hbm.xml
+++ b/model/jpa/src/main/resources/org/jboss/aerogear/unifiedpush/api/Installation.hbm.xml
@@ -39,5 +39,11 @@
                 <column name="category_id" not-null="true" />
             </many-to-many>
         </set>
+        <property name="publicKey" type="java.lang.String">
+            <column name="public_key" />
+        </property>
+        <property name="authSecret" type="java.lang.String">
+            <column name="auth_secret" />
+        </property>
     </class>
 </hibernate-mapping>

--- a/model/jpa/src/test/java/org/jboss/aerogear/unifiedpush/jpa/InstallationDaoTest.java
+++ b/model/jpa/src/test/java/org/jboss/aerogear/unifiedpush/jpa/InstallationDaoTest.java
@@ -31,6 +31,7 @@ import org.jboss.aerogear.unifiedpush.dao.PageResult;
 import org.jboss.aerogear.unifiedpush.dao.ResultStreamException;
 import org.jboss.aerogear.unifiedpush.dao.ResultsStream;
 import org.jboss.aerogear.unifiedpush.dto.Count;
+import org.jboss.aerogear.unifiedpush.dto.Token;
 import org.jboss.aerogear.unifiedpush.jpa.dao.impl.JPAInstallationDao;
 import org.jboss.aerogear.unifiedpush.utils.DaoDeployment;
 import org.jboss.aerogear.unifiedpush.utils.TestUtils;
@@ -105,7 +106,7 @@ public class InstallationDaoTest {
     @Test
     public void findDeviceTokensForOneInstallationOfOneVariant() {
         String[] alias = { "foo@bar.org" };
-        List<String> tokens = findAllDeviceTokenForVariantIDByCriteria(androidVariantID, null, Arrays.asList(alias), null);
+        List<Token> tokens = findAllDeviceTokenForVariantIDByCriteria(androidVariantID, null, Arrays.asList(alias), null);
         assertThat(tokens).hasSize(4);
 
         Installation one = installationDao.findInstallationForVariantByDeviceToken(androidVariantID, DEVICE_TOKEN_1);
@@ -121,47 +122,47 @@ public class InstallationDaoTest {
 
     @Test
     public void findDeviceTokensOfVariant() {
-        List<String> tokens = findAllDeviceTokenForVariantIDByCriteria(androidVariantID, null, null, null);
+        List<Token> tokens = findAllDeviceTokenForVariantIDByCriteria(androidVariantID, null, null, null);
         assertThat(tokens).hasSize(4);
-        assertThat(tokens).containsOnly(DEVICE_TOKEN_1, DEVICE_TOKEN_2, DEVICE_TOKEN_3, DEVICE_TOKEN_4);
+        assertThat(Token.toEndpoints(tokens)).containsOnly(DEVICE_TOKEN_1, DEVICE_TOKEN_2, DEVICE_TOKEN_3, DEVICE_TOKEN_4);
     }
 
     @Test
     public void findOldGCMDeviceTokensOfVariant() {
-        List<String> tokens = findAllOldGCMDeviceTokenForVariantIDByCriteria(androidVariantID, null, null, null);
+        List<Token> tokens = findAllOldGCMDeviceTokenForVariantIDByCriteria(androidVariantID, null, null, null);
         assertThat(tokens).hasSize(2);
-        assertThat(tokens).containsOnly(DEVICE_TOKEN_1, DEVICE_TOKEN_2);
+        assertThat(Token.toEndpoints(tokens)).containsOnly(DEVICE_TOKEN_1, DEVICE_TOKEN_2);
     }
 
     @Test
     public void findDeviceTokensForAliasOfVariant() {
         String[] alias = { "foo@bar.org" };
-        List<String> tokens = findAllDeviceTokenForVariantIDByCriteria(androidVariantID, null, Arrays.asList(alias), null);
+        List<Token> tokens = findAllDeviceTokenForVariantIDByCriteria(androidVariantID, null, Arrays.asList(alias), null);
         assertThat(tokens).hasSize(4);
-        assertThat(tokens).containsOnly(DEVICE_TOKEN_1, DEVICE_TOKEN_2, DEVICE_TOKEN_3, DEVICE_TOKEN_4);
+        assertThat(Token.toEndpoints(tokens)).containsOnly(DEVICE_TOKEN_1, DEVICE_TOKEN_2, DEVICE_TOKEN_3, DEVICE_TOKEN_4);
     }
 
     @Test
     public void findNoDeviceTokensForAliasOfVariant() {
         String[] alias = { "bar@foo.org" };
-        List<String> tokens = findAllDeviceTokenForVariantIDByCriteria(androidVariantID, null, Arrays.asList(alias), null);
-         assertThat(tokens).hasSize(0);
+        List<Token> tokens = findAllDeviceTokenForVariantIDByCriteria(androidVariantID, null, Arrays.asList(alias), null);
+        assertThat(tokens).hasSize(0);
     }
 
     @Test
     public void findDeviceTokensForAliasAndDeviceType() {
         String[] alias = { "foo@bar.org" };
         String[] types = { "Android Tablet" };
-        List<String> tokens = findAllDeviceTokenForVariantIDByCriteria(androidVariantID, null, Arrays.asList(alias), Arrays.asList(types));
+        List<Token> tokens = findAllDeviceTokenForVariantIDByCriteria(androidVariantID, null, Arrays.asList(alias), Arrays.asList(types));
         assertThat(tokens).hasSize(2);
-        assertThat(tokens).containsOnly(DEVICE_TOKEN_2, DEVICE_TOKEN_3);
+        assertThat(Token.toEndpoints(tokens)).containsOnly(DEVICE_TOKEN_2, DEVICE_TOKEN_3);
     }
 
     @Test
     public void findNoDeviceTokensForAliasAndUnusedDeviceType() {
         String[] alias = { "foo@bar.org" };
         String[] types = { "Android Clock" };
-        List<String> tokens = findAllDeviceTokenForVariantIDByCriteria(androidVariantID, null, Arrays.asList(alias), Arrays.asList(types));
+        List<Token> tokens = findAllDeviceTokenForVariantIDByCriteria(androidVariantID, null, Arrays.asList(alias), Arrays.asList(types));
         assertThat(tokens).isEmpty();
     }
 
@@ -170,7 +171,7 @@ public class InstallationDaoTest {
         String[] alias = { "foo@bar.org" };
         String[] types = { "Android Tablet" };
         String[] categories = { "soccer" };
-        List<String> tokens = findAllDeviceTokenForVariantIDByCriteria(androidVariantID, Arrays.asList(categories), Arrays.asList(alias), Arrays
+        List<Token> tokens = findAllDeviceTokenForVariantIDByCriteria(androidVariantID, Arrays.asList(categories), Arrays.asList(alias), Arrays
                 .asList(types));
         assertThat(tokens).isEmpty();
     }
@@ -180,23 +181,23 @@ public class InstallationDaoTest {
         String[] alias = { "foo@bar.org" };
         String[] types = { "Android Phone" };
         String[] cats = { "soccer", "news", "weather" };
-        List<String> tokens = findAllDeviceTokenForVariantIDByCriteria(androidVariantID, Arrays.asList(cats), Arrays.asList(alias), Arrays.asList(types));
+        List<Token> tokens = findAllDeviceTokenForVariantIDByCriteria(androidVariantID, Arrays.asList(cats), Arrays.asList(alias), Arrays.asList(types));
         assertThat(tokens).hasSize(1);
-        assertThat(tokens).containsOnly(DEVICE_TOKEN_1);
+        assertThat(Token.toEndpoints(tokens)).containsOnly(DEVICE_TOKEN_1);
     }
 
     @Test
     public void findTwoDeviceTokensForAliasAndCategories() {
         String[] alias = { "foo@bar.org" };
         String[] cats = { "soccer", "news", "weather" };
-        List<String> tokens = findAllDeviceTokenForVariantIDByCriteria(androidVariantID, Arrays.asList(cats), Arrays.asList(alias), null);
+        List<Token> tokens = findAllDeviceTokenForVariantIDByCriteria(androidVariantID, Arrays.asList(cats), Arrays.asList(alias), null);
         assertThat(tokens).hasSize(2);
     }
 
     @Test
     public void findTwoDeviceTokensCategories() {
         String[] cats = { "soccer", "news", "weather" };
-        List<String> tokens = findAllDeviceTokenForVariantIDByCriteria(androidVariantID, Arrays.asList(cats), null, null);
+        List<Token> tokens = findAllDeviceTokenForVariantIDByCriteria(androidVariantID, Arrays.asList(cats), null, null);
         assertThat(tokens).hasSize(2);
     }
 
@@ -270,17 +271,17 @@ public class InstallationDaoTest {
     @Test
     public void findPushEndpointsForAlias() {
         String[] alias = { "foo@bar.org" };
-        List<String> tokens = findAllDeviceTokenForVariantIDByCriteria(simplePushVariantID, null, Arrays.asList(alias), null);
+        List<Token> tokens = findAllDeviceTokenForVariantIDByCriteria(simplePushVariantID, null, Arrays.asList(alias), null);
         assertThat(tokens).hasSize(3);
-        assertThat(tokens.get(0)).startsWith("http://server:8080/update/");
-        assertThat(tokens.get(1)).startsWith("http://server:8080/update/");
+        assertThat(tokens.get(0).getEndpoint()).startsWith("http://server:8080/update/");
+        assertThat(tokens.get(1).getEndpoint()).startsWith("http://server:8080/update/");
     }
 
     @Test
     public void findZeroPushEndpointsForAliasAndCategories() {
         String[] alias = { "foo@bar.org" };
         String[] categories = { "US Football" };
-        List<String> tokens = findAllDeviceTokenForVariantIDByCriteria(simplePushVariantID, Arrays.asList(categories), Arrays.asList(alias), null);
+        List<Token> tokens = findAllDeviceTokenForVariantIDByCriteria(simplePushVariantID, Arrays.asList(categories), Arrays.asList(alias), null);
         assertThat(tokens).isEmpty();
     }
 
@@ -288,9 +289,9 @@ public class InstallationDaoTest {
     public void findOnePushEndpointForAliasAndCategories() {
         String[] alias = { "foo@bar.org" };
         String[] cats = { "soccer", "weather" };
-        List<String> tokens = findAllDeviceTokenForVariantIDByCriteria(simplePushVariantID, Arrays.asList(cats), Arrays.asList(alias), null);
+        List<Token> tokens = findAllDeviceTokenForVariantIDByCriteria(simplePushVariantID, Arrays.asList(cats), Arrays.asList(alias), null);
         assertThat(tokens).hasSize(1);
-        assertThat(tokens.get(0)).startsWith("http://server:8080/update/");
+        assertThat(tokens.get(0).getEndpoint()).startsWith("http://server:8080/update/");
 
     }
 
@@ -298,36 +299,36 @@ public class InstallationDaoTest {
     public void findThreePushEndpointsForAliasAndCategories() {
         String[] alias = { "foo@bar.org" };
         String[] cats = { "soccer", "news", "weather" };
-        List<String> tokens = findAllDeviceTokenForVariantIDByCriteria(simplePushVariantID, Arrays.asList(cats), Arrays.asList(alias), null);
+        List<Token> tokens = findAllDeviceTokenForVariantIDByCriteria(simplePushVariantID, Arrays.asList(cats), Arrays.asList(alias), null);
         assertThat(tokens).hasSize(3);
-        assertThat(tokens.get(0)).startsWith("http://server:8080/update/");
-        assertThat(tokens.get(1)).startsWith("http://server:8080/update/");
-        assertThat(tokens.get(2)).startsWith("http://server:8080/update/");
+        assertThat(tokens.get(0).getEndpoint()).startsWith("http://server:8080/update/");
+        assertThat(tokens.get(1).getEndpoint()).startsWith("http://server:8080/update/");
+        assertThat(tokens.get(2).getEndpoint()).startsWith("http://server:8080/update/");
     }
 
     @Test
     public void findThreePushEndpointsForCategories() {
         String[] cats = { "soccer", "news", "weather" };
-        List<String> tokens = findAllDeviceTokenForVariantIDByCriteria(simplePushVariantID, Arrays.asList(cats), null, null);
+        List<Token> tokens = findAllDeviceTokenForVariantIDByCriteria(simplePushVariantID, Arrays.asList(cats), null, null);
         assertThat(tokens).hasSize(3);
-        assertThat(tokens.get(0)).startsWith("http://server:8080/update/");
-        assertThat(tokens.get(1)).startsWith("http://server:8080/update/");
-        assertThat(tokens.get(2)).startsWith("http://server:8080/update/");
+        assertThat(tokens.get(0).getEndpoint()).startsWith("http://server:8080/update/");
+        assertThat(tokens.get(1).getEndpoint()).startsWith("http://server:8080/update/");
+        assertThat(tokens.get(2).getEndpoint()).startsWith("http://server:8080/update/");
     }
 
     @Test
     public void findPushEndpointsWithDeviceType() {
         String[] types = {"JavaFX Monitor"};
-        List<String> tokens = findAllDeviceTokenForVariantIDByCriteria(simplePushVariantID, null, null, Arrays.asList(types));
+        List<Token> tokens = findAllDeviceTokenForVariantIDByCriteria(simplePushVariantID, null, null, Arrays.asList(types));
         assertThat(tokens).hasSize(1);
-        assertThat(tokens.get(0)).startsWith("http://server:8080/update/");
+        assertThat(tokens.get(0).getEndpoint()).startsWith("http://server:8080/update/");
     }
 
     @Test
     public void findPushEndpointsWithoutDeviceType() {
-        List<String> tokens = findAllDeviceTokenForVariantIDByCriteria(simplePushVariantID, null, null, null);
+        List<Token> tokens = findAllDeviceTokenForVariantIDByCriteria(simplePushVariantID, null, null, null);
         assertThat(tokens).hasSize(3);
-        assertThat(tokens.get(0)).startsWith("http://server:8080/update/");
+        assertThat(tokens.get(0).getEndpoint()).startsWith("http://server:8080/update/");
     }
 
     @Test
@@ -502,30 +503,30 @@ public class InstallationDaoTest {
         // when
         deviceTokenTest(installation, variant);
     }
-    
+
     @Test(expected = ConstraintViolationException.class)
     public void shouldNotSaveWhenWebPushTokenDoesNotUseHttps() {
         // given
         final Installation installation = new Installation();
         installation.setDeviceToken("http://updates.push.services.mozilla.com/wpush/v1/gAAAAABXlQW2uvaJJk3Q6hey1cj2PjZYtGaDcY82DffVUF1OiV4Eu6SA1lds8jzKgZCR9JjIbioyv5jKwZQo2n6UxT8yRU3Es1qM2Fxmdv-p0cqGBhh4CjT5QNzlBAFRJ0OTLvisXB8e");
-        
+
         final WebPushVariant variant = new WebPushVariant();
         variant.setName("WebPush Variant Name");
-        
+
         // when
         deviceTokenTest(installation, variant);
     }
-    
+
     @Test
     public void shouldSaveWhenWebPushTokenValid() {
         // given
         final Installation installation = new Installation();
         installation.setDeviceToken("https://updates.push.services.mozilla.com/wpush/v1/gAAAAABXlQW2uvaJJk3Q6hey1cj2PjZYtGaDcY82DffVUF1OiV4Eu6SA1lds8jzKgZCR9JjIbioyv5jKwZQo2n6UxT8yRU3Es1qM2Fxmdv-p0cqGBhh4CjT5QNzlBAFRJ0OTLvisXB8e");
-        
+
         final WebPushVariant variant = new WebPushVariant();
         variant.setName("WebPush Variant Name");
         variant.setFcmServerKey("FCM Server Key");
-        
+
         // when
         deviceTokenTest(installation, variant);
     }
@@ -669,16 +670,16 @@ public class InstallationDaoTest {
         entityManager.flush();
     }
 
-    private List<String> findAllDeviceTokenForVariantIDByCriteria(String variantID, List<String> categories, List<String> aliases, List<String> deviceTypes) {
+    private List<Token> findAllDeviceTokenForVariantIDByCriteria(String variantID, List<String> categories, List<String> aliases, List<String> deviceTypes) {
         return findAllDeviceTokenForVariantIDByCriteria(variantID, categories, aliases, deviceTypes, false);
     }
-    private List<String> findAllOldGCMDeviceTokenForVariantIDByCriteria(String variantID, List<String> categories, List<String> aliases, List<String> deviceTypes) {
+    private List<Token> findAllOldGCMDeviceTokenForVariantIDByCriteria(String variantID, List<String> categories, List<String> aliases, List<String> deviceTypes) {
         return findAllDeviceTokenForVariantIDByCriteria(variantID, categories, aliases, deviceTypes, true);
     }
-    private List<String> findAllDeviceTokenForVariantIDByCriteria(String variantID, List<String> categories, List<String> aliases, List<String> deviceTypes, boolean oldGCM) {
+    private List<Token> findAllDeviceTokenForVariantIDByCriteria(String variantID, List<String> categories, List<String> aliases, List<String> deviceTypes, boolean oldGCM) {
         try {
-            ResultsStream<String> tokenStream = installationDao.findAllDeviceTokenForVariantIDByCriteria(variantID, categories, aliases, deviceTypes, Integer.MAX_VALUE, null, oldGCM).executeQuery();
-            List<String> list = new ArrayList<>();
+            ResultsStream<Token> tokenStream = installationDao.findAllDeviceTokenForVariantIDByCriteria(variantID, categories, aliases, deviceTypes, Integer.MAX_VALUE, null, oldGCM).executeQuery();
+            List<Token> list = new ArrayList<>();
             while (tokenStream.next()) {
                 list.add(tokenStream.get());
             }

--- a/push/sender/pom.xml
+++ b/push/sender/pom.xml
@@ -58,7 +58,7 @@
             <artifactId>jboss-ejb-api_3.1_spec</artifactId>
             <scope>provided</scope>
         </dependency>
-        
+
         <dependency>
             <groupId>org.jboss.spec.javax.jms</groupId>
             <artifactId>jboss-jms-api_1.1_spec</artifactId>
@@ -127,9 +127,9 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>fluent-hc</artifactId>
-            <version>4.3.6</version>
+            <groupId>nl.martijndwars</groupId>
+            <artifactId>web-push</artifactId>
+            <version>1.0.0</version>
         </dependency>
 
     </dependencies>

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/NotificationDispatcher.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/NotificationDispatcher.java
@@ -16,20 +16,12 @@
  */
 package org.jboss.aerogear.unifiedpush.message;
 
-import java.util.Collection;
-
-import javax.ejb.Stateless;
-import javax.enterprise.event.Event;
-import javax.enterprise.event.Observes;
-import javax.enterprise.inject.Any;
-import javax.enterprise.inject.Instance;
-import javax.inject.Inject;
-
 import org.jboss.aerogear.unifiedpush.api.PushMessageInformation;
 import org.jboss.aerogear.unifiedpush.api.Variant;
 import org.jboss.aerogear.unifiedpush.api.VariantMetricInformation;
 import org.jboss.aerogear.unifiedpush.message.event.TriggerVariantMetricCollectionEvent;
 import org.jboss.aerogear.unifiedpush.message.holder.MessageHolderWithTokens;
+import org.jboss.aerogear.unifiedpush.dto.Token;
 import org.jboss.aerogear.unifiedpush.message.jms.Dequeue;
 import org.jboss.aerogear.unifiedpush.message.jms.DispatchToQueue;
 import org.jboss.aerogear.unifiedpush.message.sender.NotificationSenderCallback;
@@ -38,6 +30,14 @@ import org.jboss.aerogear.unifiedpush.message.sender.SenderTypeLiteral;
 import org.jboss.aerogear.unifiedpush.message.token.TokenLoader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.ejb.Stateless;
+import javax.enterprise.event.Event;
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.Any;
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+import java.util.Collection;
 
 /**
  * Receives a request for dispatching push notifications to specified devices from {@link TokenLoader}
@@ -72,7 +72,7 @@ public class NotificationDispatcher {
     public void sendMessagesToPushNetwork(@Observes @Dequeue MessageHolderWithTokens msg) {
         final Variant variant = msg.getVariant();
         final UnifiedPushMessage unifiedPushMessage = msg.getUnifiedPushMessage();
-        final Collection<String> deviceTokens = msg.getDeviceTokens();
+        final Collection<Token> deviceTokens = msg.getDeviceTokens();
 
         logger.info(String.format("Received UnifiedPushMessage from JMS queue, will now trigger the Push Notification delivery for the %s variant (%s)", variant.getType().getTypeName(), variant.getVariantID()));
 

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/holder/MessageHolderWithTokens.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/holder/MessageHolderWithTokens.java
@@ -16,12 +16,13 @@
  */
 package org.jboss.aerogear.unifiedpush.message.holder;
 
-import java.io.Serializable;
-import java.util.Collection;
-
 import org.jboss.aerogear.unifiedpush.api.PushMessageInformation;
 import org.jboss.aerogear.unifiedpush.api.Variant;
+import org.jboss.aerogear.unifiedpush.dto.Token;
 import org.jboss.aerogear.unifiedpush.message.UnifiedPushMessage;
+
+import java.io.Serializable;
+import java.util.Collection;
 
 /**
  * Holds push message details together with information what specific variant and which device tokens should be notifications sent to.
@@ -34,9 +35,9 @@ public class MessageHolderWithTokens extends AbstractMessageHolder implements Se
 
     private int serialId;
     private Variant variant;
-    private Collection<String> deviceTokens;
+    private Collection<Token> deviceTokens;
 
-    public MessageHolderWithTokens(PushMessageInformation pushMessageInformation, UnifiedPushMessage unifiedPushMessage, Variant variant, Collection<String> deviceTokens, int serialId) {
+    public MessageHolderWithTokens(PushMessageInformation pushMessageInformation, UnifiedPushMessage unifiedPushMessage, Variant variant, Collection<Token> deviceTokens, int serialId) {
         super(pushMessageInformation, unifiedPushMessage);
         if (!(deviceTokens instanceof Serializable)) {
             throw new IllegalArgumentException("deviceTokens must be a serializable collection");
@@ -50,7 +51,7 @@ public class MessageHolderWithTokens extends AbstractMessageHolder implements Se
         return variant;
     }
 
-    public Collection<String> getDeviceTokens() {
+    public Collection<Token> getDeviceTokens() {
         return deviceTokens;
     }
 

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/APNsPushNotificationSender.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/APNsPushNotificationSender.java
@@ -35,6 +35,7 @@ import org.jboss.aerogear.unifiedpush.message.UnifiedPushMessage;
 import org.jboss.aerogear.unifiedpush.message.apns.APNs;
 import org.jboss.aerogear.unifiedpush.message.exception.PushNetworkUnreachableException;
 import org.jboss.aerogear.unifiedpush.message.exception.SenderResourceNotAvailableException;
+import org.jboss.aerogear.unifiedpush.dto.Token;
 import org.jboss.aerogear.unifiedpush.message.serviceHolder.ApnsServiceHolder;
 import org.jboss.aerogear.unifiedpush.message.serviceHolder.ServiceConstructor;
 import org.jboss.aerogear.unifiedpush.message.serviceHolder.ServiceDestroyer;
@@ -91,7 +92,7 @@ public class APNsPushNotificationSender implements PushNotificationSender {
      * @param pushMessageInformationId the id of the PushMessageInformation instance associated with this send.
      * @param callback that will be invoked after the sending.
      */
-    public void sendPushMessage(final Variant variant, final Collection<String> tokens, final UnifiedPushMessage pushMessage, final String pushMessageInformationId, final NotificationSenderCallback callback) {
+    public void sendPushMessage(final Variant variant, final Collection<Token> tokens, final UnifiedPushMessage pushMessage, final String pushMessageInformationId, final NotificationSenderCallback callback) {
         // no need to send empty list
         if (tokens.isEmpty()) {
             return;
@@ -161,7 +162,7 @@ public class APNsPushNotificationSender implements PushNotificationSender {
         try {
             logger.debug("Sending transformed APNs payload: " + apnsMessage);
             Date expireDate = createFutureDateBasedOnTTL(pushMessage.getConfig().getTimeToLive());
-            service.push(tokens, apnsMessage, expireDate);
+            service.push(Token.toEndpoints(tokens), apnsMessage, expireDate);
 
             logger.info(String.format("Sent push notification to the Apple APNs Server for %d tokens",tokens.size()));
             apnsServiceHolder.queueFreedUpService(pushMessageInformationId, iOSVariant.getVariantID(), service, new ServiceDestroyer<ApnsService>() {

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/AdmPushNotificationSender.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/AdmPushNotificationSender.java
@@ -25,6 +25,7 @@ import org.jboss.aerogear.unifiedpush.api.Variant;
 import org.jboss.aerogear.unifiedpush.api.VariantType;
 import org.jboss.aerogear.unifiedpush.message.InternalUnifiedPushMessage;
 import org.jboss.aerogear.unifiedpush.message.UnifiedPushMessage;
+import org.jboss.aerogear.unifiedpush.dto.Token;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,7 +36,7 @@ public class AdmPushNotificationSender implements PushNotificationSender {
     private final Logger logger = LoggerFactory.getLogger(AdmPushNotificationSender.class);
 
     @Override
-    public void sendPushMessage(Variant variant, Collection<String> clientIdentifiers, UnifiedPushMessage pushMessage, String pushMessageInformationId, NotificationSenderCallback senderCallback) {
+    public void sendPushMessage(Variant variant, Collection<Token> clientIdentifiers, UnifiedPushMessage pushMessage, String pushMessageInformationId, NotificationSenderCallback senderCallback) {
         final AdmService admService = ADM.newService();
 
         final PayloadBuilder builder = ADM.newPayload();
@@ -64,9 +65,9 @@ public class AdmPushNotificationSender implements PushNotificationSender {
 
         final AdmVariant admVariant = (AdmVariant) variant;
 
-        clientIdentifiers.forEach(token -> {
+        Token.toEndpoints(clientIdentifiers).forEach(registrationId -> {
             try {
-                admService.sendMessageToDevice(token, admVariant.getClientId(), admVariant.getClientSecret(),  builder.build());
+                admService.sendMessageToDevice(registrationId, admVariant.getClientId(), admVariant.getClientSecret(),  builder.build());
                 senderCallback.onSuccess();
             } catch (Exception e) {
                 logger.error("Error sending payload to ADM server", e);

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/FCMPushNotificationSender.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/FCMPushNotificationSender.java
@@ -29,13 +29,13 @@ import org.jboss.aerogear.unifiedpush.api.VariantType;
 import org.jboss.aerogear.unifiedpush.message.InternalUnifiedPushMessage;
 import org.jboss.aerogear.unifiedpush.message.Priority;
 import org.jboss.aerogear.unifiedpush.message.UnifiedPushMessage;
+import org.jboss.aerogear.unifiedpush.dto.Token;
 import org.jboss.aerogear.unifiedpush.service.ClientInstallationService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
@@ -64,14 +64,14 @@ public class FCMPushNotificationSender implements PushNotificationSender {
      * the {@link List} of tokens for the given {@link AndroidVariant}.
      */
     @Override
-    public void sendPushMessage(Variant variant, Collection<String> tokens, UnifiedPushMessage pushMessage, String pushMessageInformationId, NotificationSenderCallback callback) {
+    public void sendPushMessage(Variant variant, Collection<Token> tokens, UnifiedPushMessage pushMessage, String pushMessageInformationId, NotificationSenderCallback callback) {
 
         // no need to send empty list
         if (tokens.isEmpty()) {
             return;
         }
 
-        final List<String> pushTargets = new ArrayList<>(tokens);
+        final List<String> pushTargets = Token.toEndpoints(tokens);
         final AndroidVariant androidVariant = (AndroidVariant) variant;
 
         // payload builder:
@@ -183,13 +183,13 @@ public class FCMPushNotificationSender implements PushNotificationSender {
             if (errorCodeName != null) {
                 logger.info(String.format("Processing [%s] error code from FCM response, for registration ID: [%s]", errorCodeName, registrationIDs.get(i)));
             }
-            
+
             //after sending, lets find tokens that are inactive from now on and need to be replaced with the new given canonical id.
             //according to fcm documentation, google refreshes tokens after some time. So the previous tokens will become invalid.
             //When you send a notification to a registration id which is expired, for the 1st time the message(notification) will be delivered
-            //but you will get a new registration id with the name canonical id. Which mean, the registration id you sent the message to has 
+            //but you will get a new registration id with the name canonical id. Which mean, the registration id you sent the message to has
             //been changed to this canonical id, so change it on your server side as well.
-            
+
             //check if current index of result has canonical id
             String canonicalRegId = result.getCanonicalRegistrationId();
             if (canonicalRegId != null) {
@@ -216,9 +216,9 @@ public class FCMPushNotificationSender implements PushNotificationSender {
             } else {
                 // is there any 'interesting' error code, which requires a clean up of the registration IDs
                 if (FCM_ERROR_CODES.contains(errorCodeName)) {
-    
+
                     // Ok the result at INDEX 'i' represents a 'bad' registrationID
-    
+
                     // Now use the INDEX of the _that_ result object, and look
                     // for the matching registrationID inside of the List that contains
                     // _all_ the used registration IDs and store it:

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/MPNSPushNotificationSender.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/MPNSPushNotificationSender.java
@@ -20,6 +20,7 @@ import org.jboss.aerogear.unifiedpush.api.Variant;
 import org.jboss.aerogear.unifiedpush.api.VariantType;
 import org.jboss.aerogear.unifiedpush.message.Message;
 import org.jboss.aerogear.unifiedpush.message.UnifiedPushMessage;
+import org.jboss.aerogear.unifiedpush.dto.Token;
 import org.jboss.aerogear.unifiedpush.message.windows.Windows;
 import org.jboss.aerogear.windows.mpns.MPNS;
 import org.jboss.aerogear.windows.mpns.MpnsNotification;
@@ -39,7 +40,7 @@ public class MPNSPushNotificationSender implements PushNotificationSender {
     private final Logger logger = LoggerFactory.getLogger(MPNSPushNotificationSender.class);
 
     @Override
-    public void sendPushMessage(Variant variant, Collection<String> clientIdentifiers, UnifiedPushMessage pushMessage, String pushMessageInformationId, NotificationSenderCallback senderCallback) {
+    public void sendPushMessage(Variant variant, Collection<Token> clientIdentifiers, UnifiedPushMessage pushMessage, String pushMessageInformationId, NotificationSenderCallback senderCallback) {
         // no need to send empty list
         if (clientIdentifiers.isEmpty()) {
             return;
@@ -101,7 +102,8 @@ public class MPNSPushNotificationSender implements PushNotificationSender {
         }
 
         // send all out:
-        clientIdentifiers.forEach(clientIdentifier -> mpnsService.push(clientIdentifier, notification));
+        Token.toEndpoints(clientIdentifiers)
+                .forEach(clientIdentifier -> mpnsService.push(clientIdentifier, notification));
         logger.info(String.format("Sent push notification to MPNs for %d tokens",clientIdentifiers.size()));
 
         senderCallback.onSuccess();

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/PushNotificationSender.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/PushNotificationSender.java
@@ -18,6 +18,7 @@ package org.jboss.aerogear.unifiedpush.message.sender;
 
 import org.jboss.aerogear.unifiedpush.api.Variant;
 import org.jboss.aerogear.unifiedpush.message.UnifiedPushMessage;
+import org.jboss.aerogear.unifiedpush.dto.Token;
 
 import java.util.Collection;
 
@@ -37,5 +38,5 @@ public interface PushNotificationSender {
      * @param senderCallback invoked after submitting the request to the underlying push network to indicate the status
      *                       of the request (<code>success</code> or <code>error</code>
      */
-    void sendPushMessage(Variant variant, Collection<String> clientIdentifiers, UnifiedPushMessage pushMessage, String pushMessageInformationId, NotificationSenderCallback senderCallback);
+    void sendPushMessage(Variant variant, Collection<Token> clientIdentifiers, UnifiedPushMessage pushMessage, String pushMessageInformationId, NotificationSenderCallback senderCallback);
 }

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/SimplePushNotificationSender.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/SimplePushNotificationSender.java
@@ -19,6 +19,7 @@ package org.jboss.aerogear.unifiedpush.message.sender;
 import org.jboss.aerogear.unifiedpush.api.Variant;
 import org.jboss.aerogear.unifiedpush.api.VariantType;
 import org.jboss.aerogear.unifiedpush.message.UnifiedPushMessage;
+import org.jboss.aerogear.unifiedpush.dto.Token;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,7 +40,7 @@ public class SimplePushNotificationSender implements PushNotificationSender {
      * Sends SimplePush notifications to all connected clients, that are represented by
      * the {@link Collection} of channelIDs, for the given SimplePush network.
      */
-    public void sendPushMessage(Variant variant, Collection<String> tokens, UnifiedPushMessage pushMessage, String pushMessageInformationId, NotificationSenderCallback callback) {
+    public void sendPushMessage(Variant variant, Collection<Token> tokens, UnifiedPushMessage pushMessage, String pushMessageInformationId, NotificationSenderCallback callback) {
 
         // no need to send empty list
         if (tokens.isEmpty()) {
@@ -55,7 +56,7 @@ public class SimplePushNotificationSender implements PushNotificationSender {
 
         // iterate over all the given channels, if there are channels:
         boolean hasWarning = false;
-        for (String clientURL : tokens) {
+        for (String clientURL : Token.toEndpoints(tokens)) {
 
             HttpURLConnection conn = null;
             try {

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/WNSPushNotificationSender.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/WNSPushNotificationSender.java
@@ -27,6 +27,7 @@ import org.jboss.aerogear.unifiedpush.api.WindowsWNSVariant;
 import org.jboss.aerogear.unifiedpush.message.InternalUnifiedPushMessage;
 import org.jboss.aerogear.unifiedpush.message.Message;
 import org.jboss.aerogear.unifiedpush.message.UnifiedPushMessage;
+import org.jboss.aerogear.unifiedpush.dto.Token;
 import org.jboss.aerogear.unifiedpush.message.windows.Windows;
 import org.jboss.aerogear.unifiedpush.service.ClientInstallationService;
 import org.slf4j.Logger;
@@ -54,7 +55,7 @@ public class WNSPushNotificationSender implements PushNotificationSender {
     private ClientInstallationService clientInstallationService;
 
     @Override
-    public void sendPushMessage(Variant variant, Collection<String> clientIdentifiers, UnifiedPushMessage pushMessage, String pushMessageInformationId, NotificationSenderCallback senderCallback) {
+    public void sendPushMessage(Variant variant, Collection<Token> clientIdentifiers, UnifiedPushMessage pushMessage, String pushMessageInformationId, NotificationSenderCallback senderCallback) {
         setPushMessageInformationId(pushMessageInformationId);
 
         // no need to send empty list
@@ -66,7 +67,7 @@ public class WNSPushNotificationSender implements PushNotificationSender {
         WnsService wnsService = new WnsService(windowsVariant.getSid(), windowsVariant.getClientSecret(), false);
 
         Set<String> expiredClientIdentifiers = new HashSet<>(clientIdentifiers.size());
-        ArrayList<String> channelUris = new ArrayList<>(clientIdentifiers);
+        List<String> channelUris = Token.toEndpoints(clientIdentifiers);
         Message message = pushMessage.getMessage();
         try {
         	WnsNotificationRequestOptional optional = new WnsNotificationRequestOptional();
@@ -74,7 +75,7 @@ public class WNSPushNotificationSender implements PushNotificationSender {
             if (ttl != -1) {
                 optional.ttl = String.valueOf(ttl);
             }
-        	
+
             final List<WnsNotificationResponse> responses;
             if (message.getWindows().getType() != null) {
                 switch (message.getWindows().getType()) {

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/WebPushNotificationSender.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/WebPushNotificationSender.java
@@ -16,21 +16,30 @@
  */
 package org.jboss.aerogear.unifiedpush.message.sender;
 
-import org.apache.http.HttpHeaders;
-import org.apache.http.HttpResponse;
-import org.apache.http.HttpStatus;
-import org.apache.http.client.fluent.Request;
-import org.apache.http.entity.ContentType;
-import org.apache.http.util.EntityUtils;
+import nl.martijndwars.webpush.GcmNotification;
+import nl.martijndwars.webpush.Notification;
+import nl.martijndwars.webpush.PushService;
+import org.bouncycastle.jce.ECNamedCurveTable;
+import org.bouncycastle.jce.ECPointUtil;
+import org.bouncycastle.jce.spec.ECNamedCurveParameterSpec;
+import org.bouncycastle.jce.spec.ECNamedCurveSpec;
 import org.jboss.aerogear.unifiedpush.api.Variant;
 import org.jboss.aerogear.unifiedpush.api.VariantType;
 import org.jboss.aerogear.unifiedpush.api.WebPushVariant;
-import org.jboss.aerogear.unifiedpush.message.UnifiedPushMessage;
 import org.jboss.aerogear.unifiedpush.dto.Token;
-import org.json.simple.JSONObject;
+import org.jboss.aerogear.unifiedpush.dto.WebPushToken;
+import org.jboss.aerogear.unifiedpush.message.UnifiedPushMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.PublicKey;
+import java.security.spec.ECPoint;
+import java.security.spec.ECPublicKeySpec;
+import java.security.spec.InvalidKeySpecException;
+import java.util.Base64;
 import java.util.Collection;
 
 @SenderType(VariantType.WEB_PUSH)
@@ -63,86 +72,65 @@ public class WebPushNotificationSender implements PushNotificationSender {
     }
 
     @Override
-    public void sendPushMessage(Variant variant, Collection<Token> clientIdentifiers, UnifiedPushMessage pushMessage,
+    public void sendPushMessage(Variant variant, Collection<Token> tokens, UnifiedPushMessage pushMessage,
             String pushMessageInformationId, NotificationSenderCallback senderCallback) {
 
-        int ttl = pushMessage.getConfig().getTimeToLive();
-        if (ttl == -1) {
-            ttl = 0;
-        }
+        final PushService pushService = new PushService(((WebPushVariant) variant).getFcmServerKey());
 
-        int successCount = 0;
-        for (String endpoint : Token.toEndpoints(clientIdentifiers)) {
+        final byte[] payload = pushMessage.getMessage().getAlert().getBytes();
+        final int ttl = pushMessage.getConfig().getTimeToLive() > 0 ? pushMessage.getConfig().getTimeToLive() : 0;
+
+        for (Token token : tokens) {
             try {
-                final WebPushProvider wpp = WebPushProvider.defineProvider(endpoint);
+                final WebPushToken wpToken = (WebPushToken) token;
+                final PublicKey publicKey = loadP256Dh(wpToken.getPublicKey());
+                final byte[] authSecret = Base64.getUrlDecoder().decode(wpToken.getAuthSercret());
+                final Notification notification;
 
-                final String postUrl = getPostUrl(endpoint, wpp);
-
-                final Request request = Request
-                        .Post(postUrl)
-                        .addHeader("TTL", String.valueOf(ttl));
-
-                switch (wpp) {
+                final WebPushProvider provider = WebPushProvider.defineProvider(token.getEndpoint());
+                switch (provider) {
                     case MPS:
-                        // nothing to do
+                        notification = new Notification(
+                                wpToken.getEndpoint(),
+                                publicKey,
+                                authSecret,
+                                payload,
+                                ttl
+                        );
                         break;
                     case FCM:
-                        final JSONObject jsonObject = new JSONObject();
-                        jsonObject.put("to", extractSubscriptionId(endpoint));
-                        final String body = jsonObject.toJSONString();
-
-                        WebPushVariant wpVariant = (WebPushVariant) variant;
-                        request.addHeader(HttpHeaders.AUTHORIZATION, "key=" + wpVariant.getFcmServerKey())
-                                .bodyString(body, ContentType.APPLICATION_JSON);
+                        notification = new GcmNotification(
+                                wpToken.getEndpoint(),
+                                publicKey,
+                                authSecret,
+                                payload
+                        );
                         break;
                     default:
-                        throw new IllegalArgumentException("Unsupported WebPush provider: " + wpp);
+                        throw new IllegalArgumentException("Unsupported WebPush provider: " + provider);
                 }
 
-                logger.debug("WebPush request to {}: {}", wpp, request);
-
-                final HttpResponse response = request
-                        .execute()
-                        .returnResponse();
-
-                final int statusCode = response.getStatusLine().getStatusCode();
-                if (statusCode >= HttpStatus.SC_OK && statusCode <= HttpStatus.SC_NO_CONTENT) {
-                    senderCallback.onSuccess();
-                    successCount++;
-                } else {
-                    String content = EntityUtils.toString(response.getEntity());
-                    logger.error("Error sending payload to {}. Response status {}, content: {}",
-                            wpp, statusCode, content);
-                    senderCallback.onError(content);
-                }
+                pushService.send(notification);
             } catch (Exception e) {
                 logger.error("Error sending push message", e);
                 senderCallback.onError(e.getMessage());
             }
         }
-        logger.info("Sent {} web push notification of {}", successCount, clientIdentifiers.size());
+        logger.info("Sent {} web push notification(s)", tokens.size());
     }
 
-    private static String getPostUrl(String endpoint, WebPushProvider wpp) {
-        final String postUrl;
-        switch (wpp) {
-            case MPS:
-                postUrl = endpoint;
-                break;
-            case FCM:
-                postUrl = wpp.getUrl();
-                break;
-            default:
-                throw new IllegalArgumentException("Unsupported WebPush provider: " + wpp);
-        }
-        return postUrl;
-    }
+    public PublicKey loadP256Dh(final String p256dh)
+            throws NoSuchProviderException, NoSuchAlgorithmException, InvalidKeySpecException {
 
-    private static String extractSubscriptionId(String endpoint) {
-        final int idx = endpoint.lastIndexOf('/');
-        if (idx < 0) {
-            throw new IllegalArgumentException("Can not extract subscriptionId from the endpoint: " + endpoint);
-        }
-        return endpoint.substring(idx + 1);
+        final byte[] p256dhBytes = Base64.getUrlDecoder().decode(p256dh);
+
+        KeyFactory _keyFactory = KeyFactory.getInstance("ECDH", "BC");
+        ECNamedCurveParameterSpec _ecNamedCurveParameterSpec = ECNamedCurveTable.getParameterSpec("prime256v1"); // P256 curve
+        ECNamedCurveSpec _ecNamedCurveSpec = new ECNamedCurveSpec("prime256v1", _ecNamedCurveParameterSpec.getCurve(), _ecNamedCurveParameterSpec
+                .getG(), _ecNamedCurveParameterSpec.getN());
+
+        final ECPoint point = ECPointUtil.decodePoint(_ecNamedCurveSpec.getCurve(), p256dhBytes);
+        ECPublicKeySpec pubKeySpec = new ECPublicKeySpec(point, _ecNamedCurveSpec);
+        return _keyFactory.generatePublic(pubKeySpec);
     }
 }

--- a/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/message/jms/TestMessageHolderWithTokens.java
+++ b/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/message/jms/TestMessageHolderWithTokens.java
@@ -16,18 +16,10 @@
  */
 package org.jboss.aerogear.unifiedpush.message.jms;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-
-import javax.enterprise.event.Event;
-import javax.enterprise.event.Observes;
-import javax.inject.Inject;
-
 import org.jboss.aerogear.unifiedpush.api.AndroidVariant;
 import org.jboss.aerogear.unifiedpush.api.PushMessageInformation;
 import org.jboss.aerogear.unifiedpush.api.Variant;
+import org.jboss.aerogear.unifiedpush.dto.Token;
 import org.jboss.aerogear.unifiedpush.message.MockProviders;
 import org.jboss.aerogear.unifiedpush.message.UnifiedPushMessage;
 import org.jboss.aerogear.unifiedpush.message.holder.MessageHolderWithTokens;
@@ -38,6 +30,14 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import javax.enterprise.event.Event;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 
 @RunWith(Arquillian.class)
@@ -57,7 +57,7 @@ public class TestMessageHolderWithTokens {
     private UnifiedPushMessage message;
     private PushMessageInformation information;
     private Variant variant;
-    private Collection<String> deviceTokens;
+    private Collection<Token> deviceTokens;
     private static CountDownLatch delivered;
 
     @Inject @DispatchToQueue

--- a/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/message/jms/TestMessageRedelivery.java
+++ b/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/message/jms/TestMessageRedelivery.java
@@ -16,22 +16,11 @@
  */
 package org.jboss.aerogear.unifiedpush.message.jms;
 
-import static org.junit.Assert.fail;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import javax.enterprise.event.Event;
-import javax.enterprise.event.Observes;
-import javax.inject.Inject;
-
 import org.jboss.aerogear.unifiedpush.api.AndroidVariant;
 import org.jboss.aerogear.unifiedpush.api.PushMessageInformation;
 import org.jboss.aerogear.unifiedpush.api.SimplePushVariant;
 import org.jboss.aerogear.unifiedpush.api.Variant;
+import org.jboss.aerogear.unifiedpush.dto.Token;
 import org.jboss.aerogear.unifiedpush.message.MockProviders;
 import org.jboss.aerogear.unifiedpush.message.UnifiedPushMessage;
 import org.jboss.aerogear.unifiedpush.message.exception.PushNetworkUnreachableException;
@@ -44,6 +33,17 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import javax.enterprise.event.Event;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.fail;
 
 @RunWith(Arquillian.class)
 public class TestMessageRedelivery {
@@ -65,7 +65,7 @@ public class TestMessageRedelivery {
     private UnifiedPushMessage message;
     private PushMessageInformation information;
     private Variant variant;
-    private Collection<String> deviceTokens;
+    private Collection<Token> deviceTokens;
 
     private static CountDownLatch delivered;
     private static CountDownLatch resourceNotAvailable;

--- a/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/message/jms/TestTokenBatchDeduplication.java
+++ b/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/message/jms/TestTokenBatchDeduplication.java
@@ -16,23 +16,9 @@
  */
 package org.jboss.aerogear.unifiedpush.message.jms;
 
-import static org.junit.Assert.assertEquals;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import javax.annotation.Resource;
-import javax.enterprise.event.Event;
-import javax.enterprise.event.Observes;
-import javax.inject.Inject;
-import javax.jms.JMSException;
-import javax.jms.Queue;
-
 import org.jboss.aerogear.unifiedpush.api.AndroidVariant;
 import org.jboss.aerogear.unifiedpush.api.PushMessageInformation;
+import org.jboss.aerogear.unifiedpush.dto.Token;
 import org.jboss.aerogear.unifiedpush.message.AbstractJMSTest;
 import org.jboss.aerogear.unifiedpush.message.holder.MessageHolderWithTokens;
 import org.jboss.aerogear.unifiedpush.test.archive.UnifiedPushArchive;
@@ -42,6 +28,20 @@ import org.jboss.arquillian.junit.InSequence;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import javax.annotation.Resource;
+import javax.enterprise.event.Event;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+import javax.jms.JMSException;
+import javax.jms.Queue;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
 
 @RunWith(Arquillian.class)
 public class TestTokenBatchDeduplication extends AbstractJMSTest {
@@ -102,7 +102,7 @@ public class TestTokenBatchDeduplication extends AbstractJMSTest {
     }
 
     private void sendBatchWithSerialId(int serialId) {
-        List<String> tokenBatch = new ArrayList<>();
+        List<Token> tokenBatch = new ArrayList<>();
         PushMessageInformation pmi = new PushMessageInformation();
         pmi.setId(uuid);
         AndroidVariant variant = new AndroidVariant();

--- a/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/message/sender/APNsPushNotificationSenderTest.java
+++ b/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/message/sender/APNsPushNotificationSenderTest.java
@@ -17,17 +17,9 @@
 package org.jboss.aerogear.unifiedpush.message.sender;
 
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Arrays;
-import java.util.UUID;
-
+import com.notnoop.apns.ApnsService;
 import org.jboss.aerogear.unifiedpush.api.iOSVariant;
+import org.jboss.aerogear.unifiedpush.dto.Token;
 import org.jboss.aerogear.unifiedpush.message.UnifiedPushMessage;
 import org.jboss.aerogear.unifiedpush.message.serviceHolder.ApnsServiceHolder;
 import org.jboss.aerogear.unifiedpush.message.serviceHolder.ServiceConstructor;
@@ -36,7 +28,15 @@ import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
-import com.notnoop.apns.ApnsService;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.UUID;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class APNsPushNotificationSenderTest {
 
@@ -50,7 +50,7 @@ public class APNsPushNotificationSenderTest {
         when(iosVariant.getCertificate()).thenReturn(readCertificate());
         when(iosVariant.getPassphrase()).thenReturn("123456");
 
-        sender.sendPushMessage(iosVariant, Arrays.asList("token"), new UnifiedPushMessage(), "123", callback);
+        sender.sendPushMessage(iosVariant, Arrays.asList(new Token("token")), new UnifiedPushMessage(), "123", callback);
 
         verify(callback).onError("Error sending payload to APNs server: Invalid hex character: t");
     }

--- a/service/src/main/java/org/jboss/aerogear/unifiedpush/service/ClientInstallationService.java
+++ b/service/src/main/java/org/jboss/aerogear/unifiedpush/service/ClientInstallationService.java
@@ -19,6 +19,7 @@ package org.jboss.aerogear.unifiedpush.service;
 import org.jboss.aerogear.unifiedpush.api.Installation;
 import org.jboss.aerogear.unifiedpush.api.Variant;
 import org.jboss.aerogear.unifiedpush.dao.ResultsStream;
+import org.jboss.aerogear.unifiedpush.dto.Token;
 
 import java.util.List;
 import java.util.Set;
@@ -133,7 +134,7 @@ public interface ClientInstallationService {
      *
      * @return list of device tokens that matches this filter
      */
-    ResultsStream.QueryBuilder<String> findAllDeviceTokenForVariantIDByCriteria(String variantID, List<String> categories, List<String> aliases, List<String> deviceTypes, int maxResults, String lastTokenFromPreviousBatch);
+    ResultsStream.QueryBuilder<Token> findAllDeviceTokenForVariantIDByCriteria(String variantID, List<String> categories, List<String> aliases, List<String> deviceTypes, int maxResults, String lastTokenFromPreviousBatch);
 
     /**
      * Used to query all old GCM tokens, which do not contain a ':' char.
@@ -148,5 +149,5 @@ public interface ClientInstallationService {
      *
      * @return list of old GCM device tokens that matches this filter
      */
-    ResultsStream.QueryBuilder<String> findAllOldGoogleCloudMessagingDeviceTokenForVariantIDByCriteria(String variantID, List<String> categories, List<String> aliases, List<String> deviceTypes, int maxResults, String lastTokenFromPreviousBatch);
+    ResultsStream.QueryBuilder<Token> findAllOldGoogleCloudMessagingDeviceTokenForVariantIDByCriteria(String variantID, List<String> categories, List<String> aliases, List<String> deviceTypes, int maxResults, String lastTokenFromPreviousBatch);
 }

--- a/service/src/main/java/org/jboss/aerogear/unifiedpush/service/impl/ClientInstallationServiceImpl.java
+++ b/service/src/main/java/org/jboss/aerogear/unifiedpush/service/impl/ClientInstallationServiceImpl.java
@@ -157,6 +157,11 @@ public class ClientInstallationServiceImpl implements ClientInstallationService 
         installationToUpdate.setEnabled(postedInstallation.isEnabled());
         installationToUpdate.setPlatform(postedInstallation.getPlatform());
 
+        if (installationToUpdate.getVariant().getType() == VariantType.WEB_PUSH) {
+            installationToUpdate.setPublicKey(postedInstallation.getPublicKey());
+            installationToUpdate.setAuthSecret(postedInstallation.getAuthSecret());
+        }
+
         // update it:
         updateInstallation(installationToUpdate);
 
@@ -271,6 +276,12 @@ public class ClientInstallationServiceImpl implements ClientInstallationService 
         if (variant.getType().equals(VariantType.IOS)) {
             entity.setDeviceToken(entity.getDeviceToken().toLowerCase());
         }
+        // do not save publicKey and authSecret if it's not a WebPushVariant
+        if (variant.getType() != VariantType.WEB_PUSH) {
+            entity.setPublicKey(null);
+            entity.setAuthSecret(null);
+        }
+
         // set reference
         entity.setVariant(variant);
         // update attached categories

--- a/service/src/main/java/org/jboss/aerogear/unifiedpush/service/impl/ClientInstallationServiceImpl.java
+++ b/service/src/main/java/org/jboss/aerogear/unifiedpush/service/impl/ClientInstallationServiceImpl.java
@@ -24,6 +24,7 @@ import org.jboss.aerogear.unifiedpush.api.VariantType;
 import org.jboss.aerogear.unifiedpush.dao.CategoryDao;
 import org.jboss.aerogear.unifiedpush.dao.InstallationDao;
 import org.jboss.aerogear.unifiedpush.dao.ResultsStream;
+import org.jboss.aerogear.unifiedpush.dto.Token;
 import org.jboss.aerogear.unifiedpush.service.ClientInstallationService;
 import org.jboss.aerogear.unifiedpush.service.annotations.LoggedIn;
 import org.jboss.aerogear.unifiedpush.service.util.FCMTopicManager;
@@ -225,12 +226,12 @@ public class ClientInstallationServiceImpl implements ClientInstallationService 
      * Finder for 'send', used for Android, iOS and SimplePush clients
      */
     @Override
-    public ResultsStream.QueryBuilder<String> findAllDeviceTokenForVariantIDByCriteria(String variantID, List<String> categories, List<String> aliases, List<String> deviceTypes, int maxResults, String lastTokenFromPreviousBatch) {
+    public ResultsStream.QueryBuilder<Token> findAllDeviceTokenForVariantIDByCriteria(String variantID, List<String> categories, List<String> aliases, List<String> deviceTypes, int maxResults, String lastTokenFromPreviousBatch) {
         return installationDao.findAllDeviceTokenForVariantIDByCriteria(variantID, categories, aliases, deviceTypes, maxResults, lastTokenFromPreviousBatch, false);
     }
 
     @Override
-    public ResultsStream.QueryBuilder<String> findAllOldGoogleCloudMessagingDeviceTokenForVariantIDByCriteria(String variantID, List<String> categories, List<String> aliases, List<String> deviceTypes, int maxResults, String lastTokenFromPreviousBatch) {
+    public ResultsStream.QueryBuilder<Token> findAllOldGoogleCloudMessagingDeviceTokenForVariantIDByCriteria(String variantID, List<String> categories, List<String> aliases, List<String> deviceTypes, int maxResults, String lastTokenFromPreviousBatch) {
         return installationDao.findAllDeviceTokenForVariantIDByCriteria(variantID, categories, aliases, deviceTypes, maxResults, lastTokenFromPreviousBatch, true);
     }
 

--- a/service/src/test/java/org/jboss/aerogear/unifiedpush/service/ClientInstallationServiceTest.java
+++ b/service/src/test/java/org/jboss/aerogear/unifiedpush/service/ClientInstallationServiceTest.java
@@ -22,6 +22,7 @@ import org.jboss.aerogear.unifiedpush.api.Installation;
 import org.jboss.aerogear.unifiedpush.api.iOSVariant;
 import org.jboss.aerogear.unifiedpush.dao.ResultStreamException;
 import org.jboss.aerogear.unifiedpush.dao.ResultsStream;
+import org.jboss.aerogear.unifiedpush.dto.Token;
 import org.junit.Test;
 
 import javax.inject.Inject;
@@ -389,10 +390,10 @@ public class ClientInstallationServiceTest extends AbstractBaseServiceTest {
         device3.setVariant(androidVariant);
         clientInstallationService.addInstallation(androidVariant, device3);
 
-        final List<String> queriedTokens = findAllDeviceTokenForVariantIDByCriteria(androidVariant.getVariantID(), Arrays.asList("soccer"), null, null);
+        final List<Token> queriedTokens = findAllDeviceTokenForVariantIDByCriteria(androidVariant.getVariantID(), Arrays.asList("soccer"), null, null);
 
         assertThat(queriedTokens).hasSize(2);
-        assertThat(queriedTokens).contains(
+        assertThat(Token.toEndpoints(queriedTokens)).contains(
                 device1.getDeviceToken(),
                 device2.getDeviceToken()
         );
@@ -422,10 +423,10 @@ public class ClientInstallationServiceTest extends AbstractBaseServiceTest {
         device3.setVariant(androidVariant);
         clientInstallationService.addInstallation(androidVariant, device3);
 
-        final List<String> queriedTokens = findAllDeviceTokenForVariantIDByCriteria(androidVariant.getVariantID(), Arrays.asList("soccer", "football"), null, null);
+        final List<Token> queriedTokens = findAllDeviceTokenForVariantIDByCriteria(androidVariant.getVariantID(), Arrays.asList("soccer", "football"), null, null);
 
         assertThat(queriedTokens).hasSize(3);
-        assertThat(queriedTokens).contains(
+        assertThat(Token.toEndpoints(queriedTokens)).contains(
                 device1.getDeviceToken(),
                 device2.getDeviceToken(),
                 device3.getDeviceToken()
@@ -459,24 +460,25 @@ public class ClientInstallationServiceTest extends AbstractBaseServiceTest {
         device4.setCategories(categories);
         clientInstallationService.addInstallation(androidVariant, device4);
 
-        final List<String> queriedTokens = findAllDeviceTokenForVariantIDByCriteria(androidVariant.getVariantID(), null, null, null);
+        final List<Token> queriedTokens = findAllDeviceTokenForVariantIDByCriteria(androidVariant.getVariantID(), null, null, null);
 
         assertThat(queriedTokens).hasSize(4);
-        assertThat(queriedTokens).contains(
+        assertThat(Token.toEndpoints(queriedTokens)).contains(
                 device1.getDeviceToken(),
                 device2.getDeviceToken(),
                 device3.getDeviceToken(),
                 device4.getDeviceToken()
         );
-        final List<String> legacyTokenz = findAllOldGoogleCloudMessagingDeviceTokenForVariantIDByCriteria(androidVariant.getVariantID(), null, null, null);
+        final List<Token> legacyTokenz = findAllOldGoogleCloudMessagingDeviceTokenForVariantIDByCriteria(androidVariant.getVariantID(), null, null, null);
 
-        assertThat(legacyTokenz).hasSize(3);
-        assertThat(legacyTokenz).contains(
+        List<String> legacyEndpoints = Token.toEndpoints(legacyTokenz);
+        assertThat(legacyEndpoints).hasSize(3);
+        assertThat(legacyEndpoints).contains(
                 device1.getDeviceToken(),
                 device2.getDeviceToken(),
                 device3.getDeviceToken()
         );
-        assertThat(legacyTokenz).doesNotContain(
+        assertThat(legacyEndpoints).doesNotContain(
                 device4.getDeviceToken()
         );
     }
@@ -509,10 +511,10 @@ public class ClientInstallationServiceTest extends AbstractBaseServiceTest {
         return sb.toString();
     }
 
-    private List<String> findAllDeviceTokenForVariantIDByCriteria(String variantID, List<String> categories, List<String> aliases, List<String> deviceTypes) {
+    private List<Token> findAllDeviceTokenForVariantIDByCriteria(String variantID, List<String> categories, List<String> aliases, List<String> deviceTypes) {
         try {
-            ResultsStream<String> tokenStream = clientInstallationService.findAllDeviceTokenForVariantIDByCriteria(variantID, categories, aliases, deviceTypes, Integer.MAX_VALUE, null).executeQuery();
-            List<String> list = new ArrayList<>();
+            ResultsStream<Token> tokenStream = clientInstallationService.findAllDeviceTokenForVariantIDByCriteria(variantID, categories, aliases, deviceTypes, Integer.MAX_VALUE, null).executeQuery();
+            List<Token> list = new ArrayList<>();
             while (tokenStream.next()) {
                 list.add(tokenStream.get());
             }
@@ -522,10 +524,10 @@ public class ClientInstallationServiceTest extends AbstractBaseServiceTest {
         }
     }
 
-    private List<String> findAllOldGoogleCloudMessagingDeviceTokenForVariantIDByCriteria(String variantID, List<String> categories, List<String> aliases, List<String> deviceTypes) {
+    private List<Token> findAllOldGoogleCloudMessagingDeviceTokenForVariantIDByCriteria(String variantID, List<String> categories, List<String> aliases, List<String> deviceTypes) {
         try {
-            ResultsStream<String> tokenStream = clientInstallationService.findAllOldGoogleCloudMessagingDeviceTokenForVariantIDByCriteria(variantID, categories, aliases, deviceTypes, Integer.MAX_VALUE, null).executeQuery();
-            List<String> list = new ArrayList<>();
+            ResultsStream<Token> tokenStream = clientInstallationService.findAllOldGoogleCloudMessagingDeviceTokenForVariantIDByCriteria(variantID, categories, aliases, deviceTypes, Integer.MAX_VALUE, null).executeQuery();
+            List<Token> list = new ArrayList<>();
             while (tokenStream.next()) {
                 list.add(tokenStream.get());
             }


### PR DESCRIPTION
This version is based on @MartijnDwars library: https://github.com/MartijnDwars/web-push

The second version is here: https://github.com/aerogear/aerogear-unifiedpush-server/pull/748

BTW @MartijnDwars thank you very much for your lib! It significantly helped me to understand how to send notifications to Chrome and Firefox.

Unfortunately, it does not work with our code base :(
When you send a push message, a server gets an exception  `java.security.InvalidAlgorithmParameterException: parameter object not a ECParameterSpec`:

```
06:24:01,286 WARN  [org.jboss.aerogear.unifiedpush.message.NotificationDispatcher] (Thread-152 (ActiveMQ-client-global-threads-2124725465)) Error on 'webPush' delivery: parameter object not a ECParameterSpec
06:24:01,310 ERROR [org.jboss.aerogear.unifiedpush.message.sender.WebPushNotificationSender] (Thread-152 (ActiveMQ-client-global-threads-2124725465)) Error sending push message: java.security.InvalidAlgorithmParameterException: parameter object not a ECParameterSpec
    at org.bouncycastle.jcajce.provider.asymmetric.ec.KeyPairGeneratorSpi$EC.initialize(Unknown Source)
    at java.security.KeyPairGenerator.initialize(KeyPairGenerator.java:411)
    at nl.martijndwars.webpush.PushService.encrypt(PushService.java:49)
    at nl.martijndwars.webpush.PushService.send(PushService.java:78)
    at org.jboss.aerogear.unifiedpush.message.sender.WebPushNotificationSender.sendPushMessage(WebPushNotificationSender.java:113)
    at org.jboss.aerogear.unifiedpush.message.NotificationDispatcher.sendMessagesToPushNetwork(NotificationDispatcher.java:80)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:498)
    at org.jboss.as.ee.component.ManagedReferenceMethodInterceptor.processInvocation(ManagedReferenceMethodInterceptor.java:52)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.invocation.InterceptorContext$Invocation.proceed(InterceptorContext.java:437)
    at org.jboss.as.weld.ejb.Jsr299BindingsInterceptor.doMethodInterception(Jsr299BindingsInterceptor.java:82)
    at org.jboss.as.weld.ejb.Jsr299BindingsInterceptor.processInvocation(Jsr299BindingsInterceptor.java:93)
    at org.jboss.as.ee.component.interceptors.UserInterceptorFactory$1.processInvocation(UserInterceptorFactory.java:63)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.as.ejb3.component.invocationmetrics.ExecutionTimeInterceptor.processInvocation(ExecutionTimeInterceptor.java:43)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.as.jpa.interceptor.SBInvocationInterceptor.processInvocation(SBInvocationInterceptor.java:47)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.invocation.InterceptorContext$Invocation.proceed(InterceptorContext.java:437)
    at org.jboss.weld.ejb.AbstractEJBRequestScopeActivationInterceptor.aroundInvoke(AbstractEJBRequestScopeActivationInterceptor.java:64)
    at org.jboss.as.weld.ejb.EjbRequestScopeActivationInterceptor.processInvocation(EjbRequestScopeActivationInterceptor.java:83)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.as.ee.concurrent.ConcurrentContextInterceptor.processInvocation(ConcurrentContextInterceptor.java:45)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.invocation.InitialInterceptor.processInvocation(InitialInterceptor.java:21)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.invocation.ChainedInterceptor.processInvocation(ChainedInterceptor.java:61)
    at org.jboss.as.ee.component.interceptors.ComponentDispatcherInterceptor.processInvocation(ComponentDispatcherInterceptor.java:52)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.as.ejb3.component.pool.PooledInstanceInterceptor.processInvocation(PooledInstanceInterceptor.java:51)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.as.ejb3.tx.CMTTxInterceptor.invokeInOurTx(CMTTxInterceptor.java:275)
    at org.jboss.as.ejb3.tx.CMTTxInterceptor.required(CMTTxInterceptor.java:327)
    at org.jboss.as.ejb3.tx.CMTTxInterceptor.processInvocation(CMTTxInterceptor.java:239)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.as.ejb3.component.interceptors.CurrentInvocationContextInterceptor.processInvocation(CurrentInvocationContextInterceptor.java:41)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.as.ejb3.component.invocationmetrics.WaitTimeInterceptor.processInvocation(WaitTimeInterceptor.java:43)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.as.ejb3.security.SecurityContextInterceptor.processInvocation(SecurityContextInterceptor.java:100)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.as.ejb3.component.interceptors.ShutDownInterceptorFactory$1.processInvocation(ShutDownInterceptorFactory.java:64)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.as.ejb3.component.interceptors.LoggingInterceptor.processInvocation(LoggingInterceptor.java:66)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.as.ee.component.NamespaceContextInterceptor.processInvocation(NamespaceContextInterceptor.java:50)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.as.ejb3.component.interceptors.AdditionalSetupInterceptor.processInvocation(AdditionalSetupInterceptor.java:54)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.invocation.ContextClassLoaderInterceptor.processInvocation(ContextClassLoaderInterceptor.java:64)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.invocation.InterceptorContext.run(InterceptorContext.java:356)
    at org.wildfly.security.manager.WildFlySecurityManager.doChecked(WildFlySecurityManager.java:636)
    at org.jboss.invocation.AccessCheckingInterceptor.processInvocation(AccessCheckingInterceptor.java:61)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.invocation.InterceptorContext.run(InterceptorContext.java:356)
    at org.jboss.invocation.PrivilegedWithCombinerInterceptor.processInvocation(PrivilegedWithCombinerInterceptor.java:80)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.invocation.ChainedInterceptor.processInvocation(ChainedInterceptor.java:61)
    at org.jboss.as.ee.component.ViewService$View.invoke(ViewService.java:195)
    at org.jboss.as.ee.component.ViewDescription$1.processInvocation(ViewDescription.java:185)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.invocation.ChainedInterceptor.processInvocation(ChainedInterceptor.java:61)
    at org.jboss.as.ee.component.ProxyInvocationHandler.invoke(ProxyInvocationHandler.java:73)
    at org.jboss.aerogear.unifiedpush.message.NotificationDispatcher$$$view158.sendMessagesToPushNetwork(Unknown Source)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:498)
    at org.jboss.weld.util.reflection.Reflections.invokeAndUnwrap(Reflections.java:436)
    at org.jboss.weld.bean.proxy.EnterpriseBeanProxyMethodHandler.invoke(EnterpriseBeanProxyMethodHandler.java:127)
    at org.jboss.weld.bean.proxy.EnterpriseTargetBeanInstance.invoke(EnterpriseTargetBeanInstance.java:56)
    at org.jboss.weld.bean.proxy.InjectionPointPropagatingEnterpriseTargetBeanInstance.invoke(InjectionPointPropagatingEnterpriseTargetBeanInstance.java:67)
    at org.jboss.weld.bean.proxy.ProxyMethodHandler.invoke(ProxyMethodHandler.java:100)
    at org.jboss.aerogear.unifiedpush.message.NotificationDispatcher$Proxy$_$$_Weld$EnterpriseProxy$.sendMessagesToPushNetwork(Unknown Source)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:498)
    at org.jboss.weld.injection.StaticMethodInjectionPoint.invoke(StaticMethodInjectionPoint.java:88)
    at org.jboss.weld.injection.StaticMethodInjectionPoint.invoke(StaticMethodInjectionPoint.java:78)
    at org.jboss.weld.injection.MethodInvocationStrategy$SimpleMethodInvocationStrategy.invoke(MethodInvocationStrategy.java:129)
    at org.jboss.weld.event.ObserverMethodImpl.sendEvent(ObserverMethodImpl.java:309)
    at org.jboss.weld.event.ObserverMethodImpl.sendEvent(ObserverMethodImpl.java:287)
    at org.jboss.weld.event.ObserverMethodImpl.notify(ObserverMethodImpl.java:265)
    at org.jboss.weld.event.ObserverNotifier.notifySyncObservers(ObserverNotifier.java:271)
    at org.jboss.weld.event.ObserverNotifier.notify(ObserverNotifier.java:260)
    at org.jboss.weld.event.EventImpl.fire(EventImpl.java:89)
    at org.jboss.aerogear.unifiedpush.message.jms.MessageHolderWithTokensConsumer.onMessage(MessageHolderWithTokensConsumer.java:49)
    at org.jboss.aerogear.unifiedpush.message.jms.MessageHolderWithTokensConsumer.onMessage(MessageHolderWithTokensConsumer.java:36)
    at org.jboss.aerogear.unifiedpush.message.jms.AbstractJMSMessageListener.onMessage(AbstractJMSMessageListener.java:53)
    at sun.reflect.GeneratedMethodAccessor788.invoke(Unknown Source)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:498)
    at org.jboss.as.ee.component.ManagedReferenceMethodInterceptor.processInvocation(ManagedReferenceMethodInterceptor.java:52)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.invocation.InterceptorContext$Invocation.proceed(InterceptorContext.java:437)
    at org.jboss.as.weld.ejb.Jsr299BindingsInterceptor.doMethodInterception(Jsr299BindingsInterceptor.java:82)
    at org.jboss.as.weld.ejb.Jsr299BindingsInterceptor.processInvocation(Jsr299BindingsInterceptor.java:93)
    at org.jboss.as.ee.component.interceptors.UserInterceptorFactory$1.processInvocation(UserInterceptorFactory.java:63)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.as.ejb3.component.invocationmetrics.ExecutionTimeInterceptor.processInvocation(ExecutionTimeInterceptor.java:43)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.invocation.InterceptorContext$Invocation.proceed(InterceptorContext.java:437)
    at org.jboss.weld.ejb.AbstractEJBRequestScopeActivationInterceptor.aroundInvoke(AbstractEJBRequestScopeActivationInterceptor.java:73)
    at org.jboss.as.weld.ejb.EjbRequestScopeActivationInterceptor.processInvocation(EjbRequestScopeActivationInterceptor.java:83)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.as.ee.concurrent.ConcurrentContextInterceptor.processInvocation(ConcurrentContextInterceptor.java:45)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.invocation.InitialInterceptor.processInvocation(InitialInterceptor.java:21)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.invocation.ChainedInterceptor.processInvocation(ChainedInterceptor.java:61)
    at org.jboss.as.ee.component.interceptors.ComponentDispatcherInterceptor.processInvocation(ComponentDispatcherInterceptor.java:52)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.as.ejb3.component.pool.PooledInstanceInterceptor.processInvocation(PooledInstanceInterceptor.java:51)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.as.ejb3.tx.CMTTxInterceptor.invokeInNoTx(CMTTxInterceptor.java:263)
    at org.jboss.as.ejb3.tx.CMTTxInterceptor.notSupported(CMTTxInterceptor.java:313)
    at org.jboss.as.ejb3.tx.CMTTxInterceptor.processInvocation(CMTTxInterceptor.java:237)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.as.ejb3.component.interceptors.CurrentInvocationContextInterceptor.processInvocation(CurrentInvocationContextInterceptor.java:41)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.as.ejb3.component.invocationmetrics.WaitTimeInterceptor.processInvocation(WaitTimeInterceptor.java:43)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.as.ejb3.security.SecurityContextInterceptor.processInvocation(SecurityContextInterceptor.java:100)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.as.ejb3.component.interceptors.ShutDownInterceptorFactory$1.processInvocation(ShutDownInterceptorFactory.java:64)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.as.ejb3.deployment.processors.EjbSuspendInterceptor.processInvocation(EjbSuspendInterceptor.java:53)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.as.ejb3.component.interceptors.LoggingInterceptor.processInvocation(LoggingInterceptor.java:66)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.as.ee.component.NamespaceContextInterceptor.processInvocation(NamespaceContextInterceptor.java:50)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.as.ejb3.component.interceptors.AdditionalSetupInterceptor.processInvocation(AdditionalSetupInterceptor.java:54)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.as.ejb3.component.messagedriven.MessageDrivenComponentDescription$5$1.processInvocation(MessageDrivenComponentDescription.java:239)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.invocation.ContextClassLoaderInterceptor.processInvocation(ContextClassLoaderInterceptor.java:64)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.invocation.InterceptorContext.run(InterceptorContext.java:356)
    at org.wildfly.security.manager.WildFlySecurityManager.doChecked(WildFlySecurityManager.java:636)
    at org.jboss.invocation.AccessCheckingInterceptor.processInvocation(AccessCheckingInterceptor.java:61)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.invocation.InterceptorContext.run(InterceptorContext.java:356)
    at org.jboss.invocation.PrivilegedWithCombinerInterceptor.processInvocation(PrivilegedWithCombinerInterceptor.java:80)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.invocation.ChainedInterceptor.processInvocation(ChainedInterceptor.java:61)
    at org.jboss.as.ee.component.ViewService$View.invoke(ViewService.java:195)
    at org.jboss.as.ee.component.ViewDescription$1.processInvocation(ViewDescription.java:185)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.invocation.ChainedInterceptor.processInvocation(ChainedInterceptor.java:61)
    at org.jboss.as.ee.component.ProxyInvocationHandler.invoke(ProxyInvocationHandler.java:73)
    at org.jboss.aerogear.unifiedpush.message.jms.MessageHolderWithTokensConsumer$$$view142.onMessage(Unknown Source)
    at sun.reflect.GeneratedMethodAccessor788.invoke(Unknown Source)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:498)
    at org.jboss.as.ejb3.inflow.MessageEndpointInvocationHandler.doInvoke(MessageEndpointInvocationHandler.java:139)
    at org.jboss.as.ejb3.inflow.AbstractInvocationHandler.invoke(AbstractInvocationHandler.java:73)
    at org.jboss.aerogear.unifiedpush.message.jms.MessageHolderWithTokensConsumer$$$endpoint73.onMessage(Unknown Source)
    at org.apache.activemq.artemis.ra.inflow.ActiveMQMessageHandler.onMessage(ActiveMQMessageHandler.java:310)
    at org.apache.activemq.artemis.core.client.impl.ClientConsumerImpl.callOnMessage(ClientConsumerImpl.java:932)
    at org.apache.activemq.artemis.core.client.impl.ClientConsumerImpl.access$400(ClientConsumerImpl.java:47)
    at org.apache.activemq.artemis.core.client.impl.ClientConsumerImpl$Runner.run(ClientConsumerImpl.java:1045)
    at org.apache.activemq.artemis.utils.OrderedExecutorFactory$OrderedExecutor$ExecutorTask.run(OrderedExecutorFactory.java:100)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
    at java.lang.Thread.run(Thread.java:745)
```

I thought that it happens because Keycloak also depends on Bouncy Castle `bcprov-jdk15on` and here is a version conflict. I tried to:
- override `bcprov-jdk15on` version to the latest one
- replace `bcprov-jdk15on` jar in the final war
- exclude `bcprov-jdk15on` from all Keycloak dependencies

But nothing helped. Could anyone look at this?
