### PR TITLE
Adding some more info what tool did send the request

### DIFF
--- a/admin-ui/app/components/app-detail/include/activity.html
+++ b/admin-ui/app/components/app-detail/include/activity.html
@@ -41,7 +41,7 @@
         </a>
       </td>
       <td>{{ metric.$message.alert | limitTo : 15 }}{{ metric.$message.alert.length > 15 ? '&hellip;' : '' }}</td>
-      <td>{{ metric.ipAddress }}</td>
+      <td title="by {{ metric.clientIdentifier }}">{{ metric.ipAddress }}</td>
       <td>{{ metric.totalReceivers }} receivers / {{ metric.appOpenCounter }} opened</td>
       <td ng-if="metric.servedVariants < metric.totalVariants">
         <!--<i class="pficon-running"></i>-->

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/NotificationRouter.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/NotificationRouter.java
@@ -118,7 +118,7 @@ public class NotificationRouter {
 
         // we split the variants per type since each type may have its own configuration (e.g. batch size)
         for (final Entry<VariantType, List<Variant>> entry : variants.entrySet()) {
-            logger.info(String.format("Internal dispatching of push message for one %s variant", entry.getKey().getTypeName()));
+            logger.info(String.format("Internal dispatching of push message for one %s variant (by %s)", entry.getKey().getTypeName(), message.getClientIdentifier()));
             dispatchVariantMessageEvent.fire(new MessageHolderWithVariants(pushMessageInformation, message, entry.getKey(), entry.getValue()));
         }
     }


### PR DESCRIPTION
In our push metrics we collect the sender (tracked via `aerogear-sender` header or `user-agent`), but currently we are not showing the info (we used to do that in the old UI).

this PR displays the sender info on the activty log (tooltip in the IP-Address field)

It also adds it to the NotificationRouter log