### PR TITLE
Enabled hibernate cache

### DIFF
--- a/model/jpa/src/main/java/org/jboss/aerogear/unifiedpush/jpa/dao/impl/JPAPushApplicationDao.java
+++ b/model/jpa/src/main/java/org/jboss/aerogear/unifiedpush/jpa/dao/impl/JPAPushApplicationDao.java
@@ -50,7 +50,8 @@ public class JPAPushApplicationDao extends JPABaseDao<PushApplication, String> i
                 .setParameter("developer", loginName).getSingleResult();
         List<PushApplication> entities = entityManager.createQuery("select pa " + select, PushApplication.class)
                 .setFirstResult(page * pageSize).setMaxResults(pageSize)
-                .setParameter("developer", loginName).getResultList();
+                .setParameter("developer", loginName)
+                .setHint("org.hibernate.cacheable", true).getResultList();
 
         return new PageResult<PushApplication, Count>(entities, new Count(count));
     }
@@ -59,7 +60,8 @@ public class JPAPushApplicationDao extends JPABaseDao<PushApplication, String> i
     @Override
     public List<String> findAllPushApplicationIDsForDeveloper (String loginName) {
         return createQuery("select pa.pushApplicationID from PushApplication pa where pa.developer = :developer", String.class)
-                .setParameter("developer", loginName).getResultList();
+                .setParameter("developer", loginName)
+                .setHint("org.hibernate.cacheable", true).getResultList();
     }
 
     @Override
@@ -73,7 +75,8 @@ public class JPAPushApplicationDao extends JPABaseDao<PushApplication, String> i
     @Override
     public PushApplication findByPushApplicationID(String pushApplicationID) {
         return getSingleResultForQuery(createQuery("select pa from PushApplication pa where pa.pushApplicationID = :pushApplicationID")
-                .setParameter("pushApplicationID", pushApplicationID));
+                .setParameter("pushApplicationID", pushApplicationID)
+                .setHint("org.hibernate.cacheable", true));
     }
 
     @Override
@@ -110,7 +113,8 @@ public class JPAPushApplicationDao extends JPABaseDao<PushApplication, String> i
     public List<PushApplication> findByVariantIds(List<String> variantIDs) {
         final String jpql = "select pa from PushApplication pa left join fetch pa.variants v where v.variantID in (:variantIDs)";
 
-        return createQuery(jpql).setParameter("variantIDs", variantIDs).getResultList();
+        return createQuery(jpql).setParameter("variantIDs", variantIDs)
+            .setHint("org.hibernate.cacheable", true).getResultList();
     }
 
     @Override

--- a/model/jpa/src/main/java/org/jboss/aerogear/unifiedpush/jpa/dao/impl/JPAVariantDao.java
+++ b/model/jpa/src/main/java/org/jboss/aerogear/unifiedpush/jpa/dao/impl/JPAVariantDao.java
@@ -39,7 +39,8 @@ public class JPAVariantDao extends JPABaseDao<Variant, String> implements Varian
     @Override
     public Variant findByVariantID(String variantID) {
         return getSingleResultForQuery(createQuery("select t from Variant t where t.variantID = :variantID")
-                .setParameter("variantID", variantID));
+                .setParameter("variantID", variantID)
+                .setHint("org.hibernate.cacheable", true));
     }
 
     @Override
@@ -67,7 +68,8 @@ public class JPAVariantDao extends JPABaseDao<Variant, String> implements Varian
         }
 
         return createQuery("select t from Variant t where t.variantID IN :variantIDs")
-                .setParameter("variantIDs", variantIDs).getResultList();
+                .setParameter("variantIDs", variantIDs)
+                .setHint("org.hibernate.cacheable", true).getResultList();
     }
 
     //Admin queries

--- a/model/jpa/src/main/resources/META-INF/persistence.xml
+++ b/model/jpa/src/main/resources/META-INF/persistence.xml
@@ -23,6 +23,7 @@
     <jta-data-source>java:jboss/datasources/UnifiedPushDS</jta-data-source>
 
     <mapping-file>META-INF/orm.xml</mapping-file>
+    <shared-cache-mode>ALL</shared-cache-mode>
 
     <properties>
       <property name="hibernate.dialect_resolvers" value="org.jboss.aerogear.unifiedpush.jpa.MysqlDialectResolver"/>
@@ -31,6 +32,11 @@
       <property name="hibernate.format_sql" value="true"/>
       <property name="hibernate.transaction.flush_before_completion" value="true"/>
       <property name="hibernate.id.new_generator_mappings" value="true"/>
+
+      <property name="hibernate.cache.use_query_cache" value="true"/>
+      <property name="hibernate.cache.use_second_level_cache" value="true"/>
+
+      <property name="hibernate.cache.infinispan.statistics" value="true"/>
     </properties>
   </persistence-unit>
 


### PR DESCRIPTION
# Motivation
UPS database can grow up to become quite big.
Since many queries are executed, that could slow down the database and, thus, slow the whole platform.

# Solution
We want to enable Hibernate cache so that queries are not executed again on the database if they have been already executed and still cached.
