### PR TITLE
Replaced merge with getReference in delete method

### DIFF
--- a/model/jpa/src/main/java/org/jboss/aerogear/unifiedpush/jpa/dao/impl/JPABaseDao.java
+++ b/model/jpa/src/main/java/org/jboss/aerogear/unifiedpush/jpa/dao/impl/JPABaseDao.java
@@ -92,7 +92,8 @@ public abstract class JPABaseDao<T, K> implements GenericBaseDao<T, K> {
             // making sure the entity in question,
             // is really part of this transaction
             if (! entityManager.contains(entity)) {
-                entity = entityManager.merge(entity);
+                final Object entityId = entityManager.getEntityManagerFactory().getPersistenceUnitUtil().getIdentifier(entity);
+                entity = entityManager.getReference(getType(), entityId);
             }
 
             entityManager.remove(entity);

--- a/model/jpa/src/test/java/org/jboss/aerogear/unifiedpush/jpa/InstallationDaoTest.java
+++ b/model/jpa/src/test/java/org/jboss/aerogear/unifiedpush/jpa/InstallationDaoTest.java
@@ -27,6 +27,7 @@ import java.util.Set;
 
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
+import javax.persistence.EntityNotFoundException;
 import javax.persistence.PersistenceException;
 import javax.validation.ConstraintViolation;
 import javax.validation.ConstraintViolationException;
@@ -237,7 +238,7 @@ public class InstallationDaoTest {
         assertThat(list).hasSize(0);
     }
 
-    @Test
+    @Test(expected= EntityNotFoundException.class)
     public void deleteNonExistingInstallation() {
         Installation installation = new Installation();
         installation.setId("2345");


### PR DESCRIPTION
# Motivation
Currently the delete method used the merge approach to load the object to be deleted.
It has the drawback of loading the whole object from the database, while a simple reference would be enough.

# Solution
Using getReference instead of merge