### PR TITLE
If there are no metrics available, there is no 0 index...

### DIFF
--- a/admin-ui/app/components/app-detail/include/activity.js
+++ b/admin-ui/app/components/app-detail/include/activity.js
@@ -75,7 +75,7 @@ angular.module('upsConsole')
         .then(function() {
           $log.debug('refreshed');
           // is the _last_ push job pending?
-          var isPending = self.metrics[0].servedVariants < self.metrics[0].totalVariants;
+          var isPending = self.metrics[0] && (self.metrics[0].servedVariants < self.metrics[0].totalVariants);
           // var isPending = self.metrics.some(function(metric) {
           //   return metric.servedVariants < metric.totalVariants;
           // });


### PR DESCRIPTION
If there is a variant, that has ZERO push notifications sent, clicking on the `Activity log` gives a JS error: `can not resolve property servedVariants of undefined`

This is due to the fact that, when there are no metric entires in the table, there is also nothing in index `0` ... 