### PR TITLE
Only one request when changing tabs

### DIFF
--- a/admin-ui/app/components/app-detail/app-detail.html
+++ b/admin-ui/app/components/app-detail/app-detail.html
@@ -16,16 +16,16 @@
 
       <ul class="nav nav-tabs">
         <li ng-class="{ active: appDetail.tab == 'analytics' }" ng-if="appDetail.app.variants.length">
-          <a id="analytics-tab" ng-link="appDetail({app: appDetail.app.pushApplicationID, tab: 'analytics'})">Analytics</a>
+          <a id="analytics-tab" href="#/app/{{appDetail.app.pushApplicationID}}/analytics">Analytics</a>
         </li>
         <li ng-class="{ active: appDetail.tab == 'variants' }">
-          <a id="variants-tab" ng-link="appDetail({app: appDetail.app.pushApplicationID, tab: 'variants'})">Variants</a>
+          <a id="variants-tab" href="#/app/{{appDetail.app.pushApplicationID}}/variants">Variants</a>
         </li>
         <li ng-class="{ active: appDetail.tab == 'sender' }" ng-if="appDetail.app.variants.length">
-          <a id="sender-tab" ng-link="appDetail({app: appDetail.app.pushApplicationID, tab: 'sender'})">Sender API</a>
+          <a id="sender-tab" href="#/app/{{appDetail.app.pushApplicationID}}/sender">Sender API</a>
         </li>
         <li ng-class="{ active: appDetail.tab == 'activity' }"  ng-if="appDetail.app.variants.length">
-          <a id="activity-tab" ng-link="appDetail({app: appDetail.app.pushApplicationID, tab: 'activity'})">Activity log</a>
+          <a id="activity-tab" href="#/app/{{appDetail.app.pushApplicationID}}/activity">Activity log</a>
         </li>
       </ul>
 

--- a/admin-ui/app/components/app-detail/app-detail.js
+++ b/admin-ui/app/components/app-detail/app-detail.js
@@ -58,7 +58,8 @@ angular.module('upsConsole')
               $scope.pushData.criteria.categories = $scope.categories.split(',');
             }
 
-            messageSenderEndpoint( self.app.pushApplicationID, self.app.masterSecret ).send({}, $scope.pushData)
+            messageSenderEndpoint( self.app.pushApplicationID, self.app.masterSecret )
+              .send({}, $scope.pushData)
               .then(function() {
                 self.app.$messageCount += 1;
                 self.notifications.unshift({ submitDate: new Date().getTime() });

--- a/admin-ui/app/scripts/endpoints/messageSenderEndpoint.js
+++ b/admin-ui/app/scripts/endpoints/messageSenderEndpoint.js
@@ -4,7 +4,9 @@ var upsServices = angular.module('upsConsole');
 
 upsServices.factory('messageSenderEndpoint', function ($resource, apiPrefix) {
   return function ( applicationID, masterSecret ) {
-    return $resource( apiPrefix + 'rest/sender', {}, {
+    var url = apiPrefix + 'rest/sender';
+    var paramDefaults = {};
+    var actions = {
       send: {
         method: 'POST',
         headers: {
@@ -12,6 +14,8 @@ upsServices.factory('messageSenderEndpoint', function ($resource, apiPrefix) {
           'Authorization': 'Basic ' + btoa(applicationID + ':' + masterSecret)
         }
       }
-    });
+    };
+
+    return $resource(url, paramDefaults, actions);
   };
 });


### PR DESCRIPTION
This PR solves the ticket: [AGPUSH-2052](https://issues.jboss.org/browse/AGPUSH-2052)

It is an alternative for #784.
It is the same as #804 

#### Reason
After a lot of debugging, the problem _seems to be_ the "ngLink" directive, that generates an url starting with `.` instead of `#`. 

#### Solution
Although one solution would be changing all `.` for `#` in the declaration of the directive (`ngLinkDirective` function in `app/scripts/angular.router.es5.js`) I find more readable and clean to simply specify the reference.

I think the best way to deal with this behaviour would be to create a method `setTab` to the appDetail controller. By updating the `tab` property this way, the component would be shown and refreshed. *However*, the current implementation requires the URL to be the one to update in order to fetch the components data.