### PR TITLE
[AGPUSH-2166] Create notification dispatcher consumer  

### DIFF
--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/NotificationDispatcher.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/NotificationDispatcher.java
@@ -68,7 +68,7 @@ public class NotificationDispatcher {
      *
      * @param msg object containing details about the payload and the related device tokens
      */
-    @Consumer(topics = {ADM_TOPIC, APNS_TOPIC, FCM_TOPIC, MPNS_TOPIC, MOZ_TOPIC, WNS_TOPIC}, groupId = "NotificationDispatcherKafkaConsumer_group")
+    @Consumer(topics = {ADM_TOPIC, APNS_TOPIC, FCM_TOPIC, MPNS_TOPIC, MOZ_TOPIC, WNS_TOPIC}, groupId = "agpush_notificationDispatcherConsumerGroup")
     public void sendMessagesToPushNetwork(final MessageHolderWithTokens msg) {
         final Variant variant = msg.getVariant();
         final UnifiedPushMessage unifiedPushMessage = msg.getUnifiedPushMessage();


### PR DESCRIPTION
**Description:** 
Replace observer in the notification dispatcher class with a Kafka consumer. This allows us to remove the `MessageHolderWithTokensConsumer` class altogether. 

**Implementation:**
Annotated the `sendMessagesToPushNetwork` to consume records from the various token topics. 

**Ticket:** [AGPUSH-2166](https://issues.jboss.org/browse/AGPUSH-2166)