### PR TITLE
[AGPUSH-2188] Add APNS token delivery metrics producer

### DIFF
--- a/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/NotificationDispatcher.java
+++ b/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/NotificationDispatcher.java
@@ -61,7 +61,7 @@ public class NotificationDispatcher {
         final UnifiedPushMessage unifiedPushMessage = msg.getUnifiedPushMessage();
         final Collection<String> deviceTokens = msg.getDeviceTokens();
 
-        logger.info(String.format("Received UnifiedPushMessage from JMS queue, will now trigger the Push Notification delivery for the %s variant (%s)", variant.getType().getTypeName(), variant.getVariantID()));
+        logger.info("UnifiedPushMessage was successfully received. Push Notification delivery for the {} variant ({}) will now be triggered.", variant.getType().getTypeName(), variant.getVariantID());
 
         senders.select(new SenderTypeLiteral(variant.getType())).get()
                             .sendPushMessage(variant, deviceTokens, unifiedPushMessage, msg.getPushMessageInformation().getId(),
@@ -73,6 +73,11 @@ public class NotificationDispatcher {
                             );
     }
 
+    /**
+     * Implementation of the {@link NotificationSenderCallback} interface for specific
+     * push networks with additional fields for variant, token size and flat push message
+     * information
+     */
     private class SenderServiceCallback implements NotificationSenderCallback {
         private final Variant variant;
         private final int tokenSize;
@@ -86,13 +91,14 @@ public class NotificationDispatcher {
 
         @Override
         public void onSuccess() {
-            logger.debug(String.format("Sent '%s' message to '%d' devices", variant.getType().getTypeName(), tokenSize));
+            logger.debug("Sent '{}' message to '{}' devices", variant.getType().getTypeName(), tokenSize);
         }
 
         @Override
         public void onError(final String reason) {
-            logger.warn(String.format("Error on '%s' delivery: %s", variant.getType().getTypeName(), reason));
+            logger.warn("Error on '{}' delivery: {}", variant.getType().getTypeName(), reason);
             pushMessageMetricsService.appendError(pushMessageInformation, variant, reason);
         }
     }
+
 }


### PR DESCRIPTION
**Description**:
Add producer for APNS specific token metrics, which will be used for further processing later. (More details [here](http://lists.jboss.org/pipermail/aerogear-dev/2017-May/012802.html))

**Implementation**:
Send success message to the `agpush_apnsTokenDeliveryMetrics` Kafka topic if a token was accepted, and a failure message otherwise.  

**Ticket**: [AGPUSH-2188](https://issues.jboss.org/browse/AGPUSH-2188)