### PR TITLE
[AGPUSH-2182] Jackson polymorphic deserialisation for Variant

### DIFF
--- a/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/Variant.java
+++ b/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/Variant.java
@@ -16,6 +16,9 @@
  */
 package org.jboss.aerogear.unifiedpush.api;
 
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import java.util.UUID;
@@ -23,6 +26,15 @@ import java.util.UUID;
 /**
  * Logical construct which matches a mobile app in the appstore.
  */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = AndroidVariant.class, name = "AndroidVariant"),
+        @JsonSubTypes.Type(value = AdmVariant.class, name = "AdmVariant"),
+        @JsonSubTypes.Type(value = iOSVariant.class, name = "iOSVariant"),
+        @JsonSubTypes.Type(value = SimplePushVariant.class, name = "SimplePushVariant"),
+        @JsonSubTypes.Type(value = WindowsMPNSVariant.class, name = "WindowsMPNSVariant"),
+        @JsonSubTypes.Type(value = WindowsWNSVariant.class, name = "WindowsWNSVariant")
+})
 public abstract class Variant extends BaseModel {
     private static final long serialVersionUID = -5028062942838899201L;
 


### PR DESCRIPTION
**Description:**
Abstract classes cannot be serialized/deserialized with generic serdes:
```
com.fasterxml.jackson.databind.JsonMappingException: Can not construct instance of org.jboss.aerogear.unifiedpush.api.Variant, problem: 
abstract types either need to be mapped to concrete types, have custom deserializer, or be instantiated with additional type information
```

**Implementation:**
- Added Jackson type info for all variant types
- ~Updated Installation Metrics producer to only send `pushMessageId` (variant not used)~


**Ticket:** [AGPUSH-2182](https://issues.jboss.org/browse/AGPUSH-2182)