### PR TITLE
Remove Variant criteria from topic check

### DIFF
--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/token/TokenLoaderUtils.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/token/TokenLoaderUtils.java
@@ -59,10 +59,9 @@ public final class TokenLoaderUtils {
      */
     public static boolean isCategoryOnlyCriteria(final Criteria criteria) {
 
-        return  isEmpty(criteria.getAliases()) &&
-                isEmpty(criteria.getDeviceTypes()) &&
-                isEmpty(criteria.getVariants()) &&
-                !isEmpty(criteria.getCategories());
+        return  isEmpty(criteria.getAliases()) &&      // we are not subscribing to alias topic (yet)
+                isEmpty(criteria.getDeviceTypes()) &&  // we are not subscribing to device type topic (yet)
+                !isEmpty(criteria.getCategories());    // BUT! categories are mapped to topics
     }
 
     /**
@@ -72,7 +71,6 @@ public final class TokenLoaderUtils {
 
         return  isEmpty(criteria.getAliases()) &&
                 isEmpty(criteria.getDeviceTypes()) &&
-                isEmpty(criteria.getVariants()) &&
                 isEmpty(criteria.getCategories());
     }
 

--- a/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/message/token/TokenLoaderUtilsTest.java
+++ b/push/sender/src/test/java/org/jboss/aerogear/unifiedpush/message/token/TokenLoaderUtilsTest.java
@@ -118,5 +118,32 @@ public class TokenLoaderUtilsTest {
         assertThat(TokenLoaderUtils.isGCMTopicRequest(criteria)).isFalse();
     }
 
+    @Test
+    public void testGCMTopicForVariant() {
+        final Criteria criteria = new Criteria();
+        criteria.setVariants(Arrays.asList("variant1", "variant2"));
+        assertThat(TokenLoaderUtils.isGCMTopicRequest(criteria)).isTrue();
+    }
 
+    @Test
+    public void testGCMTopicForVariantAndCategory() {
+        final Criteria criteria = new Criteria();
+        criteria.setVariants(Arrays.asList("variant1", "variant2"));
+        criteria.setCategories(Arrays.asList("football"));
+
+        assertThat(TokenLoaderUtils.isGCMTopicRequest(criteria)).isTrue();
+        assertThat(TokenLoaderUtils.extractGCMTopics(criteria, "123")).containsOnly(
+                Constants.TOPIC_PREFIX+"football"
+        );
+
+    }
+
+    @Test
+    public void testGCMTopicForVariantAndAlias() {
+        final Criteria criteria = new Criteria();
+        criteria.setVariants(Arrays.asList("variant1", "variant2"));
+        criteria.setAliases(Arrays.asList("foo@bar.org"));
+
+        assertThat(TokenLoaderUtils.isGCMTopicRequest(criteria)).isFalse();
+    }
 }


### PR DESCRIPTION
The `TokenLoader` class iterates over affected Vairants, per push job, and on EACH variant it checks if the request is a FCM/GCM topic request (e.g. does it have categories, or are there no criterias).

So, inside of a variant (used as topic any ways), it's not making sense, but instead returns false result.
