### PR TITLE
[AGPUSH-2136] Add @KafkaConfig annotation for bootstrap servers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,12 +7,12 @@ local-config.json
 *.war
 *.ear
 
-#Build targets
+# Build targets
 target/
 /target
 */target
 
-#Maven release files
+# Maven release files
 *.releaseBackup
 release.properties
 
@@ -25,3 +25,7 @@ release.properties
 
 .DS_Store
 *.checkstyle
+
+# SonarQube
+.scannerwork/
+sonar-project.properties

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/installations/InstallationRegistrationEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/installations/InstallationRegistrationEndpoint.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.qmino.miredot.annotations.BodyType;
 import com.qmino.miredot.annotations.ReturnType;
+import net.wessendorf.kafka.cdi.annotation.KafkaConfig;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -59,6 +60,7 @@ import java.util.List;
 import java.util.Properties;
 
 @Path("/registry/device")
+@KafkaConfig(bootstrapServers = "#{KAFKA_HOST}:#{KAFKA_PORT}")
 public class InstallationRegistrationEndpoint extends AbstractBaseEndpoint {
 
     public static final String KAFKA_PRODUCER_PROPERTIES_PATH = "/kafka/producer.properties";

--- a/kafka/README.md
+++ b/kafka/README.md
@@ -8,7 +8,7 @@ Getting started with Linux is a fairly straightforward process:
 $ docker run -d --name zookeeper --network kafka-net zookeeper:3.4
 $ docker run -d --name kafka --network kafka-net -p 9092:9092 --env ZOOKEEPER_IP=zookeeper ches/kafka
 ```
-Connect to the Kafka broker by updating your `bootstrap.servers` with `localhost:9092` or the IP of the Kafka container.
+Connect to the Kafka broker with `localhost` or the IP of the Kafka container.
 
 ### Mac
 Establishing a connection between a container and a host service with Docker for Mac is slightly more convoluted. To get going, first run both the Zookeeper and Kafka containers normally:
@@ -29,7 +29,7 @@ Add this IP to the `loopback 0` interface:
 $ sudo ifconfig lo0 alias $CONTAINER_IP
 ```
 
-And finally connect to the broker using this address by updating the `bootstrap.servers` in the the `consumer.props` and `producer.props`.
+Connect to the broker using this address.
 
 ______ 
 
@@ -40,4 +40,16 @@ $ HOST_IP=$(ifconfig en0 | grep "inet " | cut -d " " -f2)
 $ docker run -d --name zookeeper --network kafka-net zookeeper:3.4
 $ docker run -d --name kafka --network kafka-net -p 9092:9092 --env ZOOKEEPER_IP=$HOST_IP --env KAFKA_ADVERTISED_HOST_NAME=$HOST_IP ches/kafka
 ```
-Connect to the Kafka broker using your host IP by updating the `bootstrap.servers` accordingly.
+Connect to the Kafka broker using your host IP.
+
+## Connecting to the server
+
+Allow the UPS to connect to your Kafka broker by passing in the host and port (configured in the previous step) to the Wildfly server. Use the environment variables `KAFKA_HOST` and `KAFKA_PORT`:
+```
+$SERVER_HOME/bin/standalone.sh -c standalone-full.xml -DKAFKA_HOST=<ip_address> -DKAFKA_PORT=<port>
+```
+
+For example:
+```
+$SERVER_HOME/bin/standalone.sh -c standalone-full.xml -DKAFKA_HOST=172.18.0.3 -DKAFKA_PORT=9092
+```


### PR DESCRIPTION
**Description:**
Replace hardcoded bootstrap servers in `properties` files by using the @KafkaConfig annotation for configuration.

**Implementation:**
Use the @KafkaConfig annotation from the Kafka CDI library to dynamically resolve the expression: `#{KAFKA_HOST}:#{KAFKA_PORT}`. `KAFKA_HOST` and `KAFKA_PORT` must be passed in as environment variables.
For now this is in the `InstallationRegistrationEndpoint` but will be moved later with [AGPUSH-2133](https://issues.jboss.org/browse/AGPUSH-2133).

**Ticket:** [AGPUSH-2136](https://issues.jboss.org/browse/AGPUSH-2136)