### PR TITLE
Integration with AeroGear WebPush Server

### DIFF
--- a/admin-ui/app/components/app-detail/include/variantDetail.html
+++ b/admin-ui/app/components/app-detail/include/variantDetail.html
@@ -111,8 +111,10 @@
   <dt>FCM Server Key:</dt>
   <dd class="project-number">{{ variant.fcmServerKey }}</dd>
   <dt>FCM Sender ID:</dt>
-  <dd class="google-key">
-    {{ variant.fcmSenderID }}<br />
+  <dd class="google-key">{{ variant.fcmSenderID }}</dd>
+  <dt>Custom server URL:</dt>
+  <dd class="custom-server-url">
+    {{ variant.customServerUrl }}<br />
     <button class="btn btn-sm btn-default" ng-click="variants.edit( variant )"><span class="fa fa-pencil"></span> Edit network options</button>
   </dd>
 </dl>

--- a/admin-ui/app/dialogs/create-variant.html
+++ b/admin-ui/app/dialogs/create-variant.html
@@ -239,6 +239,12 @@
             <input type="text" placeholder="e.g. 42" id="fcmSenderID" class="form-control" ng-model="variant.fcmSenderID">
           </div>
         </div>
+        <div class="form-group">
+          <label class="col-sm-3 control-label" for="customServerUrl"></label>
+          <div class="col-sm-7">Custom server URL<br>
+            <input type="text" placeholder="https://localhost:8443" id="customServerUrl" class="form-control" ng-model="variant.customServerUrl">
+          </div>
+        </div>
       </div>
 
     </div>

--- a/admin-ui/app/scripts/services/variantModal.js
+++ b/admin-ui/app/scripts/services/variantModal.js
@@ -163,7 +163,7 @@ angular.module('upsConsole').factory('variantModal', function ($modal, $q, varia
       properties = properties.concat(['clientId', 'clientSecret']);
       break;
     case 'webPush':
-      properties = properties.concat(['fcmServerKey', 'fcmSenderID']);
+      properties = properties.concat(['fcmServerKey', 'fcmSenderID', 'customServerUrl']);
       break;
     default:
       throw 'Unknown variant type ' + variant.type;

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/WebPushVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/WebPushVariantEndpoint.java
@@ -141,7 +141,9 @@ public class WebPushVariantEndpoint extends AbstractVariantEndpoint {
             // update FCM info:
             webPushVariant.setFcmServerKey(updatedWebPushVariant.getFcmServerKey());
             webPushVariant.setFcmSenderID(updatedWebPushVariant.getFcmSenderID());
-            
+            // update custom server info:
+            webPushVariant.setCustomServerUrl(updatedWebPushVariant.getCustomServerUrl());
+
             variantService.updateVariant(webPushVariant);
             return Response.ok(webPushVariant).build();
         }

--- a/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/WebPushVariant.java
+++ b/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/WebPushVariant.java
@@ -24,14 +24,17 @@ import javax.validation.constraints.Size;
  */
 public class WebPushVariant extends Variant {
     private static final long serialVersionUID = 1142847851407493017L;
-    
+
     @NotNull
     @Size(min = 1, max = 255, message = "Server Key must be max. 255 chars long")
     private String fcmServerKey;
-    
+
     @Size(max = 255, message = "Sender ID must be max. 255 chars long")
     private String fcmSenderID;
-    
+
+    @Size(max = 255, message = "Custom server URL must be max. 255 chars long")
+    private String customServerUrl;
+
     /**
      * The Server Key from the Firebase Cloud Messaging Console of a project which has been enabled for FCM.
      *
@@ -40,11 +43,11 @@ public class WebPushVariant extends Variant {
     public String getFcmServerKey() {
         return fcmServerKey;
     }
-    
+
     public void setFcmServerKey(final String fcmServerKey) {
         this.fcmServerKey = fcmServerKey;
     }
-    
+
     /**
      * The Sender ID from the Firebase Cloud Messaging Console is <i>not</i> needed for sending push messages,
      * but it is a convenience to "see" it on the Admin UI as well, since the web applications require it.
@@ -54,9 +57,23 @@ public class WebPushVariant extends Variant {
     public String getFcmSenderID() {
         return fcmSenderID;
     }
-    
+
     public void setFcmSenderID(final String fcmSenderID) {
         this.fcmSenderID = fcmSenderID;
+    }
+
+    /**
+     * The URL to the custom WebPush Server, which could be used for WebPush notification in intranet
+     * or for IoT devices.
+     *
+     * @return the custom server URL
+     */
+    public String getCustomServerUrl() {
+        return customServerUrl;
+    }
+
+    public void setCustomServerUrl(String customServerUrl) {
+        this.customServerUrl = customServerUrl;
     }
 
     @Override

--- a/model/jpa/src/main/resources/META-INF/orm.xml
+++ b/model/jpa/src/main/resources/META-INF/orm.xml
@@ -145,6 +145,9 @@ http://java.sun.com/xml/ns/persistence/orm_2_0.xsd"
             <basic name="fcmSenderID">
                 <column name="fcm_sender_id" length="255"/>
             </basic>
+            <basic name="customServerUrl">
+                <column name="custom_server_url" length="255"/>
+            </basic>
         </attributes>
     </entity>
 


### PR DESCRIPTION
I've extended WebPush variant to send push notification to the [AeroGear WebPush Server](https://github.com/aerogear/aerogear-webpush-server). To test it, follow the next steps:

1. Compile and deploy current branch.
2. Compile and run AeroGear WebPush Server.
3. Add SSL certificate of AeroGear WebPush Server to the trusted storage. See [1](http://www.mkyong.com/webservices/jax-ws/suncertpathbuilderexception-unable-to-find-valid-certification-path-to-requested-target/), [2](http://java.globinch.com/enterprise-java/security/pkix-path-building-failed-validation-sun-security-validatorexception/).
4. Go to the UPS console, create WebPush variant and add link to your AeroGear WebPush Server instance.
5. Run [AeroGear WebPush Console](https://github.com/aerogear/aerogear-webpush-server/tree/master/console), execute `connect`, `subscribe` and `monitor` commands.
6. Register your installation on UPS, see example below:
```
curl -v -u "variantID:secret"
    -H "Accept: application/json"
    -H "Content-type: application/json"
    -H "aerogear-push-id: someid"
    -X POST
    -d '{
            "deviceToken" : "https://localhost:8443/webpush/p/pzNYitnLVYi5U0iO4rMPgkF74UkwqOfv9cnY6BeFxK12bq%2FnlD8%2Fh6ffmy1ed%2FM545ztH6vMjbSWVUZWFrSwAndOqkJZP%2BctUPEGYYMOqR8FWuyaeWjIYiogYZSLj6v91WUtJFVXwDYI",
            "deviceType" : "webpush-console",
            "alias" : "localhost"
    }'
    http://localhost:8080/ag-push/rest/registry/device
```
Now send a push message via UPS. See at your WebPush Console... Congrants! :)