### PR TITLE
[AGPUSH-2155] Check id before parsing the page size.

### DIFF
--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/metrics/PushMetricsEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/metrics/PushMetricsEndpoint.java
@@ -68,14 +68,14 @@ public class PushMetricsEndpoint {
             @QueryParam("sort") String sorting,
             @QueryParam("search") String search) {
 
+        if (id == null) {
+            return Response.status(Response.Status.NOT_FOUND).entity("Could not find requested information").build();
+        }
+        
         pageSize = parsePageSize(pageSize);
 
         if (page == null) {
             page = 0;
-        }
-
-        if (id == null) {
-            return Response.status(Response.Status.NOT_FOUND).entity("Could not find requested information").build();
         }
 
         PageResult<PushMessageInformation, MessageMetrics> pageResult =


### PR DESCRIPTION
No need to parse pageSize when the id is null. Therefore make the check for id first then parsing of page size if needed.