### PR TITLE
Fixes UPS GUI broken links in studio

### DIFF
--- a/admin-ui/app/components/app-detail/app-detail.html
+++ b/admin-ui/app/components/app-detail/app-detail.html
@@ -16,16 +16,16 @@
 
       <ul class="nav nav-tabs">
         <li ng-class="{ active: appDetail.tab == 'analytics' }" ng-if="appDetail.app.variants.length">
-          <a id="analytics-tab" href="#/app/{{appDetail.app.pushApplicationID}}/analytics">Analytics</a>
+          <a id="analytics-tab" ng-link="appDetail({app: appDetail.app.pushApplicationID, tab: 'analytics'})">Analytics</a>
         </li>
         <li ng-class="{ active: appDetail.tab == 'variants' }">
-          <a id="variants-tab" href="#/app/{{appDetail.app.pushApplicationID}}/variants">Variants</a>
+          <a id="variants-tab" ng-link="appDetail({app: appDetail.app.pushApplicationID, tab: 'variants'})">Variants</a>
         </li>
         <li ng-class="{ active: appDetail.tab == 'sender' }" ng-if="appDetail.app.variants.length">
-          <a id="sender-tab" href="#/app/{{appDetail.app.pushApplicationID}}/sender">Sender API</a>
+          <a id="sender-tab" ng-link="appDetail({app: appDetail.app.pushApplicationID, tab: 'sender'})">Sender API</a>
         </li>
         <li ng-class="{ active: appDetail.tab == 'activity' }"  ng-if="appDetail.app.variants.length">
-          <a id="activity-tab" href="#/app/{{appDetail.app.pushApplicationID}}/activity">Activity log</a>
+          <a id="activity-tab" ng-link="appDetail({app: appDetail.app.pushApplicationID, tab: 'activity'})">Activity log</a>
         </li>
       </ul>
 


### PR DESCRIPTION
This PR solves the ticket: [AGPUSH-15180](https://issues.jboss.org/browse/RHMAP-15180)

Same as #826 

#### Reason
In a previous PR (#804) the ngLink directive that was causing a double HTTP request was changed into a simple href property. This might have caused the current issue.

#### Solution
Revert the changes made in #804.

#### Collateral Damage
Reverting to #804 will re-open the double requests issue so this fix should be only temporal until a better solution is found.