### PR TITLE
Moving the success cb up

### DIFF
--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/PushyApnsSender.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/PushyApnsSender.java
@@ -102,6 +102,9 @@ public class PushyApnsSender implements PushNotificationSender {
 
         if (apnsClient.isConnected()) {
 
+            // we have managed to connect and will send tokens ;-)
+            senderCallback.onSuccess();
+
             final String defaultApnsTopic = ApnsUtil.readDefaultTopic(iOSVariant.getCertificate(), iOSVariant.getPassphrase().toCharArray());
             logger.debug("sending payload for all tokens for {} to APNs ({})", iOSVariant.getVariantID(), defaultApnsTopic);
 
@@ -121,8 +124,6 @@ public class PushyApnsSender implements PushNotificationSender {
                 });
             }
 
-            // we have managed to dispatch all messages ;-)
-            senderCallback.onSuccess();
         } else {
             logger.error("Unable to send notifications, client is not connected");
             senderCallback.onError("Unable to send notifications, client is not connected");
@@ -193,7 +194,7 @@ public class PushyApnsSender implements PushNotificationSender {
                 apnsClient.getReconnectionFuture().addListener(new GenericFutureListener<Future<? super Void>>() {
                     @Override
                     public void operationComplete(Future<? super Void> future) throws Exception {
-                        logger.debug("Reconnecting to APNs");
+                        logger.trace("Reconnecting to APNs");
                     }
                 });
                 return apnsClient;


### PR DESCRIPTION
Once we are sure we are connected, but _before_ the streaming of all tokens/payload pairs, we now invoke the `onSuccess` handler.

We are able to do because we are _successfully_ connected to APNs.

If one of the tokens in the iteration is a bogus one, we generally not flagging this as `failure`... since that also makes no sense (e.g. if one token out of 10.000 is bogus, the transaction is _NOT_ failed).

The `onError` handle is invoked, if we are not connected to APNs, which really indicates a failure, an error 