### PR TITLE
comment out the section that triggers the 30 seconds polling

### DIFF
--- a/admin-ui/app/scripts/controllers/AppController.js
+++ b/admin-ui/app/scripts/controllers/AppController.js
@@ -70,11 +70,12 @@ angular.module('upsConsole')
     }
     updateWarnings();
 
-    var updateWarningsInterval = $interval(updateWarnings, 30000);
-    $scope.$on('$destroy', function() {
-      $log.debug('cancelling updateWarnings interval');
-      $interval.cancel( updateWarningsInterval );
-    });
+    // For AGPUSH-1895: temporarrly we disable the polling
+    // var updateWarningsInterval = $interval(updateWarnings, 30000);
+    // $scope.$on('$destroy', function() {
+    //   $log.debug('cancelling updateWarnings interval');
+    //   $interval.cancel( updateWarningsInterval );
+    // });
     $scope.$on('upsNotificationSent', function() {
       var timer1 = $timeout(updateWarnings, 1500);
       var timer2 = $timeout(updateWarnings, 5000);


### PR DESCRIPTION
For [AGPUSH-1895](https://issues.jboss.org/browse/AGPUSH-1895) we disable the polling

This also causes problems on screens that embed the AdminUI, since the interval is never cleared.

Also, polling is a bad technique, since the underlying SQL queries get executed over and over again, even when there is no change  