### PR TITLE
AGPUSH-2052 - update router to prevent tab transition request executi…

### DIFF
--- a/admin-ui/app/components/app-detail/include/activity.js
+++ b/admin-ui/app/components/app-detail/include/activity.js
@@ -97,9 +97,14 @@ angular.module('upsConsole')
       }
     });
 
-    $scope.$watch(function() { return self.searchString }, function( searchString ) {
-      self.currentPage = 1;
-      fetchMetrics( self.currentPage, self.searchString );
+    $scope.$watch(function() { 
+      return self.searchString 
+    }, function (newSearchString, oldSearchString) {
+      //ensure that the value has actually changed, to prevent fetchMetrics being called on initial load here
+      if (newSearchString !== oldSearchString) {
+        self.currentPage = 1;
+        fetchMetrics(self.currentPage, self.newSearchString);
+      }
     });
 
   });

--- a/admin-ui/app/components/app-detail/include/analytics.js
+++ b/admin-ui/app/components/app-detail/include/analytics.js
@@ -50,8 +50,6 @@ angular.module('upsConsole')
         });
     }
 
-    updateAnalytics();
-
     $scope.$on('upsNotificationSent', function( pushData, app ) {
       updateAnalytics();
     });

--- a/admin-ui/app/scripts/controllers/AppController.js
+++ b/admin-ui/app/scripts/controllers/AppController.js
@@ -17,7 +17,7 @@
 'use strict';
 
 angular.module('upsConsole')
-  .controller('AppController', function ( $rootScope, $scope, Auth, $http, $interval, $timeout, $log, appConfig, dashboardEndpoint ) {
+  .controller('AppController', function ( $rootScope, $scope, Auth, $http, $interval, $timeout, $log, appConfig, dashboardEndpoint, $$rootRouter ) {
 
     var self = this;
 
@@ -31,6 +31,7 @@ angular.module('upsConsole')
     this.username = getUsername();
     $scope.$watch(getUsername, function( newValue ) {
       self.username = newValue;
+      $$rootRouter.navigate('/');
     });
 
     this.logout = function() {

--- a/admin-ui/app/scripts/external/angular.router.es5.js
+++ b/admin-ui/app/scripts/external/angular.router.es5.js
@@ -83,12 +83,6 @@ function routerFactory($$rootRouter, $rootScope, $location, $$grammar, $controll
     $$grammar.config(name, config);
   });
 
-  $rootScope.$watch(function () {
-    return $location.path();
-  }, function (newUrl) {
-    $$rootRouter.navigate(newUrl);
-  });
-
   var nav = $$rootRouter.navigate;
   $$rootRouter.navigate = function (url) {
     return nav.call(this, url).then(function (newUrl) {


### PR DESCRIPTION
…ng twice

## Motivation
Angular UI executes requests twice when transitioning from one UI tab to another

## Result
This is a bug with the Angular router being used `angular-new-router` [here](https://github.com/angular/router/issues/204).  Stopped watching the `$location.path()` and updated the `Activity` and `Analytics` tab controllers.  As a result of not watching `$location.path()` the path in the url does not trigger a navigate request and therefore the back/forward buttons in the browsers do not work. 