### PR TITLE
[AGPUSH-2179] Update installation metrics producer

### DIFF
--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/installations/InstallationRegistrationEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/installations/InstallationRegistrationEndpoint.java
@@ -69,7 +69,7 @@ public class InstallationRegistrationEndpoint extends AbstractBaseEndpoint {
     @Inject
     private GenericVariantService genericVariantService;
 
-    @Producer(topic = KAFKA_INSTALLATION_TOPIC)
+    @Producer
     private SimpleKafkaProducer<String, String> installationMetricsProducer;
 
     /**
@@ -232,7 +232,7 @@ public class InstallationRegistrationEndpoint extends AbstractBaseEndpoint {
 
             // start the producer and push a message to installation metrics
             // topic
-            installationMetricsProducer.send(pushMessageId, variant.getVariantID());
+            installationMetricsProducer.send(KAFKA_INSTALLATION_TOPIC, pushMessageId);
 
             return Response.ok(EmptyJSON.STRING).build();
 

--- a/kafka/src/main/java/org/jboss/aerogear/unifiedpush/kafka/consumers/InstallationMetricsKafkaConsumer.java
+++ b/kafka/src/main/java/org/jboss/aerogear/unifiedpush/kafka/consumers/InstallationMetricsKafkaConsumer.java
@@ -44,8 +44,8 @@ public class InstallationMetricsKafkaConsumer {
      * id.
      */
     @Consumer(topic = KAFKA_INSTALLATION_TOPIC, groupId = KAFKA_INSTALLATION_TOPIC_CONSUMER_GROUP_ID)
-    public void receiver(final String pushMessageId, final String variantId) {
-        logger.info("Update metric analytics for push message's ID {} and variant's ID {}", pushMessageId, variantId);
+    public void receiver(final String pushMessageId) {
+        logger.info("Update metric analytics for push message's ID {}", pushMessageId);
         metricsService.updateAnalytics(pushMessageId);
     }
 }

--- a/kafka/src/main/java/org/jboss/aerogear/unifiedpush/kafka/consumers/InstallationMetricsKafkaConsumer.java
+++ b/kafka/src/main/java/org/jboss/aerogear/unifiedpush/kafka/consumers/InstallationMetricsKafkaConsumer.java
@@ -28,7 +28,7 @@ import static org.jboss.aerogear.unifiedpush.kafka.KafkaClusterConfig.KAFKA_INST
 import static org.jboss.aerogear.unifiedpush.kafka.KafkaClusterConfig.KAFKA_INSTALLATION_TOPIC_CONSUMER_GROUP_ID;
 
 /**
- * Kafka Consumer that reads from "installationMetrics" topic a pair (PushMessageID, VariantID) and updates analytics by
+ * Kafka Consumer that reads the VariantID from "agpush_installationMetrics" and updates analytics by
  * invocation of {@link PushMessageMetricsService#updateAnalytics(String)}.
  * 
  */
@@ -40,8 +40,7 @@ public class InstallationMetricsKafkaConsumer {
     private PushMessageMetricsService metricsService;
 
     /**
-     * A method invoked for each record that a consumer reads. It updates metrics analytics based on push message id and variant
-     * id.
+     * Update metrics analytics based on push message id from the consumed record.
      */
     @Consumer(topic = KAFKA_INSTALLATION_TOPIC, groupId = KAFKA_INSTALLATION_TOPIC_CONSUMER_GROUP_ID)
     public void receiver(final String pushMessageId) {

--- a/pom.xml
+++ b/pom.xml
@@ -191,7 +191,7 @@
         <aerogear.bom.version>0.9.0</aerogear.bom.version>
 
         <kafka.clients.version>0.10.2.1</kafka.clients.version>
-        <kafka.cdi.version>0.0.7</kafka.cdi.version>
+        <kafka.cdi.version>0.0.8</kafka.cdi.version>
         <debezium.version>0.5.1</debezium.version>
 
         <!-- Override versions of AeroGear BOMs-->


### PR DESCRIPTION
**Description:**
Installation Metrics producer is outdated 

**Implementation:**
- Use Kafka CDI latest (`0.0.8`)
- Move `topic` out of annotation
- Update Installation Metrics producer to only send `pushMessageId` (variant not used)

**Ticket:** [AGPUSH-2179](https://issues.jboss.org/browse/AGPUSH-2179)