### PR TITLE
Re-enable to triggering of the VariantCompletedEvent

### DIFF
--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/MetricsCollector.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/MetricsCollector.java
@@ -89,7 +89,7 @@ public class MetricsCollector {
                 .forEach(variantMetricInformation -> {
                     pushMessageInformation.setServedVariants(1 + pushMessageInformation.getServedVariants());
                     logger.debug(String.format("All batches for variant %s were processed", variantMetricInformation.getVariantID()));
-
+                    variantCompleted.fire(new VariantCompletedEvent(pushMessageInformation.getId(), variantMetricInformation.getVariantID()));
                 });
 
         if (areAllVariantsServed(pushMessageInformation)) {


### PR DESCRIPTION
was removed, by accident in this commit:
https://github.com/aerogear/aerogear-unifiedpush-server/commit/7291065ddbcef270e55e5c68d6b810c8397fefb3#diff-7b028ee70d46d036c357134313d099d3