### PR TITLE
Only check until the LATEST push job is finished

### DIFF
--- a/admin-ui/app/components/app-detail/include/activity.js
+++ b/admin-ui/app/components/app-detail/include/activity.js
@@ -74,9 +74,11 @@ angular.module('upsConsole')
       fetchMetrics( self.currentPage, self.searchString )
         .then(function() {
           $log.debug('refreshed');
-          var isPending = self.metrics.some(function(metric) {
-            return metric.servedVariants < metric.totalVariants;
-          });
+          // is the _last_ push job pending?
+          var isPending = self.metrics[0].servedVariants < self.metrics[0].totalVariants;
+          // var isPending = self.metrics.some(function(metric) {
+          //   return metric.servedVariants < metric.totalVariants;
+          // });
           if (isPending) {
             if (!refreshInterval) {
               $log.debug('scheduling refresh');


### PR DESCRIPTION
Some UI fix, preventing polling all the time, when there is one ore more push jobs not finished, due to whatever possible error.

It's kind of rediculous, that we ping the server every second, in case there is a broken push job from the past... e.g. last day or so 