### PR TITLE
[AGPUSH-2151][CHANGE] MPNSPushNotificationSender - Use isEmpty() to c…

### DIFF
--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/MPNSPushNotificationSender.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/MPNSPushNotificationSender.java
@@ -73,21 +73,22 @@ public class MPNSPushNotificationSender implements PushNotificationSender {
                     tile.title(message.getAlert());
 
                     List<String> images = windows.getImages();
-                    if (images.size() >= 1) {
-                        tile.backgroundImage(images.get(0));
-                    }
 
-                    if (images.size() >= 2) {
-                        tile.backBackgroundImage(images.get(1));
+                    if (!images.isEmpty()) {
+                        tile.backgroundImage(images.get(0));
+                        if (images.size() >= 2) {
+                            tile.backBackgroundImage(images.get(1));
+                        }
                     }
 
                     List<String> textFields = windows.getTextFields();
-                    if (textFields.size() >= 1) {
+                    if (!textFields.isEmpty()) {
                         tile.backTitle(textFields.get(0));
+                        if (textFields.size() >= 2) {
+                            tile.backContent(textFields.get(1));
+                        }
                     }
-                    if (textFields.size() >= 2) {
-                        tile.backContent(textFields.get(1));
-                    }
+
                     notification = tile.build();
                     break;
                 default:


### PR DESCRIPTION
…heck whether the collection is empty or not

- Changed the first list validation from .size() to isEmpty()
- Moved the second size() validation into isEmpty() validation