### PR TITLE
Lifeclycle APIs in JSR 236 are disabled, throwing IllegalStateExceptions

### DIFF
--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/kafka/InstallationMetricsConsumerRegistrationHook.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/kafka/InstallationMetricsConsumerRegistrationHook.java
@@ -65,7 +65,6 @@ public class InstallationMetricsConsumerRegistrationHook {
     private void shutdown() {
         logger.debug("Shutting down the consumer {}.", InstallationMetricsKafkaConsumer.class);
         consumer.shutdown();
-        executor.shutdown();
     }
 
 }


### PR DESCRIPTION
@polinankoleva @dimitraz the lifecycle APIs of Managed ExecutorService in Java EE (JSR 236) are disabled, throwing a `IllegalStateException`