### PR TITLE
Correcting the version on master

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.jboss.aerogear.unifiedpush</groupId>
         <artifactId>unifiedpush-parent</artifactId>
-        <version>1.2.1.Final-SNAPSHOT</version>
+        <version>1.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>unifiedpush-common</artifactId>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.jboss.aerogear.unifiedpush</groupId>
         <artifactId>unifiedpush-parent</artifactId>
-        <version>1.2.1.Final-SNAPSHOT</version>
+        <version>1.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>unifiedpush-dependencies-parent</artifactId>

--- a/dependencies/server-dependencies/pom.xml
+++ b/dependencies/server-dependencies/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.jboss.aerogear.unifiedpush</groupId>
         <artifactId>unifiedpush-dependencies-parent</artifactId>
-        <version>1.2.1.Final-SNAPSHOT</version>
+        <version>1.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>unifiedpush-server-dependencies</artifactId>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.jboss.aerogear.unifiedpush</groupId>
         <artifactId>unifiedpush-parent</artifactId>
-        <version>1.2.1.Final-SNAPSHOT</version>
+        <version>1.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>unifiedpush-dist</artifactId>

--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.jboss.aerogear.unifiedpush</groupId>
         <artifactId>unifiedpush-parent</artifactId>
-        <version>1.2.1.Final-SNAPSHOT</version>
+        <version>1.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>unifiedpush-jaxrs</artifactId>

--- a/migrator/pom.xml
+++ b/migrator/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jboss.aerogear.unifiedpush</groupId>
         <artifactId>unifiedpush-parent</artifactId>
-				<version>1.2.1.Final-SNAPSHOT</version>
+				<version>1.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>unifiedpush-migrator</artifactId>

--- a/model/api/pom.xml
+++ b/model/api/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.jboss.aerogear.unifiedpush</groupId>
         <artifactId>unifiedpush-model-parent</artifactId>
-        <version>1.2.1.Final-SNAPSHOT</version>
+        <version>1.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>unifiedpush-model-api</artifactId>

--- a/model/jpa/pom.xml
+++ b/model/jpa/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.jboss.aerogear.unifiedpush</groupId>
         <artifactId>unifiedpush-model-parent</artifactId>
-        <version>1.2.1.Final-SNAPSHOT</version>
+        <version>1.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>unifiedpush-model-jpa</artifactId>

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.jboss.aerogear.unifiedpush</groupId>
         <artifactId>unifiedpush-parent</artifactId>
-        <version>1.2.1.Final-SNAPSHOT</version>
+        <version>1.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>unifiedpush-model-parent</artifactId>

--- a/model/push/pom.xml
+++ b/model/push/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.jboss.aerogear.unifiedpush</groupId>
         <artifactId>unifiedpush-model-parent</artifactId>
-        <version>1.2.1.Final-SNAPSHOT</version>
+        <version>1.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>unifiedpush-push-model</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
     <groupId>org.jboss.aerogear.unifiedpush</groupId>
     <artifactId>unifiedpush-parent</artifactId>
-    <version>1.2.1.Final-SNAPSHOT</version>
+    <version>1.2.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>AeroGear UnifiedPush Server</name>

--- a/push-sender/pom.xml
+++ b/push-sender/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.jboss.aerogear.unifiedpush</groupId>
         <artifactId>unifiedpush-parent</artifactId>
-        <version>1.2.1.Final-SNAPSHOT</version>
+        <version>1.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>unifiedpush-push-sender</artifactId>

--- a/servers/pom.xml
+++ b/servers/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.jboss.aerogear.unifiedpush</groupId>
         <artifactId>unifiedpush-parent</artifactId>
-        <version>1.2.1.Final-SNAPSHOT</version>
+        <version>1.2.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.jboss.aerogear.unifiedpush</groupId>
         <artifactId>unifiedpush-parent</artifactId>
-        <version>1.2.1.Final-SNAPSHOT</version>
+        <version>1.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>unifiedpush-service</artifactId>


### PR DESCRIPTION
By accident the maven-release plugin did set the version to `1.2.1.Final-SNAPSHOT`,

but it needs to be `1.2.1-SNAPSHOT` ...

Used the plugin to correct that, by running:

```
mvn release:update-versions -Pdist,test -DdevelopmentVersion=1.2.1-SNAPSHOT
```