### PR TITLE
[AGPUSH-2167] NotificationSenderCallback onSuccess/onError Topic.

### DIFF
--- a/kafka/pom.xml
+++ b/kafka/pom.xml
@@ -73,6 +73,12 @@
 
         <dependency>
             <groupId>org.jboss.aerogear.unifiedpush</groupId>
+            <artifactId>unifiedpush-push-sender</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.aerogear.unifiedpush</groupId>
             <artifactId>unifiedpush-service</artifactId>
             <version>${project.version}</version>
             <scope>compile</scope>
@@ -84,13 +90,7 @@
             <version>${project.version}</version>
             <scope>compile</scope>
         </dependency>
-
-        <dependency>
-            <groupId>org.jboss.aerogear.unifiedpush</groupId>
-            <artifactId>unifiedpush-push-sender</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-
+        
         <dependency>
             <groupId>javax.enterprise</groupId>
             <artifactId>cdi-api</artifactId>

--- a/kafka/src/test/java/org/jboss/aerogear/unifiedpush/kafka/BaseKafkaTest.java
+++ b/kafka/src/test/java/org/jboss/aerogear/unifiedpush/kafka/BaseKafkaTest.java
@@ -26,7 +26,7 @@ import org.junit.Before;
  * Basic class that starts up a Kafka cluster before each test case and stops it afterwards. Each test class that uses embedded
  * Kafka cluster has to extend this. See usage {@link InstallationMetricsConsumerTest}.
  */
-public class BasicKafkaTest {
+public class BaseKafkaTest {
 
     protected KafkaClusterWrapper kafkaCluster = new KafkaClusterWrapper();
     /**

--- a/kafka/src/test/java/org/jboss/aerogear/unifiedpush/kafka/KafkaClusterTest.java
+++ b/kafka/src/test/java/org/jboss/aerogear/unifiedpush/kafka/KafkaClusterTest.java
@@ -31,7 +31,7 @@ import static org.junit.Assert.assertNotNull;
 /**
  * Test cases for plain Kafka producer and consumer.
  */
-public class KafkaClusterTest extends BasicKafkaTest {
+public class KafkaClusterTest extends BaseKafkaTest {
 
     private KafkaConsumer consumer;
     private KafkaProducer producer;

--- a/kafka/src/test/java/org/jboss/aerogear/unifiedpush/kafka/consumers/InstallationMetricsConsumerTest.java
+++ b/kafka/src/test/java/org/jboss/aerogear/unifiedpush/kafka/consumers/InstallationMetricsConsumerTest.java
@@ -22,7 +22,7 @@ import java.util.concurrent.CountDownLatch;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 import org.jboss.aerogear.unifiedpush.kafka.utils.MockProviders;
-import org.jboss.aerogear.unifiedpush.kafka.BasicKafkaTest;
+import org.jboss.aerogear.unifiedpush.kafka.BaseKafkaTest;
 import org.jboss.aerogear.unifiedpush.kafka.KafkaClusterConfig;
 import org.jboss.aerogear.unifiedpush.kafka.MessageConsumedEvent;
 import org.jboss.aerogear.unifiedpush.rest.AbstractBaseEndpoint;
@@ -45,7 +45,7 @@ import net.wessendorf.kafka.impl.DelegationKafkaConsumer;
  * Test cases for {@link InstallationMetricsConsumer#consume(String)} method.
  */
 @RunWith(Arquillian.class)
-public class InstallationMetricsConsumerTest extends BasicKafkaTest {
+public class InstallationMetricsConsumerTest extends BaseKafkaTest {
 
     private boolean isMethodCalled = Boolean.FALSE;
     private static CountDownLatch countDownLatch;

--- a/kafka/src/test/java/org/jboss/aerogear/unifiedpush/kafka/producers/InstallationMetricsProducerTest.java
+++ b/kafka/src/test/java/org/jboss/aerogear/unifiedpush/kafka/producers/InstallationMetricsProducerTest.java
@@ -26,7 +26,7 @@ import javax.inject.Inject;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.jboss.aerogear.unifiedpush.kafka.BasicKafkaTest;
+import org.jboss.aerogear.unifiedpush.kafka.BaseKafkaTest;
 import org.jboss.aerogear.unifiedpush.kafka.KafkaClusterConfig;
 import org.jboss.aerogear.unifiedpush.kafka.utils.MockProviders;
 import org.jboss.aerogear.unifiedpush.rest.AbstractBaseEndpoint;
@@ -36,6 +36,7 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -43,9 +44,7 @@ import org.junit.runner.RunWith;
  * Test cases for {@link InstallationRegistrationEndpoint#getInstallationMetricsProducer()} object.
  */
 @RunWith(Arquillian.class)
-public class InstallationMetricsProducerTest extends BasicKafkaTest {
-
-    private KafkaConsumer<?, ?> consumer;
+public class InstallationMetricsProducerTest extends BaseKafkaTest {
 
     @Inject
     InstallationRegistrationEndpoint installationRegistrationEndpoint;
@@ -72,7 +71,7 @@ public class InstallationMetricsProducerTest extends BasicKafkaTest {
         installationRegistrationEndpoint.getInstallationMetricsProducer().send(KafkaClusterConfig.KAFKA_INSTALLATION_TOPIC,
                 randomPushMessageId);
 
-        consumer = new KafkaConsumer<>(kafkaCluster.consumerPropperties());
+        KafkaConsumer<?, ?> consumer = new KafkaConsumer<>(kafkaCluster.consumerPropperties());
         consumer.subscribe(Arrays.asList(KafkaClusterConfig.KAFKA_INSTALLATION_TOPIC));
         
         // wait 1 sec to consume the messages 
@@ -86,5 +85,10 @@ public class InstallationMetricsProducerTest extends BasicKafkaTest {
         }
 
         consumer.close();
+    }
+    
+    @Test
+    public void producerNotNullTest() {
+        Assert.assertNotNull(installationRegistrationEndpoint.getInstallationMetricsProducer());
     }
 }

--- a/push/sender/pom.xml
+++ b/push/sender/pom.xml
@@ -33,6 +33,12 @@
             <scope>provided</scope>
         </dependency>
 
+         <dependency>
+            <groupId>net.wessendorf.kafka</groupId>
+            <artifactId>kafka-cdi-extension</artifactId>
+            <version>${kafka.cdi.version}</version>
+        </dependency>
+        
         <dependency>
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
@@ -178,14 +184,13 @@
                     <artifactId>arquillian-junit-container</artifactId>
                     <scope>test</scope>
                 </dependency>
+                
                 <dependency>
                     <groupId>org.arquillian.container</groupId>
                     <artifactId>arquillian-container-chameleon</artifactId>
                     <version>1.0.0.Beta1</version>
                     <scope>test</scope>
                 </dependency>
-
-
 
                 <dependency>
                     <groupId>org.wildfly.extras.creaper</groupId>
@@ -203,6 +208,7 @@
                     </exclusions>
                     <scope>test</scope>
                 </dependency>
+                
                 <dependency>
                     <groupId>org.wildfly.extras.creaper</groupId>
                     <artifactId>creaper-commands</artifactId>
@@ -222,12 +228,14 @@
                     <version>2.2.0.Final</version>
                     <scope>test</scope>
                 </dependency>
+                
                 <dependency>
                     <groupId>org.wildfly.core</groupId>
                     <artifactId>wildfly-cli</artifactId>
                     <version>2.2.0.Final</version>
                     <scope>test</scope>
                 </dependency>
+                
                 <dependency>
                     <groupId>org.wildfly.core</groupId>
                     <artifactId>wildfly-patching</artifactId>

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/NotificationDispatcher.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/NotificationDispatcher.java
@@ -28,11 +28,15 @@ import org.jboss.aerogear.unifiedpush.service.metrics.PushMessageMetricsService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import net.wessendorf.kafka.SimpleKafkaProducer;
+import net.wessendorf.kafka.cdi.annotation.Producer;
+
 import javax.ejb.Stateless;
 import javax.enterprise.event.Observes;
 import javax.enterprise.inject.Any;
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
+
 import java.util.Collection;
 
 /**
@@ -43,12 +47,22 @@ public class NotificationDispatcher {
 
     private final Logger logger = LoggerFactory.getLogger(NotificationDispatcher.class);
 
+    /**
+     * Topic to which a "success" message will be sent if a push message was successfully send and "failure" message otherwise.
+     */
+    public static final String KAFKA_PUSH_MESSAGE_SENDING_METRICS_TOPIC = "agpush_pushMessageSendingMetrics";
+    public static final String KAFKA_PUSH_MESSAGE_SENDING_SUCCESS = "agpush_success";
+    public static final String KAFKA_PUSH_MESSAGE_SENDING_FAILURE = "agpush_failure";
+    
     @Inject
     @Any
     private Instance<PushNotificationSender> senders;
 
     @Inject
     private PushMessageMetricsService pushMessageMetricsService;
+   
+    @Producer
+    private SimpleKafkaProducer<String, String> pushMessageSendingMetricsProducer;
 
     /**
      * Receives a {@link UnifiedPushMessage} and list of device tokens that the message should be sent to, selects appropriate sender implementation that
@@ -91,14 +105,33 @@ public class NotificationDispatcher {
 
         @Override
         public void onSuccess() {
+<<<<<<< HEAD
             logger.debug("Sent '{}' message to '{}' devices", variant.getType().getTypeName(), tokenSize);
+=======
+            // add to a Kafka topic that one more message was sent successfully
+            pushMessageSendingMetricsProducer.send(KAFKA_PUSH_MESSAGE_SENDING_METRICS_TOPIC, KAFKA_PUSH_MESSAGE_SENDING_SUCCESS);
+            logger.debug("Sent {} message to {} devices", variant.getType().getTypeName(), tokenSize);
+>>>>>>> f422974... [AGPUSH-2167] NotificationSenderCallback onSuccess/onError Topic.
         }
 
         @Override
         public void onError(final String reason) {
+<<<<<<< HEAD
             logger.warn("Error on '{}' delivery: {}", variant.getType().getTypeName(), reason);
+=======
+            logger.warn("Error on {} delivery: {}", variant.getType().getTypeName(), reason);
+>>>>>>> f422974... [AGPUSH-2167] NotificationSenderCallback onSuccess/onError Topic.
             pushMessageMetricsService.appendError(pushMessageInformation, variant, reason);
+            // add to a Kafka topic that a message was sent unsuccessfully
+            pushMessageSendingMetricsProducer.send(KAFKA_PUSH_MESSAGE_SENDING_METRICS_TOPIC, KAFKA_PUSH_MESSAGE_SENDING_FAILURE);
         }
     }
+<<<<<<< HEAD
 
+=======
+    
+    public SimpleKafkaProducer<String, String> getPushMessageSendingMetricsProducer(){
+        return pushMessageSendingMetricsProducer;
+    }
+>>>>>>> f422974... [AGPUSH-2167] NotificationSenderCallback onSuccess/onError Topic.
 }

--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/NotificationDispatcher.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/NotificationDispatcher.java
@@ -105,33 +105,21 @@ public class NotificationDispatcher {
 
         @Override
         public void onSuccess() {
-<<<<<<< HEAD
-            logger.debug("Sent '{}' message to '{}' devices", variant.getType().getTypeName(), tokenSize);
-=======
             // add to a Kafka topic that one more message was sent successfully
             pushMessageSendingMetricsProducer.send(KAFKA_PUSH_MESSAGE_SENDING_METRICS_TOPIC, KAFKA_PUSH_MESSAGE_SENDING_SUCCESS);
             logger.debug("Sent {} message to {} devices", variant.getType().getTypeName(), tokenSize);
->>>>>>> f422974... [AGPUSH-2167] NotificationSenderCallback onSuccess/onError Topic.
         }
 
         @Override
         public void onError(final String reason) {
-<<<<<<< HEAD
             logger.warn("Error on '{}' delivery: {}", variant.getType().getTypeName(), reason);
-=======
-            logger.warn("Error on {} delivery: {}", variant.getType().getTypeName(), reason);
->>>>>>> f422974... [AGPUSH-2167] NotificationSenderCallback onSuccess/onError Topic.
             pushMessageMetricsService.appendError(pushMessageInformation, variant, reason);
             // add to a Kafka topic that a message was sent unsuccessfully
             pushMessageSendingMetricsProducer.send(KAFKA_PUSH_MESSAGE_SENDING_METRICS_TOPIC, KAFKA_PUSH_MESSAGE_SENDING_FAILURE);
         }
     }
-<<<<<<< HEAD
-
-=======
     
     public SimpleKafkaProducer<String, String> getPushMessageSendingMetricsProducer(){
         return pushMessageSendingMetricsProducer;
     }
->>>>>>> f422974... [AGPUSH-2167] NotificationSenderCallback onSuccess/onError Topic.
 }


### PR DESCRIPTION
**Description:** 
NotificationSenderCallback onSuccess/onError Topic

**Implementation:**
Write "success message" to Kafka topic when onSuccess method invoked. Write "failure message" to the same Kafka topic when onError method invoked.

**Ticket:** [AGPUSH-2167](https://issues.jboss.org/browse/AGPUSH-2167)