### PR TITLE
using FCM URL for health check

### DIFF
--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/util/HealthNetworkServiceImpl.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/util/HealthNetworkServiceImpl.java
@@ -16,9 +16,9 @@
  */
 package org.jboss.aerogear.unifiedpush.message.util;
 
-import com.google.android.gcm.server.Constants;
 import com.notnoop.apns.internal.Utilities;
 import org.jboss.aerogear.unifiedpush.message.HealthNetworkService;
+import org.jboss.aerogear.unifiedpush.message.sender.fcm.ConfigurableFCMSender;
 import org.jboss.aerogear.unifiedpush.service.impl.health.HealthDetails;
 import org.jboss.aerogear.unifiedpush.service.impl.health.Ping;
 import org.jboss.aerogear.unifiedpush.service.impl.health.PushNetwork;
@@ -45,11 +45,11 @@ public class HealthNetworkServiceImpl implements HealthNetworkService {
     private static final String customAerogearApnsPushHost = tryGetProperty(CUSTOM_AEROGEAR_APNS_PUSH_HOST);
     private static final Integer customAerogearApnsPushPort = tryGetIntegerProperty(CUSTOM_AEROGEAR_APNS_PUSH_PORT);
 
-    private static final String GCM_SEND_ENDPOINT = Constants.GCM_SEND_ENDPOINT.substring("https://".length(), Constants.GCM_SEND_ENDPOINT.indexOf('/', "https://".length()));
+    private static final String FCM_SEND_ENDPOINT = ConfigurableFCMSender.FCM_ENDPOINT_HOST.substring("https://".length(), ConfigurableFCMSender.FCM_ENDPOINT_HOST.indexOf('/', "https://".length()));
     public static final String WNS_SEND_ENDPOINT = "db3.notify.windows.com";
     private static final List<PushNetwork> PUSH_NETWORKS = new ArrayList<>(Arrays.asList(
             new PushNetwork[]{
-                    new PushNetwork("Google Cloud Messaging", GCM_SEND_ENDPOINT, 443),
+                    new PushNetwork("Firebase Cloud Messaging", FCM_SEND_ENDPOINT, 433),
                     new PushNetwork("Apple Push Network Sandbox", Utilities.SANDBOX_GATEWAY_HOST, Utilities.SANDBOX_GATEWAY_PORT),
                     new PushNetwork("Apple Push Network Production", Utilities.PRODUCTION_GATEWAY_HOST, Utilities.PRODUCTION_GATEWAY_PORT),
                     new PushNetwork("Windows Push Network", WNS_SEND_ENDPOINT, 443)


### PR DESCRIPTION
since we send all payload to FCM, no need to do health check on the older GCM APIs anymore :trollface: