### PR TITLE
Adds payload encryption for WebPush variant (v2)

### DIFF
--- a/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/Installation.java
+++ b/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/Installation.java
@@ -42,6 +42,10 @@ public class Installation extends BaseModel {
     @JsonIgnore
     private Variant variant;
 
+    // for WebPushVariant:
+    private String publicKey;
+    private String authSecret;
+
     public boolean isEnabled() {
         return this.enabled;
     }
@@ -171,5 +175,32 @@ public class Installation extends BaseModel {
 
     public void setVariant(Variant variant) {
         this.variant = variant;
+    }
+
+    public String getPublicKey() {
+        return publicKey;
+    }
+
+    /**
+     * A elliptic curve Diffie-Hellman (ECDH) public key from the User Agent for push message encryption.
+     *
+     * @param publicKey the string representation of a public key
+     */
+    public void setPublicKey(String publicKey) {
+        this.publicKey = publicKey;
+    }
+
+    public String getAuthSecret() {
+        return authSecret;
+    }
+
+    /**
+     * The authentication secret ensures that exposure or leakage of the DH public key - which, as a public key,
+     * is not necessarily treated as a secret - does not enable an adversary to generate valid push messages.
+     *
+     * @param authSecret the string representation of an authentication secret
+     */
+    public void setAuthSecret(String authSecret) {
+        this.authSecret = authSecret;
     }
 }

--- a/model/api/src/main/java/org/jboss/aerogear/unifiedpush/dao/InstallationDao.java
+++ b/model/api/src/main/java/org/jboss/aerogear/unifiedpush/dao/InstallationDao.java
@@ -18,6 +18,7 @@ package org.jboss.aerogear.unifiedpush.dao;
 
 import org.jboss.aerogear.unifiedpush.api.Installation;
 import org.jboss.aerogear.unifiedpush.dto.Count;
+import org.jboss.aerogear.unifiedpush.dto.Token;
 
 import java.util.List;
 import java.util.Set;
@@ -59,7 +60,7 @@ public interface InstallationDao extends GenericBaseDao<Installation, String> {
      *
      * @return list of device tokens that matches this filter
      */
-    ResultsStream.QueryBuilder<String> findAllDeviceTokenForVariantIDByCriteria(String variantID, List<String> categories, List<String> aliases, List<String> deviceTypes, int maxResults, String lastTokenFromPreviousBatch, boolean oldGCM);
+    ResultsStream.QueryBuilder<Token> findAllDeviceTokenForVariantIDByCriteria(String variantID, List<String> categories, List<String> aliases, List<String> deviceTypes, int maxResults, String lastTokenFromPreviousBatch, boolean oldGCM);
 
     Set<String> findAllDeviceTokenForVariantID(String variantID);
 

--- a/model/api/src/main/java/org/jboss/aerogear/unifiedpush/dto/Token.java
+++ b/model/api/src/main/java/org/jboss/aerogear/unifiedpush/dto/Token.java
@@ -1,0 +1,82 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright Red Hat, Inc., and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.aerogear.unifiedpush.dto;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+/**
+ * Holds device token information.
+ *
+ * May be extended if a variant requires additional field for sending push message.
+ */
+public class Token implements Serializable, Comparable<Token> {
+
+    private static final long serialVersionUID = -3782844785133457996L;
+
+    private final String endpoint;
+
+    public Token(String endpoint) {
+        this.endpoint = Objects.requireNonNull(endpoint, "endpoint can not be null");
+    }
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    @Override
+    public int compareTo(Token that) {
+        return this.endpoint.compareTo(that.endpoint);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Token token = (Token) o;
+        return Objects.equals(endpoint, token.endpoint);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(endpoint);
+    }
+
+    /**
+     * Transforms collection of {@link Token} objects to collections of strings for backward compatibility.
+     */
+    public static List<String> toEndpoints(Collection<Token> tokens) {
+        return tokens.stream()
+                .map(Token::getEndpoint)
+                .collect(Collectors.toList());
+    }
+
+    public static Set<Token> toTokens(Collection<String> endpoints) {
+        return endpoints.stream()
+                .map(Token::new)
+                .collect(Collectors.toCollection(TreeSet::new));
+    }
+}

--- a/model/api/src/main/java/org/jboss/aerogear/unifiedpush/dto/WebPushToken.java
+++ b/model/api/src/main/java/org/jboss/aerogear/unifiedpush/dto/WebPushToken.java
@@ -1,0 +1,44 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright Red Hat, Inc., and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.aerogear.unifiedpush.dto;
+
+import org.jboss.aerogear.unifiedpush.api.VariantType;
+
+/**
+ * Holds additional information for {@link VariantType#WEB_PUSH} for push message encryption.
+ */
+public final class WebPushToken extends Token {
+
+    private static final long serialVersionUID = 58015315605339296L;
+
+    private final String publicKey;
+    private final String authSercret;
+
+    public WebPushToken(String endpoint, String publicKey, String authSercret) {
+        super(endpoint);
+        this.publicKey = publicKey;
+        this.authSercret = authSercret;
+    }
+
+    public String getPublicKey() {
+        return publicKey;
+    }
+
+    public String getAuthSercret() {
+        return authSercret;
+    }
+}

--- a/model/jpa/src/main/resources/org/jboss/aerogear/unifiedpush/api/Installation.hbm.xml
+++ b/model/jpa/src/main/resources/org/jboss/aerogear/unifiedpush/api/Installation.hbm.xml
@@ -39,5 +39,11 @@
                 <column name="category_id" not-null="true" />
             </many-to-many>
         </set>
+        <property name="publicKey" type="java.lang.String">
+            <column name="public_key" />
+        </property>
+        <property name="authSecret" type="java.lang.String">
+            <column name="auth_secret" />
+        </property>
     </class>
 </hibernate-mapping>

--- a/model/jpa/src/test/java/org/jboss/aerogear/unifiedpush/jpa/InstallationDaoTest.java
+++ b/model/jpa/src/test/java/org/jboss/aerogear/unifiedpush/jpa/InstallationDaoTest.java
@@ -31,6 +31,7 @@ import org.jboss.aerogear.unifiedpush.dao.PageResult;
 import org.jboss.aerogear.unifiedpush.dao.ResultStreamException;
 import org.jboss.aerogear.unifiedpush.dao.ResultsStream;
 import org.jboss.aerogear.unifiedpush.dto.Count;
+import org.jboss.aerogear.unifiedpush.dto.Token;
 import org.jboss.aerogear.unifiedpush.jpa.dao.impl.JPAInstallationDao;
 import org.jboss.aerogear.unifiedpush.utils.DaoDeployment;
 import org.jboss.aerogear.unifiedpush.utils.TestUtils;
@@ -105,7 +106,7 @@ public class InstallationDaoTest {
     @Test
     public void findDeviceTokensForOneInstallationOfOneVariant() {
         String[] alias = { "foo@bar.org" };
-        List<String> tokens = findAllDeviceTokenForVariantIDByCriteria(androidVariantID, null, Arrays.asList(alias), null);
+        List<Token> tokens = findAllDeviceTokenForVariantIDByCriteria(androidVariantID, null, Arrays.asList(alias), null);
         assertThat(tokens).hasSize(4);
 
         Installation one = installationDao.findInstallationForVariantByDeviceToken(androidVariantID, DEVICE_TOKEN_1);
@@ -121,47 +122,47 @@ public class InstallationDaoTest {
 
     @Test
     public void findDeviceTokensOfVariant() {
-        List<String> tokens = findAllDeviceTokenForVariantIDByCriteria(androidVariantID, null, null, null);
+        List<Token> tokens = findAllDeviceTokenForVariantIDByCriteria(androidVariantID, null, null, null);
         assertThat(tokens).hasSize(4);
-        assertThat(tokens).containsOnly(DEVICE_TOKEN_1, DEVICE_TOKEN_2, DEVICE_TOKEN_3, DEVICE_TOKEN_4);
+        assertThat(Token.toEndpoints(tokens)).containsOnly(DEVICE_TOKEN_1, DEVICE_TOKEN_2, DEVICE_TOKEN_3, DEVICE_TOKEN_4);
     }
 
     @Test
     public void findOldGCMDeviceTokensOfVariant() {
-        List<String> tokens = findAllOldGCMDeviceTokenForVariantIDByCriteria(androidVariantID, null, null, null);
+        List<Token> tokens = findAllOldGCMDeviceTokenForVariantIDByCriteria(androidVariantID, null, null, null);
         assertThat(tokens).hasSize(2);
-        assertThat(tokens).containsOnly(DEVICE_TOKEN_1, DEVICE_TOKEN_2);
+        assertThat(Token.toEndpoints(tokens)).containsOnly(DEVICE_TOKEN_1, DEVICE_TOKEN_2);
     }
 
     @Test
     public void findDeviceTokensForAliasOfVariant() {
         String[] alias = { "foo@bar.org" };
-        List<String> tokens = findAllDeviceTokenForVariantIDByCriteria(androidVariantID, null, Arrays.asList(alias), null);
+        List<Token> tokens = findAllDeviceTokenForVariantIDByCriteria(androidVariantID, null, Arrays.asList(alias), null);
         assertThat(tokens).hasSize(4);
-        assertThat(tokens).containsOnly(DEVICE_TOKEN_1, DEVICE_TOKEN_2, DEVICE_TOKEN_3, DEVICE_TOKEN_4);
+        assertThat(Token.toEndpoints(tokens)).containsOnly(DEVICE_TOKEN_1, DEVICE_TOKEN_2, DEVICE_TOKEN_3, DEVICE_TOKEN_4);
     }
 
     @Test
     public void findNoDeviceTokensForAliasOfVariant() {
         String[] alias = { "bar@foo.org" };
-        List<String> tokens = findAllDeviceTokenForVariantIDByCriteria(androidVariantID, null, Arrays.asList(alias), null);
-         assertThat(tokens).hasSize(0);
+        List<Token> tokens = findAllDeviceTokenForVariantIDByCriteria(androidVariantID, null, Arrays.asList(alias), null);
+        assertThat(tokens).hasSize(0);
     }
 
     @Test
     public void findDeviceTokensForAliasAndDeviceType() {
         String[] alias = { "foo@bar.org" };
         String[] types = { "Android Tablet" };
-        List<String> tokens = findAllDeviceTokenForVariantIDByCriteria(androidVariantID, null, Arrays.asList(alias), Arrays.asList(types));
+        List<Token> tokens = findAllDeviceTokenForVariantIDByCriteria(androidVariantID, null, Arrays.asList(alias), Arrays.asList(types));
         assertThat(tokens).hasSize(2);
-        assertThat(tokens).containsOnly(DEVICE_TOKEN_2, DEVICE_TOKEN_3);
+        assertThat(Token.toEndpoints(tokens)).containsOnly(DEVICE_TOKEN_2, DEVICE_TOKEN_3);
     }
 
     @Test
     public void findNoDeviceTokensForAliasAndUnusedDeviceType() {
         String[] alias = { "foo@bar.org" };
         String[] types = { "Android Clock" };
-        List<String> tokens = findAllDeviceTokenForVariantIDByCriteria(androidVariantID, null, Arrays.asList(alias), Arrays.asList(types));
+        List<Token> tokens = findAllDeviceTokenForVariantIDByCriteria(androidVariantID, null, Arrays.asList(alias), Arrays.asList(types));
         assertThat(tokens).isEmpty();
     }
 
@@ -170,7 +171,7 @@ public class InstallationDaoTest {
         String[] alias = { "foo@bar.org" };
         String[] types = { "Android Tablet" };
         String[] categories = { "soccer" };
-        List<String> tokens = findAllDeviceTokenForVariantIDByCriteria(androidVariantID, Arrays.asList(categories), Arrays.asList(alias), Arrays
+        List<Token> tokens = findAllDeviceTokenForVariantIDByCriteria(androidVariantID, Arrays.asList(categories), Arrays.asList(alias), Arrays
                 .asList(types));
         assertThat(tokens).isEmpty();
     }
@@ -180,23 +181,23 @@ public class InstallationDaoTest {
         String[] alias = { "foo@bar.org" };
         String[] types = { "Android Phone" };
         String[] cats = { "soccer", "news", "weather" };
-        List<String> tokens = findAllDeviceTokenForVariantIDByCriteria(androidVariantID, Arrays.asList(cats), Arrays.asList(alias), Arrays.asList(types));
+        List<Token> tokens = findAllDeviceTokenForVariantIDByCriteria(androidVariantID, Arrays.asList(cats), Arrays.asList(alias), Arrays.asList(types));
         assertThat(tokens).hasSize(1);
-        assertThat(tokens).containsOnly(DEVICE_TOKEN_1);
+        assertThat(Token.toEndpoints(tokens)).containsOnly(DEVICE_TOKEN_1);
     }
 
     @Test
     public void findTwoDeviceTokensForAliasAndCategories() {
         String[] alias = { "foo@bar.org" };
         String[] cats = { "soccer", "news", "weather" };
-        List<String> tokens = findAllDeviceTokenForVariantIDByCriteria(androidVariantID, Arrays.asList(cats), Arrays.asList(alias), null);
+        List<Token> tokens = findAllDeviceTokenForVariantIDByCriteria(androidVariantID, Arrays.asList(cats), Arrays.asList(alias), null);
         assertThat(tokens).hasSize(2);
     }
 
     @Test
     public void findTwoDeviceTokensCategories() {
         String[] cats = { "soccer", "news", "weather" };
-        List<String> tokens = findAllDeviceTokenForVariantIDByCriteria(androidVariantID, Arrays.asList(cats), null, null);
+        List<Token> tokens = findAllDeviceTokenForVariantIDByCriteria(androidVariantID, Arrays.asList(cats), null, null);
         assertThat(tokens).hasSize(2);
     }
 
@@ -270,17 +271,17 @@ public class InstallationDaoTest {
     @Test
     public void findPushEndpointsForAlias() {
         String[] alias = { "foo@bar.org" };
-        List<String> tokens = findAllDeviceTokenForVariantIDByCriteria(simplePushVariantID, null, Arrays.asList(alias), null);
+        List<Token> tokens = findAllDeviceTokenForVariantIDByCriteria(simplePushVariantID, null, Arrays.asList(alias), null);
         assertThat(tokens).hasSize(3);
-        assertThat(tokens.get(0)).startsWith("http://server:8080/update/");
-        assertThat(tokens.get(1)).startsWith("http://server:8080/update/");
+        assertThat(tokens.get(0).getEndpoint()).startsWith("http://server:8080/update/");
+        assertThat(tokens.get(1).getEndpoint()).startsWith("http://server:8080/update/");
     }
 
     @Test
     public void findZeroPushEndpointsForAliasAndCategories() {
         String[] alias = { "foo@bar.org" };
         String[] categories = { "US Football" };
-        List<String> tokens = findAllDeviceTokenForVariantIDByCriteria(simplePushVariantID, Arrays.asList(categories), Arrays.asList(alias), null);
+        List<Token> tokens = findAllDeviceTokenForVariantIDByCriteria(simplePushVariantID, Arrays.asList(categories), Arrays.asList(alias), null);
         assertThat(tokens).isEmpty();
     }
 
@@ -288,9 +289,9 @@ public class InstallationDaoTest {
     public void findOnePushEndpointForAliasAndCategories() {
         String[] alias = { "foo@bar.org" };
         String[] cats = { "soccer", "weather" };
-        List<String> tokens = findAllDeviceTokenForVariantIDByCriteria(simplePushVariantID, Arrays.asList(cats), Arrays.asList(alias), null);
+        List<Token> tokens = findAllDeviceTokenForVariantIDByCriteria(simplePushVariantID, Arrays.asList(cats), Arrays.asList(alias), null);
         assertThat(tokens).hasSize(1);
-        assertThat(tokens.get(0)).startsWith("http://server:8080/update/");
+        assertThat(tokens.get(0).getEndpoint()).startsWith("http://server:8080/update/");
 
     }
 
@@ -298,36 +299,36 @@ public class InstallationDaoTest {
     public void findThreePushEndpointsForAliasAndCategories() {
         String[] alias = { "foo@bar.org" };
         String[] cats = { "soccer", "news", "weather" };
-        List<String> tokens = findAllDeviceTokenForVariantIDByCriteria(simplePushVariantID, Arrays.asList(cats), Arrays.asList(alias), null);
+        List<Token> tokens = findAllDeviceTokenForVariantIDByCriteria(simplePushVariantID, Arrays.asList(cats), Arrays.asList(alias), null);
         assertThat(tokens).hasSize(3);
-        assertThat(tokens.get(0)).startsWith("http://server:8080/update/");
-        assertThat(tokens.get(1)).startsWith("http://server:8080/update/");
-        assertThat(tokens.get(2)).startsWith("http://server:8080/update/");
+        assertThat(tokens.get(0).getEndpoint()).startsWith("http://server:8080/update/");
+        assertThat(tokens.get(1).getEndpoint()).startsWith("http://server:8080/update/");
+        assertThat(tokens.get(2).getEndpoint()).startsWith("http://server:8080/update/");
     }
 
     @Test
     public void findThreePushEndpointsForCategories() {
         String[] cats = { "soccer", "news", "weather" };
-        List<String> tokens = findAllDeviceTokenForVariantIDByCriteria(simplePushVariantID, Arrays.asList(cats), null, null);
+        List<Token> tokens = findAllDeviceTokenForVariantIDByCriteria(simplePushVariantID, Arrays.asList(cats), null, null);
         assertThat(tokens).hasSize(3);
-        assertThat(tokens.get(0)).startsWith("http://server:8080/update/");
-        assertThat(tokens.get(1)).startsWith("http://server:8080/update/");
-        assertThat(tokens.get(2)).startsWith("http://server:8080/update/");
+        assertThat(tokens.get(0).getEndpoint()).startsWith("http://server:8080/update/");
+        assertThat(tokens.get(1).getEndpoint()).startsWith("http://server:8080/update/");
+        assertThat(tokens.get(2).getEndpoint()).startsWith("http://server:8080/update/");
     }
 
     @Test
     public void findPushEndpointsWithDeviceType() {
         String[] types = {"JavaFX Monitor"};
-        List<String> tokens = findAllDeviceTokenForVariantIDByCriteria(simplePushVariantID, null, null, Arrays.asList(types));
+        List<Token> tokens = findAllDeviceTokenForVariantIDByCriteria(simplePushVariantID, null, null, Arrays.asList(types));
         assertThat(tokens).hasSize(1);
-        assertThat(tokens.get(0)).startsWith("http://server:8080/update/");
+        assertThat(tokens.get(0).getEndpoint()).startsWith("http://server:8080/update/");
     }
 
     @Test
     public void findPushEndpointsWithoutDeviceType() {
-        List<String> tokens = findAllDeviceTokenForVariantIDByCriteria(simplePushVariantID, null, null, null);
+        List<Token> tokens = findAllDeviceTokenForVariantIDByCriteria(simplePushVariantID, null, null, null);
         assertThat(tokens).hasSize(3);
-        assertThat(tokens.get(0)).startsWith("http://server:8080/update/");
+        assertThat(tokens.get(0).getEndpoint()).startsWith("http://server:8080/update/");
     }
 
     @Test
@@ -502,30 +503,30 @@ public class InstallationDaoTest {
         // when
         deviceTokenTest(installation, variant);
     }
-    
+
     @Test(expected = ConstraintViolationException.class)
     public void shouldNotSaveWhenWebPushTokenDoesNotUseHttps() {
         // given
         final Installation installation = new Installation();
         installation.setDeviceToken("http://updates.push.services.mozilla.com/wpush/v1/gAAAAABXlQW2uvaJJk3Q6hey1cj2PjZYtGaDcY82DffVUF1OiV4Eu6SA1lds8jzKgZCR9JjIbioyv5jKwZQo2n6UxT8yRU3Es1qM2Fxmdv-p0cqGBhh4CjT5QNzlBAFRJ0OTLvisXB8e");
-        
+
         final WebPushVariant variant = new WebPushVariant();
         variant.setName("WebPush Variant Name");
-        
+
         // when
         deviceTokenTest(installation, variant);
     }
-    
+
     @Test
     public void shouldSaveWhenWebPushTokenValid() {
         // given
         final Installation installation = new Installation();
         installation.setDeviceToken("https://updates.push.services.mozilla.com/wpush/v1/gAAAAABXlQW2uvaJJk3Q6hey1cj2PjZYtGaDcY82DffVUF1OiV4Eu6SA1lds8jzKgZCR9JjIbioyv5jKwZQo2n6UxT8yRU3Es1qM2Fxmdv-p0cqGBhh4CjT5QNzlBAFRJ0OTLvisXB8e");
-        
+
         final WebPushVariant variant = new WebPushVariant();
         variant.setName("WebPush Variant Name");
         variant.setFcmServerKey("FCM Server Key");
-        
+
         // when
         deviceTokenTest(installation, variant);
     }
@@ -669,16 +670,16 @@ public class InstallationDaoTest {
         entityManager.flush();
     }
 
-    private List<String> findAllDeviceTokenForVariantIDByCriteria(String variantID, List<String> categories, List<String> aliases, List<String> deviceTypes) {
+    private List<Token> findAllDeviceTokenForVariantIDByCriteria(String variantID, List<String> categories, List<String> aliases, List<String> deviceTypes) {
         return findAllDeviceTokenForVariantIDByCriteria(variantID, categories, aliases, deviceTypes, false);
     }
-    private List<String> findAllOldGCMDeviceTokenForVariantIDByCriteria(String variantID, List<String> categories, List<String> aliases, List<String> deviceTypes) {
+    private List<Token> findAllOldGCMDeviceTokenForVariantIDByCriteria(String variantID, List<String> categories, List<String> aliases, List<String> deviceTypes) {
         return findAllDeviceTokenForVariantIDByCriteria(variantID, categories, aliases, deviceTypes, true);
     }
-    private List<String> findAllDeviceTokenForVariantIDByCriteria(String variantID, List<String> categories, List<String> aliases, List<String> deviceTypes, boolean oldGCM) {
+    private List<Token> findAllDeviceTokenForVariantIDByCriteria(String variantID, List<String> categories, List<String> aliases, List<String> deviceTypes, boolean oldGCM) {
         try {
-            ResultsStream<String> tokenStream = installationDao.findAllDeviceTokenForVariantIDByCriteria(variantID, categories, aliases, deviceTypes, Integer.MAX_VALUE, null, oldGCM).executeQuery();
-            List<String> list = new ArrayList<>();
+            ResultsStream<Token> tokenStream = installationDao.findAllDeviceTokenForVariantIDByCriteria(variantID, categories, aliases, deviceTypes, Integer.MAX_VALUE, null, oldGCM).executeQuery();
+            List<Token> list = new ArrayList<>();
             while (tokenStream.next()) {
                 list.add(tokenStream.get());
             }

--- a/push/sender/pom.xml
+++ b/push/sender/pom.xml
@@ -58,7 +58,7 @@
             <artifactId>jboss-ejb-api_3.1_spec</artifactId>
             <scope>provided</scope>
         </dependency>
-        
+
         <dependency>
             <groupId>org.jboss.spec.javax.jms</groupId>
             <artifactId>jboss-jms-api_1.1_spec</artifactId>
@@ -130,6 +130,11 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>fluent-hc</artifactId>
             <version>4.3.6</version>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk15on</artifactId>
+            <version>1.54</version>
         </dependency>
 
     </dependencies>

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/NotificationDispatcher.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/NotificationDispatcher.java
@@ -16,20 +16,12 @@
  */
 package org.jboss.aerogear.unifiedpush.message;
 
-import java.util.Collection;
-
-import javax.ejb.Stateless;
-import javax.enterprise.event.Event;
-import javax.enterprise.event.Observes;
-import javax.enterprise.inject.Any;
-import javax.enterprise.inject.Instance;
-import javax.inject.Inject;
-
 import org.jboss.aerogear.unifiedpush.api.PushMessageInformation;
 import org.jboss.aerogear.unifiedpush.api.Variant;
 import org.jboss.aerogear.unifiedpush.api.VariantMetricInformation;
 import org.jboss.aerogear.unifiedpush.message.event.TriggerVariantMetricCollectionEvent;
 import org.jboss.aerogear.unifiedpush.message.holder.MessageHolderWithTokens;
+import org.jboss.aerogear.unifiedpush.dto.Token;
 import org.jboss.aerogear.unifiedpush.message.jms.Dequeue;
 import org.jboss.aerogear.unifiedpush.message.jms.DispatchToQueue;
 import org.jboss.aerogear.unifiedpush.message.sender.NotificationSenderCallback;
@@ -38,6 +30,14 @@ import org.jboss.aerogear.unifiedpush.message.sender.SenderTypeLiteral;
 import org.jboss.aerogear.unifiedpush.message.token.TokenLoader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.ejb.Stateless;
+import javax.enterprise.event.Event;
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.Any;
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+import java.util.Collection;
 
 /**
  * Receives a request for dispatching push notifications to specified devices from {@link TokenLoader}
@@ -72,7 +72,7 @@ public class NotificationDispatcher {
     public void sendMessagesToPushNetwork(@Observes @Dequeue MessageHolderWithTokens msg) {
         final Variant variant = msg.getVariant();
         final UnifiedPushMessage unifiedPushMessage = msg.getUnifiedPushMessage();
-        final Collection<String> deviceTokens = msg.getDeviceTokens();
+        final Collection<Token> deviceTokens = msg.getDeviceTokens();
 
         logger.info(String.format("Received UnifiedPushMessage from JMS queue, will now trigger the Push Notification delivery for the %s variant (%s)", variant.getType().getTypeName(), variant.getVariantID()));
 

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/holder/MessageHolderWithTokens.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/holder/MessageHolderWithTokens.java
@@ -16,12 +16,13 @@
  */
 package org.jboss.aerogear.unifiedpush.message.holder;
 
-import java.io.Serializable;
-import java.util.Collection;
-
 import org.jboss.aerogear.unifiedpush.api.PushMessageInformation;
 import org.jboss.aerogear.unifiedpush.api.Variant;
+import org.jboss.aerogear.unifiedpush.dto.Token;
 import org.jboss.aerogear.unifiedpush.message.UnifiedPushMessage;
+
+import java.io.Serializable;
+import java.util.Collection;
 
 /**
  * Holds push message details together with information what specific variant and which device tokens should be notifications sent to.
@@ -34,9 +35,9 @@ public class MessageHolderWithTokens extends AbstractMessageHolder implements Se
 
     private int serialId;
     private Variant variant;
-    private Collection<String> deviceTokens;
+    private Collection<Token> deviceTokens;
 
-    public MessageHolderWithTokens(PushMessageInformation pushMessageInformation, UnifiedPushMessage unifiedPushMessage, Variant variant, Collection<String> deviceTokens, int serialId) {
+    public MessageHolderWithTokens(PushMessageInformation pushMessageInformation, UnifiedPushMessage unifiedPushMessage, Variant variant, Collection<Token> deviceTokens, int serialId) {
         super(pushMessageInformation, unifiedPushMessage);
         if (!(deviceTokens instanceof Serializable)) {
             throw new IllegalArgumentException("deviceTokens must be a serializable collection");
@@ -50,7 +51,7 @@ public class MessageHolderWithTokens extends AbstractMessageHolder implements Se
         return variant;
     }
 
-    public Collection<String> getDeviceTokens() {
+    public Collection<Token> getDeviceTokens() {
         return deviceTokens;
     }
 

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/APNsPushNotificationSender.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/APNsPushNotificationSender.java
@@ -35,6 +35,7 @@ import org.jboss.aerogear.unifiedpush.message.UnifiedPushMessage;
 import org.jboss.aerogear.unifiedpush.message.apns.APNs;
 import org.jboss.aerogear.unifiedpush.message.exception.PushNetworkUnreachableException;
 import org.jboss.aerogear.unifiedpush.message.exception.SenderResourceNotAvailableException;
+import org.jboss.aerogear.unifiedpush.dto.Token;
 import org.jboss.aerogear.unifiedpush.message.serviceHolder.ApnsServiceHolder;
 import org.jboss.aerogear.unifiedpush.message.serviceHolder.ServiceConstructor;
 import org.jboss.aerogear.unifiedpush.message.serviceHolder.ServiceDestroyer;
@@ -91,7 +92,7 @@ public class APNsPushNotificationSender implements PushNotificationSender {
      * @param pushMessageInformationId the id of the PushMessageInformation instance associated with this send.
      * @param callback that will be invoked after the sending.
      */
-    public void sendPushMessage(final Variant variant, final Collection<String> tokens, final UnifiedPushMessage pushMessage, final String pushMessageInformationId, final NotificationSenderCallback callback) {
+    public void sendPushMessage(final Variant variant, final Collection<Token> tokens, final UnifiedPushMessage pushMessage, final String pushMessageInformationId, final NotificationSenderCallback callback) {
         // no need to send empty list
         if (tokens.isEmpty()) {
             return;
@@ -161,7 +162,7 @@ public class APNsPushNotificationSender implements PushNotificationSender {
         try {
             logger.debug("Sending transformed APNs payload: " + apnsMessage);
             Date expireDate = createFutureDateBasedOnTTL(pushMessage.getConfig().getTimeToLive());
-            service.push(tokens, apnsMessage, expireDate);
+            service.push(Token.toEndpoints(tokens), apnsMessage, expireDate);
 
             logger.info(String.format("Sent push notification to the Apple APNs Server for %d tokens",tokens.size()));
             apnsServiceHolder.queueFreedUpService(pushMessageInformationId, iOSVariant.getVariantID(), service, new ServiceDestroyer<ApnsService>() {

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/AdmPushNotificationSender.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/AdmPushNotificationSender.java
@@ -25,6 +25,7 @@ import org.jboss.aerogear.unifiedpush.api.Variant;
 import org.jboss.aerogear.unifiedpush.api.VariantType;
 import org.jboss.aerogear.unifiedpush.message.InternalUnifiedPushMessage;
 import org.jboss.aerogear.unifiedpush.message.UnifiedPushMessage;
+import org.jboss.aerogear.unifiedpush.dto.Token;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,7 +36,7 @@ public class AdmPushNotificationSender implements PushNotificationSender {
     private final Logger logger = LoggerFactory.getLogger(AdmPushNotificationSender.class);
 
     @Override
-    public void sendPushMessage(Variant variant, Collection<String> clientIdentifiers, UnifiedPushMessage pushMessage, String pushMessageInformationId, NotificationSenderCallback senderCallback) {
+    public void sendPushMessage(Variant variant, Collection<Token> clientIdentifiers, UnifiedPushMessage pushMessage, String pushMessageInformationId, NotificationSenderCallback senderCallback) {
         final AdmService admService = ADM.newService();
 
         final PayloadBuilder builder = ADM.newPayload();
@@ -64,9 +65,9 @@ public class AdmPushNotificationSender implements PushNotificationSender {
 
         final AdmVariant admVariant = (AdmVariant) variant;
 
-        clientIdentifiers.forEach(token -> {
+        Token.toEndpoints(clientIdentifiers).forEach(registrationId -> {
             try {
-                admService.sendMessageToDevice(token, admVariant.getClientId(), admVariant.getClientSecret(),  builder.build());
+                admService.sendMessageToDevice(registrationId, admVariant.getClientId(), admVariant.getClientSecret(),  builder.build());
                 senderCallback.onSuccess();
             } catch (Exception e) {
                 logger.error("Error sending payload to ADM server", e);

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/FCMPushNotificationSender.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/FCMPushNotificationSender.java
@@ -29,13 +29,13 @@ import org.jboss.aerogear.unifiedpush.api.VariantType;
 import org.jboss.aerogear.unifiedpush.message.InternalUnifiedPushMessage;
 import org.jboss.aerogear.unifiedpush.message.Priority;
 import org.jboss.aerogear.unifiedpush.message.UnifiedPushMessage;
+import org.jboss.aerogear.unifiedpush.dto.Token;
 import org.jboss.aerogear.unifiedpush.service.ClientInstallationService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
@@ -64,14 +64,14 @@ public class FCMPushNotificationSender implements PushNotificationSender {
      * the {@link List} of tokens for the given {@link AndroidVariant}.
      */
     @Override
-    public void sendPushMessage(Variant variant, Collection<String> tokens, UnifiedPushMessage pushMessage, String pushMessageInformationId, NotificationSenderCallback callback) {
+    public void sendPushMessage(Variant variant, Collection<Token> tokens, UnifiedPushMessage pushMessage, String pushMessageInformationId, NotificationSenderCallback callback) {
 
         // no need to send empty list
         if (tokens.isEmpty()) {
             return;
         }
 
-        final List<String> pushTargets = new ArrayList<>(tokens);
+        final List<String> pushTargets = Token.toEndpoints(tokens);
         final AndroidVariant androidVariant = (AndroidVariant) variant;
 
         // payload builder:
@@ -183,13 +183,13 @@ public class FCMPushNotificationSender implements PushNotificationSender {
             if (errorCodeName != null) {
                 logger.info(String.format("Processing [%s] error code from FCM response, for registration ID: [%s]", errorCodeName, registrationIDs.get(i)));
             }
-            
+
             //after sending, lets find tokens that are inactive from now on and need to be replaced with the new given canonical id.
             //according to fcm documentation, google refreshes tokens after some time. So the previous tokens will become invalid.
             //When you send a notification to a registration id which is expired, for the 1st time the message(notification) will be delivered
-            //but you will get a new registration id with the name canonical id. Which mean, the registration id you sent the message to has 
+            //but you will get a new registration id with the name canonical id. Which mean, the registration id you sent the message to has
             //been changed to this canonical id, so change it on your server side as well.
-            
+
             //check if current index of result has canonical id
             String canonicalRegId = result.getCanonicalRegistrationId();
             if (canonicalRegId != null) {
@@ -216,9 +216,9 @@ public class FCMPushNotificationSender implements PushNotificationSender {
             } else {
                 // is there any 'interesting' error code, which requires a clean up of the registration IDs
                 if (FCM_ERROR_CODES.contains(errorCodeName)) {
-    
+
                     // Ok the result at INDEX 'i' represents a 'bad' registrationID
-    
+
                     // Now use the INDEX of the _that_ result object, and look
                     // for the matching registrationID inside of the List that contains
                     // _all_ the used registration IDs and store it:

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/MPNSPushNotificationSender.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/MPNSPushNotificationSender.java
@@ -20,6 +20,7 @@ import org.jboss.aerogear.unifiedpush.api.Variant;
 import org.jboss.aerogear.unifiedpush.api.VariantType;
 import org.jboss.aerogear.unifiedpush.message.Message;
 import org.jboss.aerogear.unifiedpush.message.UnifiedPushMessage;
+import org.jboss.aerogear.unifiedpush.dto.Token;
 import org.jboss.aerogear.unifiedpush.message.windows.Windows;
 import org.jboss.aerogear.windows.mpns.MPNS;
 import org.jboss.aerogear.windows.mpns.MpnsNotification;
@@ -39,7 +40,7 @@ public class MPNSPushNotificationSender implements PushNotificationSender {
     private final Logger logger = LoggerFactory.getLogger(MPNSPushNotificationSender.class);
 
     @Override
-    public void sendPushMessage(Variant variant, Collection<String> clientIdentifiers, UnifiedPushMessage pushMessage, String pushMessageInformationId, NotificationSenderCallback senderCallback) {
+    public void sendPushMessage(Variant variant, Collection<Token> clientIdentifiers, UnifiedPushMessage pushMessage, String pushMessageInformationId, NotificationSenderCallback senderCallback) {
         // no need to send empty list
         if (clientIdentifiers.isEmpty()) {
             return;
@@ -101,7 +102,8 @@ public class MPNSPushNotificationSender implements PushNotificationSender {
         }
 
         // send all out:
-        clientIdentifiers.forEach(clientIdentifier -> mpnsService.push(clientIdentifier, notification));
+        Token.toEndpoints(clientIdentifiers)
+                .forEach(clientIdentifier -> mpnsService.push(clientIdentifier, notification));
         logger.info(String.format("Sent push notification to MPNs for %d tokens",clientIdentifiers.size()));
 
         senderCallback.onSuccess();

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/PushNotificationSender.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/PushNotificationSender.java
@@ -18,6 +18,7 @@ package org.jboss.aerogear.unifiedpush.message.sender;
 
 import org.jboss.aerogear.unifiedpush.api.Variant;
 import org.jboss.aerogear.unifiedpush.message.UnifiedPushMessage;
+import org.jboss.aerogear.unifiedpush.dto.Token;
 
 import java.util.Collection;
 
@@ -37,5 +38,5 @@ public interface PushNotificationSender {
      * @param senderCallback invoked after submitting the request to the underlying push network to indicate the status
      *                       of the request (<code>success</code> or <code>error</code>
      */
-    void sendPushMessage(Variant variant, Collection<String> clientIdentifiers, UnifiedPushMessage pushMessage, String pushMessageInformationId, NotificationSenderCallback senderCallback);
+    void sendPushMessage(Variant variant, Collection<Token> clientIdentifiers, UnifiedPushMessage pushMessage, String pushMessageInformationId, NotificationSenderCallback senderCallback);
 }

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/SimplePushNotificationSender.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/SimplePushNotificationSender.java
@@ -19,6 +19,7 @@ package org.jboss.aerogear.unifiedpush.message.sender;
 import org.jboss.aerogear.unifiedpush.api.Variant;
 import org.jboss.aerogear.unifiedpush.api.VariantType;
 import org.jboss.aerogear.unifiedpush.message.UnifiedPushMessage;
+import org.jboss.aerogear.unifiedpush.dto.Token;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,7 +40,7 @@ public class SimplePushNotificationSender implements PushNotificationSender {
      * Sends SimplePush notifications to all connected clients, that are represented by
      * the {@link Collection} of channelIDs, for the given SimplePush network.
      */
-    public void sendPushMessage(Variant variant, Collection<String> tokens, UnifiedPushMessage pushMessage, String pushMessageInformationId, NotificationSenderCallback callback) {
+    public void sendPushMessage(Variant variant, Collection<Token> tokens, UnifiedPushMessage pushMessage, String pushMessageInformationId, NotificationSenderCallback callback) {
 
         // no need to send empty list
         if (tokens.isEmpty()) {
@@ -55,7 +56,7 @@ public class SimplePushNotificationSender implements PushNotificationSender {
 
         // iterate over all the given channels, if there are channels:
         boolean hasWarning = false;
-        for (String clientURL : tokens) {
+        for (String clientURL : Token.toEndpoints(tokens)) {
 
             HttpURLConnection conn = null;
             try {

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/WNSPushNotificationSender.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/WNSPushNotificationSender.java
@@ -27,6 +27,7 @@ import org.jboss.aerogear.unifiedpush.api.WindowsWNSVariant;
 import org.jboss.aerogear.unifiedpush.message.InternalUnifiedPushMessage;
 import org.jboss.aerogear.unifiedpush.message.Message;
 import org.jboss.aerogear.unifiedpush.message.UnifiedPushMessage;
+import org.jboss.aerogear.unifiedpush.dto.Token;
 import org.jboss.aerogear.unifiedpush.message.windows.Windows;
 import org.jboss.aerogear.unifiedpush.service.ClientInstallationService;
 import org.slf4j.Logger;
@@ -54,7 +55,7 @@ public class WNSPushNotificationSender implements PushNotificationSender {
     private ClientInstallationService clientInstallationService;
 
     @Override
-    public void sendPushMessage(Variant variant, Collection<String> clientIdentifiers, UnifiedPushMessage pushMessage, String pushMessageInformationId, NotificationSenderCallback senderCallback) {
+    public void sendPushMessage(Variant variant, Collection<Token> clientIdentifiers, UnifiedPushMessage pushMessage, String pushMessageInformationId, NotificationSenderCallback senderCallback) {
         setPushMessageInformationId(pushMessageInformationId);
 
         // no need to send empty list
@@ -66,7 +67,7 @@ public class WNSPushNotificationSender implements PushNotificationSender {
         WnsService wnsService = new WnsService(windowsVariant.getSid(), windowsVariant.getClientSecret(), false);
 
         Set<String> expiredClientIdentifiers = new HashSet<>(clientIdentifiers.size());
-        ArrayList<String> channelUris = new ArrayList<>(clientIdentifiers);
+        List<String> channelUris = Token.toEndpoints(clientIdentifiers);
         Message message = pushMessage.getMessage();
         try {
         	WnsNotificationRequestOptional optional = new WnsNotificationRequestOptional();
@@ -74,7 +75,7 @@ public class WNSPushNotificationSender implements PushNotificationSender {
             if (ttl != -1) {
                 optional.ttl = String.valueOf(ttl);
             }
-        	
+
             final List<WnsNotificationResponse> responses;
             if (message.getWindows().getType() != null) {
                 switch (message.getWindows().getType()) {

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/util/webpush/encryption/Constants.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/util/webpush/encryption/Constants.java
@@ -1,0 +1,35 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright Red Hat, Inc., and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.aerogear.unifiedpush.message.util.webpush.encryption;
+
+import java.nio.charset.StandardCharsets;
+
+final class Constants {
+
+    private Constants() {}
+
+    public static final byte[] CONTENT_ENCODING = "Content-Encoding: ".getBytes(StandardCharsets.UTF_8);
+    public static final byte[] AESGCM128 = "aesgcm".getBytes(StandardCharsets.UTF_8);
+    public static final byte[] NONCE = "nonce".getBytes(StandardCharsets.UTF_8);
+    public static final byte[] P256 = "P-256".getBytes(StandardCharsets.UTF_8);
+    public static final int GCM_TAG_LENGTH = 16; // in bytes
+    public static final String SECP256R1 = "secp256r1"; // TODO change to 'prime256v1'
+    public static final String HMAC_SHA256 = "HmacSHA256";
+    public static final byte NULL_BYTE = 0;
+    public static final byte KEY_LENGTH_BYTE = 65; // This is always 65 for our curve
+    public static final int MAX_PAYLOAD_LENGTH = 4078;
+}

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/util/webpush/encryption/EllipticCurveKeyUtil.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/util/webpush/encryption/EllipticCurveKeyUtil.java
@@ -1,0 +1,166 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright Red Hat, Inc., and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.aerogear.unifiedpush.message.util.webpush.encryption;
+
+import org.apache.commons.codec.DecoderException;
+import org.bouncycastle.jce.ECNamedCurveTable;
+import org.bouncycastle.jce.ECPointUtil;
+import org.bouncycastle.jce.spec.ECNamedCurveParameterSpec;
+import org.bouncycastle.jce.spec.ECNamedCurveSpec;
+import org.bouncycastle.jce.spec.ECParameterSpec;
+import org.bouncycastle.jce.spec.ECPrivateKeySpec;
+
+import javax.crypto.KeyAgreement;
+import java.math.BigInteger;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.PublicKey;
+import java.security.SecureRandom;
+import java.security.Security;
+import java.security.interfaces.ECPrivateKey;
+import java.security.interfaces.ECPublicKey;
+import java.security.spec.ECPoint;
+import java.security.spec.ECPublicKeySpec;
+import java.security.spec.InvalidKeySpecException;
+import java.util.Base64;
+
+import static org.apache.commons.codec.binary.Hex.decodeHex;
+
+class EllipticCurveKeyUtil {
+
+    public static final String CRYPTO_TYPE_ECDH = "ECDH";
+    public static final String PROVIDER_BOUNCY_CASTLE = "BC";
+    private final KeyFactory _keyFactory;
+    private final ECNamedCurveParameterSpec _ecNamedCurveParameterSpec;
+    private final ECNamedCurveSpec _ecNamedCurveSpec;
+    private final ECParameterSpec _ecParameterSpec;
+    private final KeyPairGenerator _keyPairGenerator;
+
+    public EllipticCurveKeyUtil()
+            throws NoSuchProviderException, NoSuchAlgorithmException, InvalidAlgorithmParameterException {
+        Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());
+
+        _keyFactory = KeyFactory.getInstance(CRYPTO_TYPE_ECDH, PROVIDER_BOUNCY_CASTLE);
+        _ecNamedCurveParameterSpec = ECNamedCurveTable.getParameterSpec(Constants.SECP256R1); // P256 curve
+        _ecNamedCurveSpec = new ECNamedCurveSpec(Constants.SECP256R1, _ecNamedCurveParameterSpec.getCurve(), _ecNamedCurveParameterSpec
+                .getG(), _ecNamedCurveParameterSpec.getN());
+
+        _ecParameterSpec = ECNamedCurveTable.getParameterSpec(Constants.SECP256R1); // P256 curve
+        _keyPairGenerator = KeyPairGenerator.getInstance(CRYPTO_TYPE_ECDH, PROVIDER_BOUNCY_CASTLE);
+        _keyPairGenerator.initialize(_ecParameterSpec, new SecureRandom());
+    }
+
+    /**
+     * Creates a ECDH keypair from the curve parameters for the p256 curve
+     * @param x Affine X for the public key point
+     * @param y Affine Y for the public key point
+     * @param s S parameter for the private key
+     * @return ECDH keypair
+     * @throws NoSuchProviderException
+     * @throws NoSuchAlgorithmException
+     * @throws InvalidKeySpecException
+     */
+    public KeyPair loadECKeyPair(BigInteger x, BigInteger y, BigInteger s)
+            throws NoSuchProviderException, NoSuchAlgorithmException, InvalidKeySpecException {
+        ECPoint ecPoint = new ECPoint(x, y);
+        ECPublicKeySpec pubKeySpec = new ECPublicKeySpec(ecPoint, _ecNamedCurveSpec);
+        ECPrivateKeySpec privateKeySpec = new ECPrivateKeySpec(s, _ecNamedCurveParameterSpec);
+        ECPublicKey publicKey =  (ECPublicKey) _keyFactory.generatePublic(pubKeySpec);
+        ECPrivateKey privateKey = (ECPrivateKey) _keyFactory.generatePrivate(privateKeySpec);
+        return new KeyPair(publicKey, privateKey);
+    }
+
+    /**
+     * Generates a new keypair for ECDH using the p256 curve.
+     * Creating a new keypair per request is expensive, but preferred
+     * @return ECDH Keypair
+     * @throws NoSuchAlgorithmException
+     * @throws InvalidAlgorithmParameterException
+     * @throws NoSuchProviderException
+     */
+    public KeyPair generateServerKeyPair()
+            throws NoSuchAlgorithmException, InvalidAlgorithmParameterException, NoSuchProviderException {
+
+        return _keyPairGenerator.generateKeyPair();
+    }
+
+    /**
+     * Converts the ECDH public key to bytes (has to be 65 bytes in length)
+     * @param publicKey Public key for ECDH p256 curve
+     * @return bytearray representation of key
+     */
+    public byte[] publicKeyToBytes(final ECPublicKey publicKey) throws DecoderException {
+        ECPoint point = publicKey.getW();
+        String x = point.getAffineX().toString(16);
+        String y = point.getAffineY().toString(16);
+
+    /*
+     *  Format is 04 followed by 32 bytes (64 hex) each for the X,Y coordinates
+    */
+        StringBuilder sb = new StringBuilder();
+        sb.append("04");
+
+        for (int i = 0; i < 64 - x.length(); i++) {
+            sb.append(0);
+        }
+        sb.append(x);
+
+        for (int i = 0; i < 64 - y.length(); i++) {
+            sb.append(0);
+        }
+        sb.append(y);
+        return decodeHex(sb.toString().toCharArray());
+    }
+
+    /**
+     * Creates a public key from the p256dh encoded using URL-safe Base64
+     * @param p256dh p256dh string
+     * @return Public Key
+     * @throws NoSuchProviderException
+     * @throws NoSuchAlgorithmException
+     * @throws InvalidKeySpecException
+     */
+    public ECPublicKey loadP256Dh(final String p256dh)
+            throws NoSuchProviderException, NoSuchAlgorithmException, InvalidKeySpecException {
+        final byte[] p256dhBytes = Base64.getUrlDecoder().decode(p256dh);
+        final ECPoint point = ECPointUtil.decodePoint(_ecNamedCurveSpec.getCurve(), p256dhBytes);
+        ECPublicKeySpec pubKeySpec = new ECPublicKeySpec(point, _ecNamedCurveSpec);
+        return (ECPublicKey) _keyFactory.generatePublic(pubKeySpec);
+    }
+
+    /**
+     * Computes the shared secret for ECDH using the server keys and the client public key
+     * @param serverKeys Server keypair
+     * @param clientPublicKey Client public key
+     * @return p256dh shared secret
+     * @throws NoSuchAlgorithmException
+     * @throws InvalidKeyException
+     * @throws NoSuchProviderException
+     */
+    public byte[] generateSharedSecret(final KeyPair serverKeys, final PublicKey clientPublicKey)
+            throws NoSuchAlgorithmException, InvalidKeyException, NoSuchProviderException {
+        KeyAgreement keyAgreement = KeyAgreement.getInstance(CRYPTO_TYPE_ECDH, PROVIDER_BOUNCY_CASTLE);
+        keyAgreement.init(serverKeys.getPrivate());
+        keyAgreement.doPhase(clientPublicKey, true);
+        return keyAgreement.generateSecret();
+    }
+}

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/util/webpush/encryption/PushApiUtil.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/util/webpush/encryption/PushApiUtil.java
@@ -1,0 +1,234 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright Red Hat, Inc., and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.aerogear.unifiedpush.message.util.webpush.encryption;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.Mac;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.SecureRandom;
+import java.util.Arrays;
+import java.util.Base64;
+
+import static org.jboss.aerogear.unifiedpush.message.util.webpush.encryption.Constants.GCM_TAG_LENGTH;
+import static org.jboss.aerogear.unifiedpush.message.util.webpush.encryption.Constants.HMAC_SHA256;
+import static org.jboss.aerogear.unifiedpush.message.util.webpush.encryption.Constants.KEY_LENGTH_BYTE;
+import static org.jboss.aerogear.unifiedpush.message.util.webpush.encryption.Constants.MAX_PAYLOAD_LENGTH;
+import static org.jboss.aerogear.unifiedpush.message.util.webpush.encryption.Constants.NULL_BYTE;
+import static org.jboss.aerogear.unifiedpush.message.util.webpush.encryption.Constants.P256;
+
+final class PushApiUtil {
+
+    private static final SecureRandom RANDOM_BYTE_GENERATOR = new SecureRandom();
+
+    private PushApiUtil() {}
+
+    /**
+     * Returns an info record. See sections 3.2 and 3.3 of
+     * {https://tools.ietf.org/html/draft-ietf-httpbis-encryption-encoding-00}
+     * @param serverPublicKey server public key
+     * @param clientPublicKey client public key
+     * @param type info type
+     * @return
+     * @throws IOException
+     */
+    public static byte[] generateInfo(final byte[] serverPublicKey, final byte[] clientPublicKey, final byte[] type)
+            throws IOException {
+
+        // The start index for each element within the buffer is:
+        // value               | length | start  |
+        // ---------------------------------------
+        // 'Content-Encoding: '|   18   | 0      |
+        // type                |   l    | 18     |
+        // null byte           |   1    | 18 + l |
+        // 'P-256'             |   5    | 19 + l |
+        // info                |   135  | 24 + l |
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        outputStream.write(Constants.CONTENT_ENCODING); // Append the string â€œContent-Encoding: â€œ
+        outputStream.write(type); // Append the |type|
+        outputStream.write(NULL_BYTE); // Append a NULL-byte
+        outputStream.write(P256); // Append the string â€œP-256â€
+
+        // The context format is:
+        // 0x00 || length(clientPublicKey) || clientPublicKey ||
+        //         length(serverPublicKey) || serverPublicKey
+        // The lengths are 16-bit, Big Endian, unsigned integers so take 2 bytes each.
+
+        // The keys should always be 65 bytes each. The format of the keys is
+        // described in section 4.3.6 of the (sadly not freely linkable) ANSI X9.62
+        // specification.
+        outputStream.write(NULL_BYTE); // Append a NULL-byte
+
+        outputStream.write(NULL_BYTE); // Append the length of the recipientâ€™s public key (here |client_public|)
+        outputStream.write(KEY_LENGTH_BYTE); // as a two-byte integer in network byte order.
+
+        outputStream.write(clientPublicKey); // Append the raw bytes (65) of the recipientâ€™s
+        // public key.
+
+        outputStream.write(NULL_BYTE); // Append the length of the senderâ€™s public key (here |server_public|)
+        outputStream.write(KEY_LENGTH_BYTE); // as a two-byte integer in network byte order.
+
+        outputStream.write(serverPublicKey); // Append the raw bytes (65) of the
+        // senderâ€™s
+        // public key.
+
+        return outputStream.toByteArray();
+    }
+
+    public static String createEncryptionHeader(final byte[] salt) {
+        // Encode |salt| using the URL-safe base64 encoding, store it in |encoded_salt|.
+        // Return the result of concatenating (â€œsalt=â€, |encoded_salt|).
+        return "salt=" + Base64.getUrlEncoder().encodeToString(salt);
+    }
+
+    public static String createCryptoKeyHeader(final byte[] serverPublic) {
+        //Encode |server_public| using the URL-safe base64 encoding, store it in |encoded_server_public|.
+        // Return the result of concatenating (â€œdh=â€, |encoded_server_public|).
+        return "dh=" + Base64.getUrlEncoder().encodeToString(serverPublic);
+    }
+
+    /**
+     * Performs an hkdf extract on the message and trims to (lengthToExtract)
+     *  * HMAC-based Extract-and-Expand Key Derivation Function (HKDF)
+     *
+     * This is used to derive a secure encryption key from a mostly-secure shared
+     * secret.
+     *
+     * This is a partial implementation of HKDF tailored to our specific purposes.
+     * In particular, for us the value of N will always be 1, and thus T always
+     * equals HMAC-Hash(PRK, info | 0x01).
+     *
+     * See {https://www.rfc-editor.org/rfc/rfc5869.txt}
+     * @param secretKey key to perform the HMAC with
+     * @param salt random salt bytes
+     * @param messageToExtract message to perform hkdf extract on
+     * @param lengthToExtract how much to trim the output by
+     * @return hkdf extract
+     * @throws NoSuchAlgorithmException
+     * @throws InvalidKeyException
+     */
+    public static byte[] hkdfExtract(final byte[] secretKey, final byte[] salt, final byte[] messageToExtract,
+            final int lengthToExtract)
+            throws NoSuchAlgorithmException, InvalidKeyException {
+        Mac outerMac = Mac.getInstance(HMAC_SHA256);
+        outerMac.init(new SecretKeySpec(salt, HMAC_SHA256));
+        byte[] outerResult = outerMac.doFinal(secretKey);
+        Mac innerMac = Mac.getInstance(HMAC_SHA256);
+        innerMac.init(new SecretKeySpec(outerResult, HMAC_SHA256));
+        byte[] message = new byte[messageToExtract.length + 1];
+        System.arraycopy(messageToExtract, 0, message, 0, messageToExtract.length);
+        message[messageToExtract.length] = (byte) 1;
+        byte[] innerResult = innerMac.doFinal(message);
+        return Arrays.copyOf(innerResult, lengthToExtract);
+    }
+
+    /**
+     * Encrypts a message such that it can be sent using the Web Push protocol.
+     * You can find out more about the various pieces:
+     *  - {https://tools.ietf.org/html/draft-ietf-httpbis-encryption-encoding}
+     *  - {https://en.wikipedia.org/wiki/Elliptic_curve_Diffie%E2%80%93Hellman}
+     *  - {https://tools.ietf.org/html/draft-ietf-webpush-encryption}
+     * @param message Message to encrypt
+     * @param sharedSecret Shared secret computed using the server keys and the client public key
+     * @param salt 16 random bytes
+     * @param contentEncryptionKeyInfo
+     * @param nonceInfo
+     * @param clientAuth Client's auth (generated on the browser)
+     * @return
+     * @throws InvalidKeyException
+     * @throws NoSuchAlgorithmException
+     * @throws IllegalBlockSizeException
+     * @throws InvalidAlgorithmParameterException
+     * @throws BadPaddingException
+     * @throws NoSuchProviderException
+     * @throws NoSuchPaddingException
+     */
+    public static byte[] encryptPayload(final String message, final byte[] sharedSecret, final byte[] salt,
+            final byte[] contentEncryptionKeyInfo, final byte[] nonceInfo, final byte[] clientAuth)
+            throws InvalidKeyException, NoSuchAlgorithmException, IllegalBlockSizeException,
+            InvalidAlgorithmParameterException, BadPaddingException, NoSuchProviderException, NoSuchPaddingException {
+
+        // Derive a Pseudo-Random Key (prk) that can be used to further derive our
+        // other encryption parameters. These derivations are described in
+        // https://tools.ietf.org/html/draft-ietf-httpbis-encryption-encoding-00
+        final byte[] prk =
+                hkdfExtract(sharedSecret, clientAuth, "Content-Encoding: auth\0".getBytes(StandardCharsets.UTF_8), 32);
+
+        // Derive the Content Encryption Key
+        final byte[] contentEncryptionKey = hkdfExtract(prk, salt, contentEncryptionKeyInfo, 16);
+
+        // Derive the Nonce / iv
+        final byte[] nonce = hkdfExtract(prk, salt, nonceInfo, 12);
+
+        // Not adding any padding for now. First two bytes are reserved for number of padding bytes (0)
+        final byte[] record = ("\0\0" + message).getBytes(StandardCharsets.UTF_8);
+
+        // Set |ciphertext| to the result of encrypting |record| with AEAD_AES_128_GCM, using
+        // the |content_encryption_key| as the key, the |nonce| as the nonce/IV, and an authentication tag of 16 bytes.
+
+        return encryptWithAESGCM128(nonce, contentEncryptionKey, record);
+    }
+
+    /**
+     * Encrypt the plaintext message using AES128/GCM
+     * @param nonce The iv
+     * @param contentEncryptionKey The private key to use
+     * @param record The message to be encrypted
+     * @return the encrypted payload
+     * @throws NoSuchPaddingException
+     * @throws NoSuchAlgorithmException
+     * @throws NoSuchProviderException
+     * @throws InvalidAlgorithmParameterException
+     * @throws InvalidKeyException
+     * @throws BadPaddingException
+     * @throws IllegalBlockSizeException
+     */
+    public static byte[] encryptWithAESGCM128(final byte[] nonce, final byte[] contentEncryptionKey,
+            final byte[] record)
+            throws NoSuchPaddingException, NoSuchAlgorithmException, NoSuchProviderException, IllegalArgumentException,
+            InvalidAlgorithmParameterException, InvalidKeyException, BadPaddingException, IllegalBlockSizeException {
+        if (record.length > MAX_PAYLOAD_LENGTH) {
+            throw new IllegalArgumentException("Record is too big, dropping notification");
+        }
+        Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding", "SunJCE");
+        SecretKey key = new SecretKeySpec(contentEncryptionKey, "AES");
+        GCMParameterSpec spec = new GCMParameterSpec(GCM_TAG_LENGTH * 8, nonce);
+        cipher.init(Cipher.ENCRYPT_MODE, key, spec);
+        return cipher.doFinal(record);
+    }
+
+    /**
+     * Generates 16 cryptographically secure random bytes
+     * @return 16 byte salt
+     */
+    public static byte[] generateSalt() {
+        byte[] salt = new byte[16];
+        RANDOM_BYTE_GENERATOR.nextBytes(salt);
+        return salt;
+    }
+}

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/util/webpush/encryption/WebPushEncryptedData.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/util/webpush/encryption/WebPushEncryptedData.java
@@ -1,0 +1,56 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright Red Hat, Inc., and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.aerogear.unifiedpush.message.util.webpush.encryption;
+
+import java.io.Serializable;
+import java.util.Arrays;
+
+public class WebPushEncryptedData implements Serializable {
+
+    private static final long serialVersionUID = -1654509737937585694L;
+
+    private final byte[] ciphertext;
+    private final byte[] salt;
+    private final byte[] dh;
+
+    public WebPushEncryptedData(byte[] ciphertext, byte[] salt, byte[] dh) {
+        this.ciphertext = ciphertext;
+        this.salt = salt;
+        this.dh = dh;
+    }
+
+    public byte[] getCiphertext() {
+        return ciphertext;
+    }
+
+    public byte[] getSalt() {
+        return salt;
+    }
+
+    public byte[] getDh() {
+        return dh;
+    }
+
+    @Override
+    public String toString() {
+        return "WebPushEncryptedData{" +
+                "ciphertext=" + Arrays.toString(ciphertext) +
+                ", salt=" + Arrays.toString(salt) +
+                ", dh=" + Arrays.toString(dh) +
+                '}';
+    }
+}

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/util/webpush/encryption/WebPushEncryptionUtil.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/util/webpush/encryption/WebPushEncryptionUtil.java
@@ -1,0 +1,48 @@
+package org.jboss.aerogear.unifiedpush.message.util.webpush.encryption;
+
+import org.apache.commons.codec.DecoderException;
+import org.jboss.aerogear.unifiedpush.dto.WebPushToken;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
+import java.io.IOException;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.KeyPair;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.interfaces.ECPublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.util.Base64;
+
+import static org.jboss.aerogear.unifiedpush.message.util.webpush.encryption.Constants.AESGCM128;
+import static org.jboss.aerogear.unifiedpush.message.util.webpush.encryption.Constants.NONCE;
+
+public final class WebPushEncryptionUtil {
+
+    private WebPushEncryptionUtil() {}
+
+    public static WebPushEncryptedData generateEncryptedPayload(final WebPushToken webPushToken, final String payload)
+            throws InvalidAlgorithmParameterException, NoSuchAlgorithmException, NoSuchProviderException,
+            InvalidKeySpecException, InvalidKeyException, IOException, NoSuchPaddingException, BadPaddingException,
+            IllegalBlockSizeException, DecoderException {
+
+        EllipticCurveKeyUtil ellipticCurveKeyUtil = new EllipticCurveKeyUtil();
+
+        KeyPair serverKeys = ellipticCurveKeyUtil.generateServerKeyPair();
+
+        final ECPublicKey clientPublicKey = ellipticCurveKeyUtil.loadP256Dh(webPushToken.getPublicKey());
+        final byte[] clientAuth = Base64.getUrlDecoder().decode(webPushToken.getAuthSercret());
+        final byte[] salt = PushApiUtil.generateSalt();
+        final byte[] sharedSecret = ellipticCurveKeyUtil.generateSharedSecret(serverKeys, clientPublicKey);
+        final byte[] serverPublicKeyBytes = ellipticCurveKeyUtil.publicKeyToBytes((ECPublicKey) serverKeys.getPublic());
+        final byte[] clientPublicKeyBytes = ellipticCurveKeyUtil.publicKeyToBytes(clientPublicKey);
+        final byte[] nonceInfo = PushApiUtil.generateInfo(serverPublicKeyBytes, clientPublicKeyBytes, NONCE);
+        final byte[] contentEncryptionKeyInfo = PushApiUtil.generateInfo(serverPublicKeyBytes, clientPublicKeyBytes, AESGCM128);
+
+        byte[] cipherText = PushApiUtil.encryptPayload(payload, sharedSecret, salt, contentEncryptionKeyInfo, nonceInfo, clientAuth);
+
+        return new WebPushEncryptedData(cipherText, salt, serverPublicKeyBytes);
+    }
+}

--- a/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/message/jms/TestMessageHolderWithTokens.java
+++ b/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/message/jms/TestMessageHolderWithTokens.java
@@ -16,18 +16,10 @@
  */
 package org.jboss.aerogear.unifiedpush.message.jms;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-
-import javax.enterprise.event.Event;
-import javax.enterprise.event.Observes;
-import javax.inject.Inject;
-
 import org.jboss.aerogear.unifiedpush.api.AndroidVariant;
 import org.jboss.aerogear.unifiedpush.api.PushMessageInformation;
 import org.jboss.aerogear.unifiedpush.api.Variant;
+import org.jboss.aerogear.unifiedpush.dto.Token;
 import org.jboss.aerogear.unifiedpush.message.MockProviders;
 import org.jboss.aerogear.unifiedpush.message.UnifiedPushMessage;
 import org.jboss.aerogear.unifiedpush.message.holder.MessageHolderWithTokens;
@@ -38,6 +30,14 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import javax.enterprise.event.Event;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 
 @RunWith(Arquillian.class)
@@ -57,7 +57,7 @@ public class TestMessageHolderWithTokens {
     private UnifiedPushMessage message;
     private PushMessageInformation information;
     private Variant variant;
-    private Collection<String> deviceTokens;
+    private Collection<Token> deviceTokens;
     private static CountDownLatch delivered;
 
     @Inject @DispatchToQueue

--- a/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/message/jms/TestMessageRedelivery.java
+++ b/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/message/jms/TestMessageRedelivery.java
@@ -16,22 +16,11 @@
  */
 package org.jboss.aerogear.unifiedpush.message.jms;
 
-import static org.junit.Assert.fail;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import javax.enterprise.event.Event;
-import javax.enterprise.event.Observes;
-import javax.inject.Inject;
-
 import org.jboss.aerogear.unifiedpush.api.AndroidVariant;
 import org.jboss.aerogear.unifiedpush.api.PushMessageInformation;
 import org.jboss.aerogear.unifiedpush.api.SimplePushVariant;
 import org.jboss.aerogear.unifiedpush.api.Variant;
+import org.jboss.aerogear.unifiedpush.dto.Token;
 import org.jboss.aerogear.unifiedpush.message.MockProviders;
 import org.jboss.aerogear.unifiedpush.message.UnifiedPushMessage;
 import org.jboss.aerogear.unifiedpush.message.exception.PushNetworkUnreachableException;
@@ -44,6 +33,17 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import javax.enterprise.event.Event;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.fail;
 
 @RunWith(Arquillian.class)
 public class TestMessageRedelivery {
@@ -65,7 +65,7 @@ public class TestMessageRedelivery {
     private UnifiedPushMessage message;
     private PushMessageInformation information;
     private Variant variant;
-    private Collection<String> deviceTokens;
+    private Collection<Token> deviceTokens;
 
     private static CountDownLatch delivered;
     private static CountDownLatch resourceNotAvailable;

--- a/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/message/jms/TestTokenBatchDeduplication.java
+++ b/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/message/jms/TestTokenBatchDeduplication.java
@@ -16,23 +16,9 @@
  */
 package org.jboss.aerogear.unifiedpush.message.jms;
 
-import static org.junit.Assert.assertEquals;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import javax.annotation.Resource;
-import javax.enterprise.event.Event;
-import javax.enterprise.event.Observes;
-import javax.inject.Inject;
-import javax.jms.JMSException;
-import javax.jms.Queue;
-
 import org.jboss.aerogear.unifiedpush.api.AndroidVariant;
 import org.jboss.aerogear.unifiedpush.api.PushMessageInformation;
+import org.jboss.aerogear.unifiedpush.dto.Token;
 import org.jboss.aerogear.unifiedpush.message.AbstractJMSTest;
 import org.jboss.aerogear.unifiedpush.message.holder.MessageHolderWithTokens;
 import org.jboss.aerogear.unifiedpush.test.archive.UnifiedPushArchive;
@@ -42,6 +28,20 @@ import org.jboss.arquillian.junit.InSequence;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import javax.annotation.Resource;
+import javax.enterprise.event.Event;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+import javax.jms.JMSException;
+import javax.jms.Queue;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
 
 @RunWith(Arquillian.class)
 public class TestTokenBatchDeduplication extends AbstractJMSTest {
@@ -102,7 +102,7 @@ public class TestTokenBatchDeduplication extends AbstractJMSTest {
     }
 
     private void sendBatchWithSerialId(int serialId) {
-        List<String> tokenBatch = new ArrayList<>();
+        List<Token> tokenBatch = new ArrayList<>();
         PushMessageInformation pmi = new PushMessageInformation();
         pmi.setId(uuid);
         AndroidVariant variant = new AndroidVariant();

--- a/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/message/sender/APNsPushNotificationSenderTest.java
+++ b/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/message/sender/APNsPushNotificationSenderTest.java
@@ -17,17 +17,9 @@
 package org.jboss.aerogear.unifiedpush.message.sender;
 
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Arrays;
-import java.util.UUID;
-
+import com.notnoop.apns.ApnsService;
 import org.jboss.aerogear.unifiedpush.api.iOSVariant;
+import org.jboss.aerogear.unifiedpush.dto.Token;
 import org.jboss.aerogear.unifiedpush.message.UnifiedPushMessage;
 import org.jboss.aerogear.unifiedpush.message.serviceHolder.ApnsServiceHolder;
 import org.jboss.aerogear.unifiedpush.message.serviceHolder.ServiceConstructor;
@@ -36,7 +28,15 @@ import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
-import com.notnoop.apns.ApnsService;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.UUID;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class APNsPushNotificationSenderTest {
 
@@ -50,7 +50,7 @@ public class APNsPushNotificationSenderTest {
         when(iosVariant.getCertificate()).thenReturn(readCertificate());
         when(iosVariant.getPassphrase()).thenReturn("123456");
 
-        sender.sendPushMessage(iosVariant, Arrays.asList("token"), new UnifiedPushMessage(), "123", callback);
+        sender.sendPushMessage(iosVariant, Arrays.asList(new Token("token")), new UnifiedPushMessage(), "123", callback);
 
         verify(callback).onError("Error sending payload to APNs server: Invalid hex character: t");
     }

--- a/service/src/main/java/org/jboss/aerogear/unifiedpush/service/ClientInstallationService.java
+++ b/service/src/main/java/org/jboss/aerogear/unifiedpush/service/ClientInstallationService.java
@@ -19,6 +19,7 @@ package org.jboss.aerogear.unifiedpush.service;
 import org.jboss.aerogear.unifiedpush.api.Installation;
 import org.jboss.aerogear.unifiedpush.api.Variant;
 import org.jboss.aerogear.unifiedpush.dao.ResultsStream;
+import org.jboss.aerogear.unifiedpush.dto.Token;
 
 import java.util.List;
 import java.util.Set;
@@ -133,7 +134,7 @@ public interface ClientInstallationService {
      *
      * @return list of device tokens that matches this filter
      */
-    ResultsStream.QueryBuilder<String> findAllDeviceTokenForVariantIDByCriteria(String variantID, List<String> categories, List<String> aliases, List<String> deviceTypes, int maxResults, String lastTokenFromPreviousBatch);
+    ResultsStream.QueryBuilder<Token> findAllDeviceTokenForVariantIDByCriteria(String variantID, List<String> categories, List<String> aliases, List<String> deviceTypes, int maxResults, String lastTokenFromPreviousBatch);
 
     /**
      * Used to query all old GCM tokens, which do not contain a ':' char.
@@ -148,5 +149,5 @@ public interface ClientInstallationService {
      *
      * @return list of old GCM device tokens that matches this filter
      */
-    ResultsStream.QueryBuilder<String> findAllOldGoogleCloudMessagingDeviceTokenForVariantIDByCriteria(String variantID, List<String> categories, List<String> aliases, List<String> deviceTypes, int maxResults, String lastTokenFromPreviousBatch);
+    ResultsStream.QueryBuilder<Token> findAllOldGoogleCloudMessagingDeviceTokenForVariantIDByCriteria(String variantID, List<String> categories, List<String> aliases, List<String> deviceTypes, int maxResults, String lastTokenFromPreviousBatch);
 }

--- a/service/src/main/java/org/jboss/aerogear/unifiedpush/service/impl/ClientInstallationServiceImpl.java
+++ b/service/src/main/java/org/jboss/aerogear/unifiedpush/service/impl/ClientInstallationServiceImpl.java
@@ -157,6 +157,11 @@ public class ClientInstallationServiceImpl implements ClientInstallationService 
         installationToUpdate.setEnabled(postedInstallation.isEnabled());
         installationToUpdate.setPlatform(postedInstallation.getPlatform());
 
+        if (installationToUpdate.getVariant().getType() == VariantType.WEB_PUSH) {
+            installationToUpdate.setPublicKey(postedInstallation.getPublicKey());
+            installationToUpdate.setAuthSecret(postedInstallation.getAuthSecret());
+        }
+
         // update it:
         updateInstallation(installationToUpdate);
 
@@ -271,6 +276,12 @@ public class ClientInstallationServiceImpl implements ClientInstallationService 
         if (variant.getType().equals(VariantType.IOS)) {
             entity.setDeviceToken(entity.getDeviceToken().toLowerCase());
         }
+        // do not save publicKey and authSecret if it's not a WebPushVariant
+        if (variant.getType() != VariantType.WEB_PUSH) {
+            entity.setPublicKey(null);
+            entity.setAuthSecret(null);
+        }
+
         // set reference
         entity.setVariant(variant);
         // update attached categories

--- a/service/src/main/java/org/jboss/aerogear/unifiedpush/service/impl/ClientInstallationServiceImpl.java
+++ b/service/src/main/java/org/jboss/aerogear/unifiedpush/service/impl/ClientInstallationServiceImpl.java
@@ -24,6 +24,7 @@ import org.jboss.aerogear.unifiedpush.api.VariantType;
 import org.jboss.aerogear.unifiedpush.dao.CategoryDao;
 import org.jboss.aerogear.unifiedpush.dao.InstallationDao;
 import org.jboss.aerogear.unifiedpush.dao.ResultsStream;
+import org.jboss.aerogear.unifiedpush.dto.Token;
 import org.jboss.aerogear.unifiedpush.service.ClientInstallationService;
 import org.jboss.aerogear.unifiedpush.service.annotations.LoggedIn;
 import org.jboss.aerogear.unifiedpush.service.util.FCMTopicManager;
@@ -225,12 +226,12 @@ public class ClientInstallationServiceImpl implements ClientInstallationService 
      * Finder for 'send', used for Android, iOS and SimplePush clients
      */
     @Override
-    public ResultsStream.QueryBuilder<String> findAllDeviceTokenForVariantIDByCriteria(String variantID, List<String> categories, List<String> aliases, List<String> deviceTypes, int maxResults, String lastTokenFromPreviousBatch) {
+    public ResultsStream.QueryBuilder<Token> findAllDeviceTokenForVariantIDByCriteria(String variantID, List<String> categories, List<String> aliases, List<String> deviceTypes, int maxResults, String lastTokenFromPreviousBatch) {
         return installationDao.findAllDeviceTokenForVariantIDByCriteria(variantID, categories, aliases, deviceTypes, maxResults, lastTokenFromPreviousBatch, false);
     }
 
     @Override
-    public ResultsStream.QueryBuilder<String> findAllOldGoogleCloudMessagingDeviceTokenForVariantIDByCriteria(String variantID, List<String> categories, List<String> aliases, List<String> deviceTypes, int maxResults, String lastTokenFromPreviousBatch) {
+    public ResultsStream.QueryBuilder<Token> findAllOldGoogleCloudMessagingDeviceTokenForVariantIDByCriteria(String variantID, List<String> categories, List<String> aliases, List<String> deviceTypes, int maxResults, String lastTokenFromPreviousBatch) {
         return installationDao.findAllDeviceTokenForVariantIDByCriteria(variantID, categories, aliases, deviceTypes, maxResults, lastTokenFromPreviousBatch, true);
     }
 

--- a/service/src/test/java/org/jboss/aerogear/unifiedpush/service/ClientInstallationServiceTest.java
+++ b/service/src/test/java/org/jboss/aerogear/unifiedpush/service/ClientInstallationServiceTest.java
@@ -22,6 +22,7 @@ import org.jboss.aerogear.unifiedpush.api.Installation;
 import org.jboss.aerogear.unifiedpush.api.iOSVariant;
 import org.jboss.aerogear.unifiedpush.dao.ResultStreamException;
 import org.jboss.aerogear.unifiedpush.dao.ResultsStream;
+import org.jboss.aerogear.unifiedpush.dto.Token;
 import org.junit.Test;
 
 import javax.inject.Inject;
@@ -389,10 +390,10 @@ public class ClientInstallationServiceTest extends AbstractBaseServiceTest {
         device3.setVariant(androidVariant);
         clientInstallationService.addInstallation(androidVariant, device3);
 
-        final List<String> queriedTokens = findAllDeviceTokenForVariantIDByCriteria(androidVariant.getVariantID(), Arrays.asList("soccer"), null, null);
+        final List<Token> queriedTokens = findAllDeviceTokenForVariantIDByCriteria(androidVariant.getVariantID(), Arrays.asList("soccer"), null, null);
 
         assertThat(queriedTokens).hasSize(2);
-        assertThat(queriedTokens).contains(
+        assertThat(Token.toEndpoints(queriedTokens)).contains(
                 device1.getDeviceToken(),
                 device2.getDeviceToken()
         );
@@ -422,10 +423,10 @@ public class ClientInstallationServiceTest extends AbstractBaseServiceTest {
         device3.setVariant(androidVariant);
         clientInstallationService.addInstallation(androidVariant, device3);
 
-        final List<String> queriedTokens = findAllDeviceTokenForVariantIDByCriteria(androidVariant.getVariantID(), Arrays.asList("soccer", "football"), null, null);
+        final List<Token> queriedTokens = findAllDeviceTokenForVariantIDByCriteria(androidVariant.getVariantID(), Arrays.asList("soccer", "football"), null, null);
 
         assertThat(queriedTokens).hasSize(3);
-        assertThat(queriedTokens).contains(
+        assertThat(Token.toEndpoints(queriedTokens)).contains(
                 device1.getDeviceToken(),
                 device2.getDeviceToken(),
                 device3.getDeviceToken()
@@ -459,24 +460,25 @@ public class ClientInstallationServiceTest extends AbstractBaseServiceTest {
         device4.setCategories(categories);
         clientInstallationService.addInstallation(androidVariant, device4);
 
-        final List<String> queriedTokens = findAllDeviceTokenForVariantIDByCriteria(androidVariant.getVariantID(), null, null, null);
+        final List<Token> queriedTokens = findAllDeviceTokenForVariantIDByCriteria(androidVariant.getVariantID(), null, null, null);
 
         assertThat(queriedTokens).hasSize(4);
-        assertThat(queriedTokens).contains(
+        assertThat(Token.toEndpoints(queriedTokens)).contains(
                 device1.getDeviceToken(),
                 device2.getDeviceToken(),
                 device3.getDeviceToken(),
                 device4.getDeviceToken()
         );
-        final List<String> legacyTokenz = findAllOldGoogleCloudMessagingDeviceTokenForVariantIDByCriteria(androidVariant.getVariantID(), null, null, null);
+        final List<Token> legacyTokenz = findAllOldGoogleCloudMessagingDeviceTokenForVariantIDByCriteria(androidVariant.getVariantID(), null, null, null);
 
-        assertThat(legacyTokenz).hasSize(3);
-        assertThat(legacyTokenz).contains(
+        List<String> legacyEndpoints = Token.toEndpoints(legacyTokenz);
+        assertThat(legacyEndpoints).hasSize(3);
+        assertThat(legacyEndpoints).contains(
                 device1.getDeviceToken(),
                 device2.getDeviceToken(),
                 device3.getDeviceToken()
         );
-        assertThat(legacyTokenz).doesNotContain(
+        assertThat(legacyEndpoints).doesNotContain(
                 device4.getDeviceToken()
         );
     }
@@ -509,10 +511,10 @@ public class ClientInstallationServiceTest extends AbstractBaseServiceTest {
         return sb.toString();
     }
 
-    private List<String> findAllDeviceTokenForVariantIDByCriteria(String variantID, List<String> categories, List<String> aliases, List<String> deviceTypes) {
+    private List<Token> findAllDeviceTokenForVariantIDByCriteria(String variantID, List<String> categories, List<String> aliases, List<String> deviceTypes) {
         try {
-            ResultsStream<String> tokenStream = clientInstallationService.findAllDeviceTokenForVariantIDByCriteria(variantID, categories, aliases, deviceTypes, Integer.MAX_VALUE, null).executeQuery();
-            List<String> list = new ArrayList<>();
+            ResultsStream<Token> tokenStream = clientInstallationService.findAllDeviceTokenForVariantIDByCriteria(variantID, categories, aliases, deviceTypes, Integer.MAX_VALUE, null).executeQuery();
+            List<Token> list = new ArrayList<>();
             while (tokenStream.next()) {
                 list.add(tokenStream.get());
             }
@@ -522,10 +524,10 @@ public class ClientInstallationServiceTest extends AbstractBaseServiceTest {
         }
     }
 
-    private List<String> findAllOldGoogleCloudMessagingDeviceTokenForVariantIDByCriteria(String variantID, List<String> categories, List<String> aliases, List<String> deviceTypes) {
+    private List<Token> findAllOldGoogleCloudMessagingDeviceTokenForVariantIDByCriteria(String variantID, List<String> categories, List<String> aliases, List<String> deviceTypes) {
         try {
-            ResultsStream<String> tokenStream = clientInstallationService.findAllOldGoogleCloudMessagingDeviceTokenForVariantIDByCriteria(variantID, categories, aliases, deviceTypes, Integer.MAX_VALUE, null).executeQuery();
-            List<String> list = new ArrayList<>();
+            ResultsStream<Token> tokenStream = clientInstallationService.findAllOldGoogleCloudMessagingDeviceTokenForVariantIDByCriteria(variantID, categories, aliases, deviceTypes, Integer.MAX_VALUE, null).executeQuery();
+            List<Token> list = new ArrayList<>();
             while (tokenStream.next()) {
                 list.add(tokenStream.get());
             }


### PR DESCRIPTION
This version is based on @ameyakarve library: https://github.com/MartijnDwars/web-push

The first version is here: https://github.com/aerogear/aerogear-unifiedpush-server/pull/747

@ameyakarve thanks for the lib, it helped me to solve the problem with public key loading process in the first version.

Unfortunately, both of them don't work with our code base :(
When you send a push message, a server gets an exception  `java.security.InvalidAlgorithmParameterException: parameter object not a ECParameterSpec`:

```
05:54:40,578 ERROR [org.jboss.aerogear.unifiedpush.message.sender.WebPushNotificationSender] (Thread-336 (ActiveMQ-client-global-threads-2124725465)) Error sending push message: java.security.InvalidAlgorithmParameterException: parameter object not a ECParameterSpec
    at org.bouncycastle.jcajce.provider.asymmetric.ec.KeyPairGeneratorSpi$EC.initialize(Unknown Source)
    at org.jboss.aerogear.unifiedpush.message.util.webpush.encryption.EllipticCurveKeyUtil.<init>(EllipticCurveKeyUtil.java:69)
    at org.jboss.aerogear.unifiedpush.message.util.webpush.encryption.WebPushEncryptionUtil.generateEncryptedPayload(WebPushEncryptionUtil.java:31)
    at org.jboss.aerogear.unifiedpush.message.sender.WebPushNotificationSender.sendPushMessage(WebPushNotificationSender.java:84)
    at org.jboss.aerogear.unifiedpush.message.NotificationDispatcher.sendMessagesToPushNetwork(NotificationDispatcher.java:80)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:498)
    at org.jboss.as.ee.component.ManagedReferenceMethodInterceptor.processInvocation(ManagedReferenceMethodInterceptor.java:52)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.invocation.InterceptorContext$Invocation.proceed(InterceptorContext.java:437)
    at org.jboss.as.weld.ejb.Jsr299BindingsInterceptor.doMethodInterception(Jsr299BindingsInterceptor.java:82)
    at org.jboss.as.weld.ejb.Jsr299BindingsInterceptor.processInvocation(Jsr299BindingsInterceptor.java:93)
    at org.jboss.as.ee.component.interceptors.UserInterceptorFactory$1.processInvocation(UserInterceptorFactory.java:63)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.as.ejb3.component.invocationmetrics.ExecutionTimeInterceptor.processInvocation(ExecutionTimeInterceptor.java:43)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.as.jpa.interceptor.SBInvocationInterceptor.processInvocation(SBInvocationInterceptor.java:47)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.invocation.InterceptorContext$Invocation.proceed(InterceptorContext.java:437)
    at org.jboss.weld.ejb.AbstractEJBRequestScopeActivationInterceptor.aroundInvoke(AbstractEJBRequestScopeActivationInterceptor.java:64)
    at org.jboss.as.weld.ejb.EjbRequestScopeActivationInterceptor.processInvocation(EjbRequestScopeActivationInterceptor.java:83)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.as.ee.concurrent.ConcurrentContextInterceptor.processInvocation(ConcurrentContextInterceptor.java:45)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.invocation.InitialInterceptor.processInvocation(InitialInterceptor.java:21)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.invocation.ChainedInterceptor.processInvocation(ChainedInterceptor.java:61)
    at org.jboss.as.ee.component.interceptors.ComponentDispatcherInterceptor.processInvocation(ComponentDispatcherInterceptor.java:52)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.as.ejb3.component.pool.PooledInstanceInterceptor.processInvocation(PooledInstanceInterceptor.java:51)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.as.ejb3.tx.CMTTxInterceptor.invokeInOurTx(CMTTxInterceptor.java:275)
    at org.jboss.as.ejb3.tx.CMTTxInterceptor.required(CMTTxInterceptor.java:327)
    at org.jboss.as.ejb3.tx.CMTTxInterceptor.processInvocation(CMTTxInterceptor.java:239)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.as.ejb3.component.interceptors.CurrentInvocationContextInterceptor.processInvocation(CurrentInvocationContextInterceptor.java:41)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.as.ejb3.component.invocationmetrics.WaitTimeInterceptor.processInvocation(WaitTimeInterceptor.java:43)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.as.ejb3.security.SecurityContextInterceptor.processInvocation(SecurityContextInterceptor.java:100)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.as.ejb3.component.interceptors.ShutDownInterceptorFactory$1.processInvocation(ShutDownInterceptorFactory.java:64)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.as.ejb3.component.interceptors.LoggingInterceptor.processInvocation(LoggingInterceptor.java:66)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.as.ee.component.NamespaceContextInterceptor.processInvocation(NamespaceContextInterceptor.java:50)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.as.ejb3.component.interceptors.AdditionalSetupInterceptor.processInvocation(AdditionalSetupInterceptor.java:54)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.invocation.ContextClassLoaderInterceptor.processInvocation(ContextClassLoaderInterceptor.java:64)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.invocation.InterceptorContext.run(InterceptorContext.java:356)
    at org.wildfly.security.manager.WildFlySecurityManager.doChecked(WildFlySecurityManager.java:636)
    at org.jboss.invocation.AccessCheckingInterceptor.processInvocation(AccessCheckingInterceptor.java:61)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.invocation.InterceptorContext.run(InterceptorContext.java:356)
    at org.jboss.invocation.PrivilegedWithCombinerInterceptor.processInvocation(PrivilegedWithCombinerInterceptor.java:80)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.invocation.ChainedInterceptor.processInvocation(ChainedInterceptor.java:61)
    at org.jboss.as.ee.component.ViewService$View.invoke(ViewService.java:195)
    at org.jboss.as.ee.component.ViewDescription$1.processInvocation(ViewDescription.java:185)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.invocation.ChainedInterceptor.processInvocation(ChainedInterceptor.java:61)
    at org.jboss.as.ee.component.ProxyInvocationHandler.invoke(ProxyInvocationHandler.java:73)
    at org.jboss.aerogear.unifiedpush.message.NotificationDispatcher$$$view125.sendMessagesToPushNetwork(Unknown Source)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:498)
    at org.jboss.weld.util.reflection.Reflections.invokeAndUnwrap(Reflections.java:436)
    at org.jboss.weld.bean.proxy.EnterpriseBeanProxyMethodHandler.invoke(EnterpriseBeanProxyMethodHandler.java:127)
    at org.jboss.weld.bean.proxy.EnterpriseTargetBeanInstance.invoke(EnterpriseTargetBeanInstance.java:56)
    at org.jboss.weld.bean.proxy.InjectionPointPropagatingEnterpriseTargetBeanInstance.invoke(InjectionPointPropagatingEnterpriseTargetBeanInstance.java:67)
    at org.jboss.weld.bean.proxy.ProxyMethodHandler.invoke(ProxyMethodHandler.java:100)
    at org.jboss.aerogear.unifiedpush.message.NotificationDispatcher$Proxy$_$$_Weld$EnterpriseProxy$.sendMessagesToPushNetwork(Unknown Source)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:498)
    at org.jboss.weld.injection.StaticMethodInjectionPoint.invoke(StaticMethodInjectionPoint.java:88)
    at org.jboss.weld.injection.StaticMethodInjectionPoint.invoke(StaticMethodInjectionPoint.java:78)
    at org.jboss.weld.injection.MethodInvocationStrategy$SimpleMethodInvocationStrategy.invoke(MethodInvocationStrategy.java:129)
    at org.jboss.weld.event.ObserverMethodImpl.sendEvent(ObserverMethodImpl.java:309)
    at org.jboss.weld.event.ObserverMethodImpl.sendEvent(ObserverMethodImpl.java:287)
    at org.jboss.weld.event.ObserverMethodImpl.notify(ObserverMethodImpl.java:265)
    at org.jboss.weld.event.ObserverNotifier.notifySyncObservers(ObserverNotifier.java:271)
    at org.jboss.weld.event.ObserverNotifier.notify(ObserverNotifier.java:260)
    at org.jboss.weld.event.EventImpl.fire(EventImpl.java:89)
    at org.jboss.aerogear.unifiedpush.message.jms.MessageHolderWithTokensConsumer.onMessage(MessageHolderWithTokensConsumer.java:49)
    at org.jboss.aerogear.unifiedpush.message.jms.MessageHolderWithTokensConsumer.onMessage(MessageHolderWithTokensConsumer.java:36)
    at org.jboss.aerogear.unifiedpush.message.jms.AbstractJMSMessageListener.onMessage(AbstractJMSMessageListener.java:53)
    at sun.reflect.GeneratedMethodAccessor594.invoke(Unknown Source)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:498)
    at org.jboss.as.ee.component.ManagedReferenceMethodInterceptor.processInvocation(ManagedReferenceMethodInterceptor.java:52)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.invocation.InterceptorContext$Invocation.proceed(InterceptorContext.java:437)
    at org.jboss.as.weld.ejb.Jsr299BindingsInterceptor.doMethodInterception(Jsr299BindingsInterceptor.java:82)
    at org.jboss.as.weld.ejb.Jsr299BindingsInterceptor.processInvocation(Jsr299BindingsInterceptor.java:93)
    at org.jboss.as.ee.component.interceptors.UserInterceptorFactory$1.processInvocation(UserInterceptorFactory.java:63)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.as.ejb3.component.invocationmetrics.ExecutionTimeInterceptor.processInvocation(ExecutionTimeInterceptor.java:43)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.invocation.InterceptorContext$Invocation.proceed(InterceptorContext.java:437)
    at org.jboss.weld.ejb.AbstractEJBRequestScopeActivationInterceptor.aroundInvoke(AbstractEJBRequestScopeActivationInterceptor.java:73)
    at org.jboss.as.weld.ejb.EjbRequestScopeActivationInterceptor.processInvocation(EjbRequestScopeActivationInterceptor.java:83)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.as.ee.concurrent.ConcurrentContextInterceptor.processInvocation(ConcurrentContextInterceptor.java:45)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.invocation.InitialInterceptor.processInvocation(InitialInterceptor.java:21)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.invocation.ChainedInterceptor.processInvocation(ChainedInterceptor.java:61)
    at org.jboss.as.ee.component.interceptors.ComponentDispatcherInterceptor.processInvocation(ComponentDispatcherInterceptor.java:52)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.as.ejb3.component.pool.PooledInstanceInterceptor.processInvocation(PooledInstanceInterceptor.java:51)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.as.ejb3.tx.CMTTxInterceptor.invokeInNoTx(CMTTxInterceptor.java:263)
    at org.jboss.as.ejb3.tx.CMTTxInterceptor.notSupported(CMTTxInterceptor.java:313)
    at org.jboss.as.ejb3.tx.CMTTxInterceptor.processInvocation(CMTTxInterceptor.java:237)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.as.ejb3.component.interceptors.CurrentInvocationContextInterceptor.processInvocation(CurrentInvocationContextInterceptor.java:41)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.as.ejb3.component.invocationmetrics.WaitTimeInterceptor.processInvocation(WaitTimeInterceptor.java:43)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.as.ejb3.security.SecurityContextInterceptor.processInvocation(SecurityContextInterceptor.java:100)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.as.ejb3.component.interceptors.ShutDownInterceptorFactory$1.processInvocation(ShutDownInterceptorFactory.java:64)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.as.ejb3.deployment.processors.EjbSuspendInterceptor.processInvocation(EjbSuspendInterceptor.java:53)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.as.ejb3.component.interceptors.LoggingInterceptor.processInvocation(LoggingInterceptor.java:66)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.as.ee.component.NamespaceContextInterceptor.processInvocation(NamespaceContextInterceptor.java:50)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.as.ejb3.component.interceptors.AdditionalSetupInterceptor.processInvocation(AdditionalSetupInterceptor.java:54)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.as.ejb3.component.messagedriven.MessageDrivenComponentDescription$5$1.processInvocation(MessageDrivenComponentDescription.java:239)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.invocation.ContextClassLoaderInterceptor.processInvocation(ContextClassLoaderInterceptor.java:64)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.invocation.InterceptorContext.run(InterceptorContext.java:356)
    at org.wildfly.security.manager.WildFlySecurityManager.doChecked(WildFlySecurityManager.java:636)
    at org.jboss.invocation.AccessCheckingInterceptor.processInvocation(AccessCheckingInterceptor.java:61)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.invocation.InterceptorContext.run(InterceptorContext.java:356)
    at org.jboss.invocation.PrivilegedWithCombinerInterceptor.processInvocation(PrivilegedWithCombinerInterceptor.java:80)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.invocation.ChainedInterceptor.processInvocation(ChainedInterceptor.java:61)
    at org.jboss.as.ee.component.ViewService$View.invoke(ViewService.java:195)
    at org.jboss.as.ee.component.ViewDescription$1.processInvocation(ViewDescription.java:185)
    at org.jboss.invocation.InterceptorContext.proceed(InterceptorContext.java:340)
    at org.jboss.invocation.ChainedInterceptor.processInvocation(ChainedInterceptor.java:61)
    at org.jboss.as.ee.component.ProxyInvocationHandler.invoke(ProxyInvocationHandler.java:73)
    at org.jboss.aerogear.unifiedpush.message.jms.MessageHolderWithTokensConsumer$$$view109.onMessage(Unknown Source)
    at sun.reflect.GeneratedMethodAccessor594.invoke(Unknown Source)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:498)
    at org.jboss.as.ejb3.inflow.MessageEndpointInvocationHandler.doInvoke(MessageEndpointInvocationHandler.java:139)
    at org.jboss.as.ejb3.inflow.AbstractInvocationHandler.invoke(AbstractInvocationHandler.java:73)
    at org.jboss.aerogear.unifiedpush.message.jms.MessageHolderWithTokensConsumer$$$endpoint61.onMessage(Unknown Source)
    at org.apache.activemq.artemis.ra.inflow.ActiveMQMessageHandler.onMessage(ActiveMQMessageHandler.java:310)
    at org.apache.activemq.artemis.core.client.impl.ClientConsumerImpl.callOnMessage(ClientConsumerImpl.java:932)
    at org.apache.activemq.artemis.core.client.impl.ClientConsumerImpl.access$400(ClientConsumerImpl.java:47)
    at org.apache.activemq.artemis.core.client.impl.ClientConsumerImpl$Runner.run(ClientConsumerImpl.java:1045)
    at org.apache.activemq.artemis.utils.OrderedExecutorFactory$OrderedExecutor$ExecutorTask.run(OrderedExecutorFactory.java:100)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
    at java.lang.Thread.run(Thread.java:745)
```

I thought that it happens because Keycloak also depends on Bouncy Castle `bcprov-jdk15on` and here is a version conflict. I tried to:
- override `bcprov-jdk15on` version to the latest one
- replace `bcprov-jdk15on` jar in the final war
- exclude `bcprov-jdk15on` from all Keycloak dependencies

But nothing helped. Could anyone look at this?
