### PR TITLE
only stash connected clients

### DIFF
--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/cache/SimpleApnsClientCache.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/cache/SimpleApnsClientCache.java
@@ -77,7 +77,10 @@ public class SimpleApnsClientCache {
             logger.debug(String.format("no cached connection for %s, establishing it", variantID));
             synchronized (apnsClientExpiringMap) {
                 client = constructor.construct();
-                putApnsClientForVariantID(variantID, client);
+
+                if (client.isConnected()) {
+                    putApnsClientForVariantID(variantID, client);
+                }
 
                 return client; // return the newly connected client
             }


### PR DESCRIPTION
generally we try to send only, when client is connected:
https://github.com/aerogear/aerogear-unifiedpush-server/blob/1.1.x-dev/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/PushyApnsSender.java#L99-L119

but, if - for what ever reason, we can not connect, let's not stash a disconnected client object...