### PR TITLE
Remove Jackson1 resteasy module

### DIFF
--- a/servers/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/servers/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -2,11 +2,8 @@
     <deployment>
         <dependencies>
             <module name="org.jboss.resteasy.resteasy-jackson2-provider"  services="import" />
-            <module name="org.jboss.resteasy.resteasy-jackson-provider"  services="import" />
             <module name="org.jboss.xnio"/>
         </dependencies>
-        <!--exclusions>
-            <module name="org.jboss.resteasy.resteasy-jackson-provider" />
-        </exclusions-->
     </deployment>
 </jboss-deployment-structure>
+


### PR DESCRIPTION
Done for [AGPUSH-1034](https://issues.jboss.org/browse/AGPUSH-1034)

:lipstick: remove Jackson1 resteasy module, which is not used at all, but was generating deployment warnings, such as:

```
14:41:03,941 WARN  [org.jboss.as.dependency.deprecated] (MSC service thread 1-3) WFLYSRV0221: Deployment "deployment.ag-push.war" is using a deprecated module ("org.jboss.resteasy.resteasy-jackson-provider") which may be removed in future versions without notice.
```