### PR TITLE
Using latest of pushy

### DIFF
--- a/push/sender/pom.xml
+++ b/push/sender/pom.xml
@@ -99,12 +99,12 @@
         <dependency>
             <groupId>com.relayrides</groupId>
             <artifactId>pushy</artifactId>
-            <version>0.9.2</version>
+            <version>0.9.3</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-tcnative-boringssl-static</artifactId>
-            <version>1.1.33.Fork24</version>
+            <version>2.0.0.Final</version>
         </dependency>
 
         <dependency>

--- a/servers/ups-as7/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/servers/ups-as7/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -5,21 +5,8 @@
             <module name="org.codehaus.jackson.jackson-mapper-asl"/>
             <module name="org.jboss.xnio"/>
 
-            <module name="org.jboss.as.web">
-                <imports>
-                    <exclude-set>
-                        <path name="org/apache/tomcat/jni"/>
-                    </exclude-set>
-                    <include path="**" />
-                </imports>
-                <exports>
-                    <exclude path="org/apache/tomcat/jni/**" />
-                </exports>
-            </module>
-
         </dependencies>
         <exclusions>
-            <module name="org.jboss.as.web" />
         </exclusions>
     </deployment>
 </jboss-deployment-structure>


### PR DESCRIPTION
Using latest of pushy and the netty-tcnative-boringssl-static lib

The other versions are leveraging tomcat (fork) classes, so there is chance of clash.

Now, we do not need to do any exclude of the Jboss Web layer anymore