### PR TITLE
Adding a timeout when reading from the BatchLoadedQueue

### DIFF
--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/MetricsCollector.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/MetricsCollector.java
@@ -108,9 +108,9 @@ public class MetricsCollector extends AbstractJMSMessageConsumer {
         }
     }
 
-    private int countLoadedBatches(String variantID) {
+    private int countLoadedBatches(final String variantID) {
         int loadedBatches = 0;
-        while (receiveInTransactionNoWait(batchLoadedQueue, "variantID", variantID) != null) {
+        while (receiveInTransactionWithTimeout(batchLoadedQueue, "variantID", variantID, 250) != null) {
             loadedBatches += 1;
         }
         return loadedBatches;


### PR DESCRIPTION
Multi Variant messages seem to have processing issues on this branch.

Adding a blocking for the `BatchLoadedQueue` seems to address it.

Looks like a tmp. workaround, but better than nothing