### PR TITLE
Preparing 1.2.0 release bundle

### DIFF
--- a/dependencies/server-dependencies/pom.xml
+++ b/dependencies/server-dependencies/pom.xml
@@ -163,7 +163,7 @@
         <dependency>
             <groupId>org.aerogear.unifiedpush</groupId>
             <artifactId>admin-ui</artifactId>
-            <version>1.2.6</version>
+            <version>${admin-ui.version}</version>
             <scope>compile</scope>
         </dependency>
 

--- a/dist/README.md
+++ b/dist/README.md
@@ -1,9 +1,11 @@
 # AeroGear UnifiedPush Server - Release Bundle
 
 The content of this archive contains:
-* database configuration files and modules for WildFly and JBoss EAP 6.x
-* WAR files for Keycloak and the UnifiedPush Server (for WildFly and JBoss EAP 6.x)
+* Keycloak development setup, via docker-compose
+* database configuration files and modules for WildFly10/11
+* WAR file for UnifiedPush Server (for WildFly)
 * source JAR files of the UnifiedPush Server for debugging.
 
 To learn more about how to configure and install the UnifiedPush Server please visit our user guide:
 http://aerogear.org/push
+

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -48,13 +48,6 @@
                             <artifactItems>
                                 <artifactItem>
                                     <groupId>${project.groupId}</groupId>
-                                    <artifactId>unifiedpush-auth-server</artifactId>
-                                    <version>${project.version}</version>
-                                    <type>war</type>
-                                    <destFileName>unifiedpush-auth-server.war</destFileName>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>${project.groupId}</groupId>
                                     <artifactId>unifiedpush-server-wildfly</artifactId>
                                     <version>${project.version}</version>
                                     <type>war</type>
@@ -75,9 +68,9 @@
                         <configuration>
                             <artifactItems>
                                 <artifactItem>
-                                    <groupId>${project.groupId}</groupId>
-                                    <artifactId>unifiedpush-admin-ui</artifactId>
-                                    <version>${project.version}</version>
+                                    <groupId>org.aerogear.unifiedpush</groupId>
+                                    <artifactId>admin-ui</artifactId>
+                                    <version>${admin-ui.version}</version>
                                     <classifier>sources</classifier>
                                 </artifactItem>
                                 <artifactItem>

--- a/dist/src/main/assembly/assembly.xml
+++ b/dist/src/main/assembly/assembly.xml
@@ -24,12 +24,17 @@
     </formats>
     
     <fileSets>
-        <!-- Bundle the database configuration files and modules --> 
+        <!-- Bundle the database configuration files and modules -->
         <fileSet>
             <directory>${project.basedir}/../databases</directory>
             <outputDirectory>/databases</outputDirectory>
         </fileSet>
-        <!-- Bundle the server WAR files --> 
+        <!-- Bundle the docker compose configuration files -->
+        <fileSet>
+            <directory>${project.basedir}/../docker-compose</directory>
+            <outputDirectory>/docker-compose</outputDirectory>
+        </fileSet>
+        <!-- Bundle the server WAR files -->
         <fileSet>
             <directory>target/servers</directory>
             <outputDirectory>servers</outputDirectory>

--- a/pom.xml
+++ b/pom.xml
@@ -187,6 +187,7 @@
         <wildfly-maven-plugin.version>1.2.0.Final</wildfly-maven-plugin.version>
 
         <aerogear.bom.version>1.1.2</aerogear.bom.version>
+        <admin-ui.version>1.2.6</admin-ui.version>
 
         <!-- Override versions of AeroGear BOMs-->
         <junit.version>4.11</junit.version>


### PR DESCRIPTION
Done for [AGPUSH-2206](https://issues.jboss.org/browse/AGPUSH-2206)

Some clean ups on the _release distribution package_:
* reflecting that we no longer have a `auth-server.war` file
* bundling our `docker-compose` folder to the bundle
* adding our UI (external repo now), as `-sources.jar` file

## How to verify? 

Run the build, like:
```
mvn clean install -DskipTests -Pdist,test
```

Inside of the `dist/target` there are two archives (`tar.gz` and `zip`), inside these, there are:
* just one WAR file
* the content of the `docker-compose` folder (including the development/demo _realm_ for Keycloak)

