### PR TITLE
AGPUSH-1023 - Improve database .cli scripts for better user experience

### DIFF
--- a/configuration/jms-setup-wildfly.cli
+++ b/configuration/jms-setup-wildfly.cli
@@ -3,55 +3,147 @@ connect
 #/subsystem=logging/console-handler=AEROGEAR:add(formatter="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n",autoflush=true)
 #/subsystem=logging/logger=org.jboss.aerogear.unifiedpush:add(level=FINEST,use-parent-handlers=false,handlers=["AEROGEAR"])
 
-batch
+try
+  /subsystem=messaging-activemq/server=default/jms-queue=AdmPushMessageQueue:add(entries=[queue/AdmPushMessageQueue])
+  /subsystem=messaging-activemq/server=default/address-setting=jms.queue.AdmPushMessageQueue:add(redelivery-delay=1500, redelivery-multiplier=1.5, max-redelivery-delay=5000, max-delivery-attempts=-1)
+  /subsystem=messaging-activemq/server=default/jms-queue=AdmTokenBatchQueue:add(entries=[queue/AdmTokenBatchQueue])
+  /subsystem=messaging-activemq/server=default/address-setting=jms.queue.AdmTokenBatchQueue:add(address-full-policy=FAIL, max-size-bytes=40000)
 
-/subsystem=messaging-activemq/server=default/jms-queue=AdmPushMessageQueue:add(entries=[queue/AdmPushMessageQueue])
-/subsystem=messaging-activemq/server=default/address-setting=jms.queue.AdmPushMessageQueue:add(redelivery-delay=1500, redelivery-multiplier=1.5, max-redelivery-delay=5000, max-delivery-attempts=-1)
-/subsystem=messaging-activemq/server=default/jms-queue=AdmTokenBatchQueue:add(entries=[queue/AdmTokenBatchQueue])
-/subsystem=messaging-activemq/server=default/address-setting=jms.queue.AdmTokenBatchQueue:add(address-full-policy=FAIL, max-size-bytes=40000)
+  /subsystem=messaging-activemq/server=default/jms-queue=APNsPushMessageQueue:add(entries=[queue/APNsPushMessageQueue])
+  /subsystem=messaging-activemq/server=default/address-setting=jms.queue.APNsPushMessageQueue:add(redelivery-delay=1500, redelivery-multiplier=1.5, max-redelivery-delay=5000, max-delivery-attempts=-1)
+  /subsystem=messaging-activemq/server=default/jms-queue=APNsTokenBatchQueue:add(entries=[queue/APNsTokenBatchQueue])
+  /subsystem=messaging-activemq/server=default/address-setting=jms.queue.APNsTokenBatchQueue:add(address-full-policy=FAIL, max-size-bytes=40000)
 
-/subsystem=messaging-activemq/server=default/jms-queue=APNsPushMessageQueue:add(entries=[queue/APNsPushMessageQueue])
-/subsystem=messaging-activemq/server=default/address-setting=jms.queue.APNsPushMessageQueue:add(redelivery-delay=1500, redelivery-multiplier=1.5, max-redelivery-delay=5000, max-delivery-attempts=-1)
-/subsystem=messaging-activemq/server=default/jms-queue=APNsTokenBatchQueue:add(entries=[queue/APNsTokenBatchQueue])
-/subsystem=messaging-activemq/server=default/address-setting=jms.queue.APNsTokenBatchQueue:add(address-full-policy=FAIL, max-size-bytes=40000)
+  /subsystem=messaging-activemq/server=default/jms-queue=GCMPushMessageQueue:add(entries=[queue/GCMPushMessageQueue])
+  /subsystem=messaging-activemq/server=default/address-setting=jms.queue.GCMPushMessageQueue:add(redelivery-delay=1500, redelivery-multiplier=1.5, max-redelivery-delay=5000, max-delivery-attempts=-1)
+  /subsystem=messaging-activemq/server=default/jms-queue=GCMTokenBatchQueue:add(entries=[queue/GCMTokenBatchQueue])
+  /subsystem=messaging-activemq/server=default/address-setting=jms.queue.GCMTokenBatchQueue:add(address-full-policy=FAIL, max-size-bytes=40000)
 
-/subsystem=messaging-activemq/server=default/jms-queue=GCMPushMessageQueue:add(entries=[queue/GCMPushMessageQueue])
-/subsystem=messaging-activemq/server=default/address-setting=jms.queue.GCMPushMessageQueue:add(redelivery-delay=1500, redelivery-multiplier=1.5, max-redelivery-delay=5000, max-delivery-attempts=-1)
-/subsystem=messaging-activemq/server=default/jms-queue=GCMTokenBatchQueue:add(entries=[queue/GCMTokenBatchQueue])
-/subsystem=messaging-activemq/server=default/address-setting=jms.queue.GCMTokenBatchQueue:add(address-full-policy=FAIL, max-size-bytes=40000)
-
-/subsystem=messaging-activemq/server=default/jms-queue=WNSPushMessageQueue:add(entries=[queue/WNSPushMessageQueue])
-/subsystem=messaging-activemq/server=default/address-setting=jms.queue.WNSPushMessageQueue:add(redelivery-delay=1500, redelivery-multiplier=1.5, max-redelivery-delay=5000, max-delivery-attempts=-1)
-/subsystem=messaging-activemq/server=default/jms-queue=WNSTokenBatchQueue:add(entries=[queue/WNSTokenBatchQueue])
-/subsystem=messaging-activemq/server=default/address-setting=jms.queue.WNSTokenBatchQueue:add(address-full-policy=FAIL, max-size-bytes=40000)
-
-
-
-/subsystem=messaging-activemq/server=default/jms-queue=MetricsQueue:add(entries=[queue/MetricsQueue])
-/subsystem=messaging-activemq/server=default/address-setting=jms.queue.MetricsQueue:add(max-delivery-attempts=-1)
-
-/subsystem=messaging-activemq/server=default/jms-queue=TriggerMetricCollectionQueue:add(entries=[queue/TriggerMetricCollectionQueue])
-/subsystem=messaging-activemq/server=default/address-setting=jms.queue.TriggerMetricCollectionQueue:add(redelivery-delay=1000, max-delivery-attempts=-1)
-
-/subsystem=messaging-activemq/server=default/jms-queue=TriggerVariantMetricCollectionQueue:add(entries=[queue/TriggerVariantMetricCollectionQueue])
+  /subsystem=messaging-activemq/server=default/jms-queue=WNSPushMessageQueue:add(entries=[queue/WNSPushMessageQueue])
+  /subsystem=messaging-activemq/server=default/address-setting=jms.queue.WNSPushMessageQueue:add(redelivery-delay=1500, redelivery-multiplier=1.5, max-redelivery-delay=5000, max-delivery-attempts=-1)
+  /subsystem=messaging-activemq/server=default/jms-queue=WNSTokenBatchQueue:add(entries=[queue/WNSTokenBatchQueue])
+  /subsystem=messaging-activemq/server=default/address-setting=jms.queue.WNSTokenBatchQueue:add(address-full-policy=FAIL, max-size-bytes=40000)
 
 
 
-/subsystem=messaging-activemq/server=default/jms-queue=BatchLoadedQueue:add(entries=[queue/BatchLoadedQueue])
-/subsystem=messaging-activemq/server=default/address-setting=jms.queue.BatchLoadedQueue:add(max-delivery-attempts=-1)
+  /subsystem=messaging-activemq/server=default/jms-queue=MetricsQueue:add(entries=[queue/MetricsQueue])
+  /subsystem=messaging-activemq/server=default/address-setting=jms.queue.MetricsQueue:add(max-delivery-attempts=-1)
 
-/subsystem=messaging-activemq/server=default/jms-queue=AllBatchesLoadedQueue:add(entries=[queue/AllBatchesLoadedQueue])
-/subsystem=messaging-activemq/server=default/address-setting=jms.queue.AllBatchesLoadedQueue:add(max-delivery-attempts=-1)
+  /subsystem=messaging-activemq/server=default/jms-queue=TriggerMetricCollectionQueue:add(entries=[queue/TriggerMetricCollectionQueue])
+  /subsystem=messaging-activemq/server=default/address-setting=jms.queue.TriggerMetricCollectionQueue:add(redelivery-delay=1000, max-delivery-attempts=-1)
 
-
-# This queue is populated with number of messages corresponding to limit of how many services can be created for given push network.
-# The message is borrowed from this queue when new service is created.
-# The message is returned to this queue when service is destroyed.
-# That ensures that there won't be created more service instances in entire cluster of servers than given limit.
-/subsystem=messaging-activemq/server=default/jms-queue=FreeServiceSlotQueue:add(entries=[queue/FreeServiceSlotQueue])
+  /subsystem=messaging-activemq/server=default/jms-queue=TriggerVariantMetricCollectionQueue:add(entries=[queue/TriggerVariantMetricCollectionQueue])
 
 
 
-/subsystem=messaging-activemq/server=default/jms-topic=MetricsProcessingStartedTopic:add(entries=[topic/MetricsProcessingStartedTopic])
+  /subsystem=messaging-activemq/server=default/jms-queue=BatchLoadedQueue:add(entries=[queue/BatchLoadedQueue])
+  /subsystem=messaging-activemq/server=default/address-setting=jms.queue.BatchLoadedQueue:add(max-delivery-attempts=-1)
 
-run-batch
+  /subsystem=messaging-activemq/server=default/jms-queue=AllBatchesLoadedQueue:add(entries=[queue/AllBatchesLoadedQueue])
+  /subsystem=messaging-activemq/server=default/address-setting=jms.queue.AllBatchesLoadedQueue:add(max-delivery-attempts=-1)
+
+
+  # This queue is populated with number of messages corresponding to limit of how many services can be created for given push network.
+  # The message is borrowed from this queue when new service is created.
+  # The message is returned to this queue when service is destroyed.
+  # That ensures that there won't be created more service instances in entire cluster of servers than given limit.
+  /subsystem=messaging-activemq/server=default/jms-queue=FreeServiceSlotQueue:add(entries=[queue/FreeServiceSlotQueue])
+
+
+
+  /subsystem=messaging-activemq/server=default/jms-topic=MetricsProcessingStartedTopic:add(entries=[topic/MetricsProcessingStartedTopic])
+
+catch
+  ## Remove all previous config and set up again
+  /subsystem=messaging-activemq/server=default/jms-queue=AdmPushMessageQueue:remove
+  /subsystem=messaging-activemq/server=default/address-setting=jms.queue.AdmPushMessageQueue:remove
+  /subsystem=messaging-activemq/server=default/jms-queue=AdmTokenBatchQueue:remove
+  /subsystem=messaging-activemq/server=default/address-setting=jms.queue.AdmTokenBatchQueue:remove
+
+  /subsystem=messaging-activemq/server=default/jms-queue=APNsPushMessageQueue:remove
+  /subsystem=messaging-activemq/server=default/address-setting=jms.queue.APNsPushMessageQueue:remove
+  /subsystem=messaging-activemq/server=default/jms-queue=APNsTokenBatchQueue:remove
+  /subsystem=messaging-activemq/server=default/address-setting=jms.queue.APNsTokenBatchQueue:remove
+
+  /subsystem=messaging-activemq/server=default/jms-queue=GCMPushMessageQueue:remove
+  /subsystem=messaging-activemq/server=default/address-setting=jms.queue.GCMPushMessageQueue:remove
+  /subsystem=messaging-activemq/server=default/jms-queue=GCMTokenBatchQueue:remove
+  /subsystem=messaging-activemq/server=default/address-setting=jms.queue.GCMTokenBatchQueue:remove
+
+  /subsystem=messaging-activemq/server=default/jms-queue=WNSPushMessageQueue:remove
+  /subsystem=messaging-activemq/server=default/address-setting=jms.queue.WNSPushMessageQueue:remove
+  /subsystem=messaging-activemq/server=default/jms-queue=WNSTokenBatchQueue:remove
+  /subsystem=messaging-activemq/server=default/address-setting=jms.queue.WNSTokenBatchQueue:remove
+
+
+
+  /subsystem=messaging-activemq/server=default/jms-queue=MetricsQueue:remove
+  /subsystem=messaging-activemq/server=default/address-setting=jms.queue.MetricsQueue:remove
+
+  /subsystem=messaging-activemq/server=default/jms-queue=TriggerMetricCollectionQueue:remove
+  /subsystem=messaging-activemq/server=default/address-setting=jms.queue.TriggerMetricCollectionQueue:remove
+
+  /subsystem=messaging-activemq/server=default/jms-queue=TriggerVariantMetricCollectionQueue:remove
+
+
+
+  /subsystem=messaging-activemq/server=default/jms-queue=BatchLoadedQueue:remove
+  /subsystem=messaging-activemq/server=default/address-setting=jms.queue.BatchLoadedQueue:remove
+
+  /subsystem=messaging-activemq/server=default/jms-queue=AllBatchesLoadedQueue:remove
+  /subsystem=messaging-activemq/server=default/address-setting=jms.queue.AllBatchesLoadedQueue:remove
+
+  /subsystem=messaging-activemq/server=default/jms-queue=FreeServiceSlotQueue:remove
+
+  /subsystem=messaging-activemq/server=default/jms-topic=MetricsProcessingStartedTopic:remove
+
+  /subsystem=messaging-activemq/server=default/jms-queue=AdmPushMessageQueue:add(entries=[queue/AdmPushMessageQueue])
+  /subsystem=messaging-activemq/server=default/address-setting=jms.queue.AdmPushMessageQueue:add(redelivery-delay=1500, redelivery-multiplier=1.5, max-redelivery-delay=5000, max-delivery-attempts=-1)
+  /subsystem=messaging-activemq/server=default/jms-queue=AdmTokenBatchQueue:add(entries=[queue/AdmTokenBatchQueue])
+  /subsystem=messaging-activemq/server=default/address-setting=jms.queue.AdmTokenBatchQueue:add(address-full-policy=FAIL, max-size-bytes=40000)
+
+  /subsystem=messaging-activemq/server=default/jms-queue=APNsPushMessageQueue:add(entries=[queue/APNsPushMessageQueue])
+  /subsystem=messaging-activemq/server=default/address-setting=jms.queue.APNsPushMessageQueue:add(redelivery-delay=1500, redelivery-multiplier=1.5, max-redelivery-delay=5000, max-delivery-attempts=-1)
+  /subsystem=messaging-activemq/server=default/jms-queue=APNsTokenBatchQueue:add(entries=[queue/APNsTokenBatchQueue])
+  /subsystem=messaging-activemq/server=default/address-setting=jms.queue.APNsTokenBatchQueue:add(address-full-policy=FAIL, max-size-bytes=40000)
+
+  /subsystem=messaging-activemq/server=default/jms-queue=GCMPushMessageQueue:add(entries=[queue/GCMPushMessageQueue])
+  /subsystem=messaging-activemq/server=default/address-setting=jms.queue.GCMPushMessageQueue:add(redelivery-delay=1500, redelivery-multiplier=1.5, max-redelivery-delay=5000, max-delivery-attempts=-1)
+  /subsystem=messaging-activemq/server=default/jms-queue=GCMTokenBatchQueue:add(entries=[queue/GCMTokenBatchQueue])
+  /subsystem=messaging-activemq/server=default/address-setting=jms.queue.GCMTokenBatchQueue:add(address-full-policy=FAIL, max-size-bytes=40000)
+
+  /subsystem=messaging-activemq/server=default/jms-queue=WNSPushMessageQueue:add(entries=[queue/WNSPushMessageQueue])
+  /subsystem=messaging-activemq/server=default/address-setting=jms.queue.WNSPushMessageQueue:add(redelivery-delay=1500, redelivery-multiplier=1.5, max-redelivery-delay=5000, max-delivery-attempts=-1)
+  /subsystem=messaging-activemq/server=default/jms-queue=WNSTokenBatchQueue:add(entries=[queue/WNSTokenBatchQueue])
+  /subsystem=messaging-activemq/server=default/address-setting=jms.queue.WNSTokenBatchQueue:add(address-full-policy=FAIL, max-size-bytes=40000)
+
+
+
+  /subsystem=messaging-activemq/server=default/jms-queue=MetricsQueue:add(entries=[queue/MetricsQueue])
+  /subsystem=messaging-activemq/server=default/address-setting=jms.queue.MetricsQueue:add(max-delivery-attempts=-1)
+
+  /subsystem=messaging-activemq/server=default/jms-queue=TriggerMetricCollectionQueue:add(entries=[queue/TriggerMetricCollectionQueue])
+  /subsystem=messaging-activemq/server=default/address-setting=jms.queue.TriggerMetricCollectionQueue:add(redelivery-delay=1000, max-delivery-attempts=-1)
+
+  /subsystem=messaging-activemq/server=default/jms-queue=TriggerVariantMetricCollectionQueue:add(entries=[queue/TriggerVariantMetricCollectionQueue])
+
+
+
+  /subsystem=messaging-activemq/server=default/jms-queue=BatchLoadedQueue:add(entries=[queue/BatchLoadedQueue])
+  /subsystem=messaging-activemq/server=default/address-setting=jms.queue.BatchLoadedQueue:add(max-delivery-attempts=-1)
+
+  /subsystem=messaging-activemq/server=default/jms-queue=AllBatchesLoadedQueue:add(entries=[queue/AllBatchesLoadedQueue])
+  /subsystem=messaging-activemq/server=default/address-setting=jms.queue.AllBatchesLoadedQueue:add(max-delivery-attempts=-1)
+
+
+  # This queue is populated with number of messages corresponding to limit of how many services can be created for given push network.
+  # The message is borrowed from this queue when new service is created.
+  # The message is returned to this queue when service is destroyed.
+  # That ensures that there won't be created more service instances in entire cluster of servers than given limit.
+  /subsystem=messaging-activemq/server=default/jms-queue=FreeServiceSlotQueue:add(entries=[queue/FreeServiceSlotQueue])
+
+
+
+  /subsystem=messaging-activemq/server=default/jms-topic=MetricsProcessingStartedTopic:add(entries=[topic/MetricsProcessingStartedTopic])
+finally
+end-try

--- a/databases/docker-compose/mysql-database-config-wildfly.cli
+++ b/databases/docker-compose/mysql-database-config-wildfly.cli
@@ -1,12 +1,32 @@
 # $WILDFLY_HOME/bin/jboss-cli.sh --file=/path/to/this/file.
 connect
-batch
 
-## Add Mysql driver
-/subsystem=datasources/jdbc-driver=mysqlup:add(driver-name=mysqlup,driver-module-name=com.mysql.jdbc,driver-xa-datasource-class-name=com.mysql.jdbc.jdbc2.optional.MysqlXADataSource)
+try 
+  ## Add Mysql driver
+  /subsystem=datasources/jdbc-driver=mysqlup:add(driver-name=mysqlup,driver-module-name=com.mysql.jdbc,driver-xa-datasource-class-name=com.mysql.jdbc.jdbc2.optional.MysqlXADataSource)
+catch
+  if (response-headers.process-state == reload-required) of /subsystem=datasources/data-source=UnifiedPushDS:remove
+    ## Reload the controller
+    reload 
+    ## Add MySQL driver to the controller again
+    /subsystem=datasources/jdbc-driver=mysqlup:remove
+    /subsystem=datasources/jdbc-driver=mysqlup:add(driver-name=mysqlup,driver-module-name=com.mysql.jdbc,driver-xa-datasource-class-name=com.mysql.jdbc.jdbc2.optional.MysqlXADataSource)
+  end-if
+finally
+end-try
 
-## Add UnifiedPush Datasource
-data-source add --name=UnifiedPushDS --driver-name=mysqlup --jndi-name=java:jboss/datasources/UnifiedPushDS --connection-url="jdbc:mysql://localhost:6306/unifiedpush?useUnicode=true&amp;characterEncoding=UTF-8" --user-name=unifiedpush --password=unifiedpush --use-ccm=false --max-pool-size=25 --blocking-timeout-wait-millis=5000 --enabled=true
-
-run-batch
-#:reload
+try 
+  ## Add UnifiedPush Datasource
+  data-source add --name=UnifiedPushDS --driver-name=mysqlup --jndi-name=java:jboss/datasources/UnifiedPushDS --connection-url="jdbc:mysql://localhost:6306/unifiedpush?useUnicode=true&amp;characterEncoding=UTF-8" --user-name=unifiedpush --password=unifiedpush --use-ccm=false --max-pool-size=25 --blocking-timeout-wait-millis=5000 --enabled=true
+catch
+  if (response-headers.process-state == reload-required) of /subsystem=datasources/data-source=UnifiedPushDS:remove
+    ## Reload the controller
+    reload 
+    ## Add UnifiedPush Datasource
+    data-source add --name=UnifiedPushDS --driver-name=mysqlup --jndi-name=java:jboss/datasources/UnifiedPushDS --connection-url="jdbc:mysql://localhost:6306/unifiedpush?useUnicode=true&amp;characterEncoding=UTF-8" --user-name=unifiedpush --password=unifiedpush --use-ccm=false --max-pool-size=25 --blocking-timeout-wait-millis=5000 --enabled=true
+  else
+    ## Add UnifiedPush Datasource
+    data-source add --name=UnifiedPushDS --driver-name=mysqlup --jndi-name=java:jboss/datasources/UnifiedPushDS --connection-url="jdbc:mysql://localhost:6306/unifiedpush?useUnicode=true&amp;characterEncoding=UTF-8" --user-name=unifiedpush --password=unifiedpush --use-ccm=false --max-pool-size=25 --blocking-timeout-wait-millis=5000 --enabled=true
+  end-if
+finally
+end-try

--- a/databases/h2-database-config-wildfly.cli
+++ b/databases/h2-database-config-wildfly.cli
@@ -1,9 +1,18 @@
 # $WILDFLY_HOME/bin/jboss-cli.sh --file=/path/to/this/file.
 connect
-batch
 
-## Add UnifiedPush Datasource
-data-source add --name=UnifiedPushDS --driver-name=h2 --jndi-name=java:jboss/datasources/UnifiedPushDS --connection-url="jdbc:h2:${jboss.server.data.dir}/unifiedpush;DB_CLOSE_DELAY=-1" --user-name=sa --password=sa --use-ccm=true --enabled=true
-
-run-batch
-#:reload
+try
+  ## Add UnifiedPush Datasource
+  data-source add --name=UnifiedPushDS --driver-name=h2 --jndi-name=java:jboss/datasources/UnifiedPushDS --connection-url="jdbc:h2:${jboss.server.data.dir}/unifiedpush;DB_CLOSE_DELAY=-1" --user-name=sa --password=sa --use-ccm=true --enabled=true
+catch
+  if (response-headers.process-state == reload-required) of /subsystem=datasources/data-source=UnifiedPushDS:remove
+    ## Reload the controller
+    reload 
+    ## Add UnifiedPush Datasource
+    data-source add --name=UnifiedPushDS --driver-name=h2 --jndi-name=java:jboss/datasources/UnifiedPushDS --connection-url="jdbc:h2:${jboss.server.data.dir}/unifiedpush;DB_CLOSE_DELAY=-1" --user-name=sa --password=sa --use-ccm=true --enabled=true
+  else
+    ## Add UnifiedPush Datasource
+    data-source add --name=UnifiedPushDS --driver-name=mysqlup --jndi-name=java:jboss/datasources/UnifiedPushDS --connection-url="jdbc:mysql://localhost:6306/unifiedpush?useUnicode=true&amp;characterEncoding=UTF-8" --user-name=unifiedpush --password=unifiedpush --use-ccm=false --max-pool-size=25 --blocking-timeout-wait-millis=5000 --enabled=true
+  end-if
+finally
+end-try

--- a/databases/ha_deployment/mysql-database-config-wildfly-full-ha.cli
+++ b/databases/ha_deployment/mysql-database-config-wildfly-full-ha.cli
@@ -1,12 +1,32 @@
 # $WILDFLY_HOME/bin/jboss-cli.sh --file=/path/to/this/file.
 connect localhost:10190
-batch
 
-## Add Mysql driver
-/subsystem=datasources/jdbc-driver=mysqlup:add(driver-name=mysqlup,driver-module-name=com.mysql.jdbc,driver-xa-datasource-class-name=com.mysql.jdbc.jdbc2.optional.MysqlXADataSource)
+try
+  ## Add Mysql driver
+  /subsystem=datasources/jdbc-driver=mysqlup:add(driver-name=mysqlup,driver-module-name=com.mysql.jdbc,driver-xa-datasource-class-name=com.mysql.jdbc.jdbc2.optional.MysqlXADataSource)
+catch
+  if (response-headers.process-state == reload-required) of /subsystem=datasources/data-source=UnifiedPushDS:remove
+    ## Reload the controller
+    reload 
+    ## Add MySQL driver to the controller again
+    /subsystem=datasources/jdbc-driver=mysqlup:remove
+    /subsystem=datasources/jdbc-driver=mysqlup:add(driver-name=mysqlup,driver-module-name=com.mysql.jdbc,driver-xa-datasource-class-name=com.mysql.jdbc.jdbc2.optional.MysqlXADataSource)
+  end-if
+finally
+end-try
 
-## Add UnifiedPush Datasource
-data-source add --name=UnifiedPushDS --driver-name=mysqlup --jndi-name=java:jboss/datasources/UnifiedPushDS --connection-url="jdbc:mysql://192.168.59.104:6306/unifiedpush?useUnicode=true&amp;characterEncoding=UTF-8" --user-name=unifiedpush --password=unifiedpush --use-ccm=false --max-pool-size=25 --blocking-timeout-wait-millis=5000 --enabled=true
-
-run-batch
-#:reload
+try
+  ## Add UnifiedPush Datasource
+  data-source add --name=UnifiedPushDS --driver-name=mysqlup --jndi-name=java:jboss/datasources/UnifiedPushDS --connection-url="jdbc:mysql://192.168.59.104:6306/unifiedpush?useUnicode=true&amp;characterEncoding=UTF-8" --user-name=unifiedpush --password=unifiedpush --use-ccm=false --max-pool-size=25 --blocking-timeout-wait-millis=5000 --enabled=true
+catch
+  if (response-headers.process-state == reload-required) of /subsystem=datasources/data-source=UnifiedPushDS:remove
+    ## Reload the controller
+    reload 
+    ## Add UnifiedPush Datasource
+    data-source add --name=UnifiedPushDS --driver-name=mysqlup --jndi-name=java:jboss/datasources/UnifiedPushDS --connection-url="jdbc:mysql://192.168.59.104:6306/unifiedpush?useUnicode=true&amp;characterEncoding=UTF-8" --user-name=unifiedpush --password=unifiedpush --use-ccm=false --max-pool-size=25 --blocking-timeout-wait-millis=5000 --enabled=true
+  else
+    ## Add UnifiedPush Datasource
+    data-source add --name=UnifiedPushDS --driver-name=mysqlup --jndi-name=java:jboss/datasources/UnifiedPushDS --connection-url="jdbc:mysql://localhost:6306/unifiedpush?useUnicode=true&amp;characterEncoding=UTF-8" --user-name=unifiedpush --password=unifiedpush --use-ccm=false --max-pool-size=25 --blocking-timeout-wait-millis=5000 --enabled=true
+  end-if
+finally
+end-try

--- a/databases/ha_deployment/mysql-database-config-wildfly-managed-domain.cli
+++ b/databases/ha_deployment/mysql-database-config-wildfly-managed-domain.cli
@@ -1,12 +1,32 @@
 # $WILDFLY_HOME/bin/jboss-cli.sh --file=/path/to/this/file.
 connect
-batch
 
-## Add Mysql driver
-/profile=full-ha/subsystem=datasources/jdbc-driver=mysqlup:add(driver-name=mysqlup,driver-module-name=com.mysql.jdbc,driver-xa-datasource-class-name=com.mysql.jdbc.jdbc2.optional.MysqlXADataSource)
+try
+  ## Add Mysql driver
+  /profile=full-ha/subsystem=datasources/jdbc-driver=mysqlup:add(driver-name=mysqlup,driver-module-name=com.mysql.jdbc,driver-xa-datasource-class-name=com.mysql.jdbc.jdbc2.optional.MysqlXADataSource)
+catch
+  if (response-headers.process-state == reload-required) of /subsystem=datasources/data-source=UnifiedPushDS:remove
+    ## Reload the controller
+    reload 
+    ## Add MySQL driver to the controller again
+    /profile=full-ha/subsystem=datasources/jdbc-driver=mysqlup:remove
+    /profile=full-ha/subsystem=datasources/jdbc-driver=mysqlup:add(driver-name=mysqlup,driver-module-name=com.mysql.jdbc,driver-xa-datasource-class-name=com.mysql.jdbc.jdbc2.optional.MysqlXADataSource)
+  end-if
+finally
+end-try
 
-## Add UnifiedPush Datasource
-data-source add --profile=full-ha --name=UnifiedPushDS --driver-name=mysqlup --jndi-name=java:jboss/datasources/UnifiedPushDS --connection-url="jdbc:mysql://192.168.59.104:6306/unifiedpush?useUnicode=true&amp;characterEncoding=UTF-8" --user-name=unifiedpush --password=unifiedpush --use-ccm=false --max-pool-size=25 --blocking-timeout-wait-millis=5000 --enabled=true
-
-run-batch
-#:reload
+try
+  ## Add UnifiedPush Datasource
+  data-source add --profile=full-ha --name=UnifiedPushDS --driver-name=mysqlup --jndi-name=java:jboss/datasources/UnifiedPushDS --connection-url="jdbc:mysql://192.168.59.104:6306/unifiedpush?useUnicode=true&amp;characterEncoding=UTF-8" --user-name=unifiedpush --password=unifiedpush --use-ccm=false --max-pool-size=25 --blocking-timeout-wait-millis=5000 --enabled=true
+catch
+  if (response-headers.process-state == reload-required) of /subsystem=datasources/data-source=UnifiedPushDS:remove
+    ## Reload the controller
+    reload 
+    ## Add UnifiedPush Datasource
+    data-source add --profile=full-ha --name=UnifiedPushDS --driver-name=mysqlup --jndi-name=java:jboss/datasources/UnifiedPushDS --connection-url="jdbc:mysql://192.168.59.104:6306/unifiedpush?useUnicode=true&amp;characterEncoding=UTF-8" --user-name=unifiedpush --password=unifiedpush --use-ccm=false --max-pool-size=25 --blocking-timeout-wait-millis=5000 --enabled=true
+  else
+    ## Add UnifiedPush Datasource
+    data-source add --profile=full-ha --name=UnifiedPushDS --driver-name=mysqlup --jndi-name=java:jboss/datasources/UnifiedPushDS --connection-url="jdbc:mysql://192.168.59.104:6306/unifiedpush?useUnicode=true&amp;characterEncoding=UTF-8" --user-name=unifiedpush --password=unifiedpush --use-ccm=false --max-pool-size=25 --blocking-timeout-wait-millis=5000 --enabled=true
+  end-if
+finally
+end-try

--- a/databases/mysql-database-config-wildfly.cli
+++ b/databases/mysql-database-config-wildfly.cli
@@ -1,12 +1,32 @@
 # $WILDFLY_HOME/bin/jboss-cli.sh --file=/path/to/this/file.
 connect
-batch
 
-## Add Mysql driver
-/subsystem=datasources/jdbc-driver=mysqlup:add(driver-name=mysqlup,driver-module-name=com.mysql.jdbc,driver-xa-datasource-class-name=com.mysql.jdbc.jdbc2.optional.MysqlXADataSource)
+try 
+  ## Add Mysql driver
+  /subsystem=datasources/jdbc-driver=mysqlup:add(driver-name=mysqlup,driver-module-name=com.mysql.jdbc,driver-xa-datasource-class-name=com.mysql.jdbc.jdbc2.optional.MysqlXADataSource)
+catch
+  if (response-headers.process-state == reload-required) of /subsystem=datasources/data-source=UnifiedPushDS:remove
+    ## Reload the controller
+    reload 
+    ## Add MySQL driver to the controller again
+    /subsystem=datasources/jdbc-driver=mysqlup:remove
+    /subsystem=datasources/jdbc-driver=mysqlup:add(driver-name=mysqlup,driver-module-name=com.mysql.jdbc,driver-xa-datasource-class-name=com.mysql.jdbc.jdbc2.optional.MysqlXADataSource)
+  end-if
+finally
+end-try
 
-## Add UnifiedPush Datasource
-data-source add --name=UnifiedPushDS --driver-name=mysqlup --jndi-name=java:jboss/datasources/UnifiedPushDS --connection-url="jdbc:mysql://localhost:6306/unifiedpush?useUnicode=true&amp;characterEncoding=UTF-8" --user-name=unifiedpush --password=unifiedpush --use-ccm=false --max-pool-size=25 --blocking-timeout-wait-millis=5000 --enabled=true
-
-run-batch
-#:reload
+try 
+  ## Add UnifiedPush Datasource
+  data-source add --name=UnifiedPushDS --driver-name=mysqlup --jndi-name=java:jboss/datasources/UnifiedPushDS --connection-url="jdbc:mysql://localhost:6306/unifiedpush?useUnicode=true&amp;characterEncoding=UTF-8" --user-name=unifiedpush --password=unifiedpush --use-ccm=false --max-pool-size=25 --blocking-timeout-wait-millis=5000 --enabled=true
+catch
+  if (response-headers.process-state == reload-required) of /subsystem=datasources/data-source=UnifiedPushDS:remove
+    ## Reload the controller
+    reload 
+    ## Add UnifiedPush Datasource
+    data-source add --name=UnifiedPushDS --driver-name=mysqlup --jndi-name=java:jboss/datasources/UnifiedPushDS --connection-url="jdbc:mysql://localhost:6306/unifiedpush?useUnicode=true&amp;characterEncoding=UTF-8" --user-name=unifiedpush --password=unifiedpush --use-ccm=false --max-pool-size=25 --blocking-timeout-wait-millis=5000 --enabled=true
+  else
+    ## Add UnifiedPush Datasource
+    data-source add --name=UnifiedPushDS --driver-name=mysqlup --jndi-name=java:jboss/datasources/UnifiedPushDS --connection-url="jdbc:mysql://localhost:6306/unifiedpush?useUnicode=true&amp;characterEncoding=UTF-8" --user-name=unifiedpush --password=unifiedpush --use-ccm=false --max-pool-size=25 --blocking-timeout-wait-millis=5000 --enabled=true
+  end-if
+finally
+end-try

--- a/databases/postgresql-database-config-wildfly.cli
+++ b/databases/postgresql-database-config-wildfly.cli
@@ -1,12 +1,32 @@
 # $WILDFLY_HOME/bin/jboss-cli.sh --file=/path/to/this/file.
 connect
-batch
 
-## Add Postgresql driver
-/subsystem=datasources/jdbc-driver=psqlup:add(driver-name=psqlup,driver-module-name=org.postgresql,driver-xa-datasource-class-name=org.postgresql.xa.PGXADataSource)
+try
+  ## Add Postgresql driver
+  /subsystem=datasources/jdbc-driver=psqlup:add(driver-name=psqlup,driver-module-name=org.postgresql,driver-xa-datasource-class-name=org.postgresql.xa.PGXADataSource)
+catch
+  if (response-headers.process-state == reload-required) of /subsystem=datasources/data-source=UnifiedPushDS:remove
+    ## Reload the controller
+    reload 
+    ## Add Postgresql driver to the controller again
+    /subsystem=datasources/jdbc-driver=psqlup:remove
+    /subsystem=datasources/jdbc-driver=psqlup:add(driver-name=psqlup,driver-module-name=org.postgresql,driver-xa-datasource-class-name=org.postgresql.xa.PGXADataSource)
+  end-if
+finally
+end-try
 
-## Add UnifiedPush Datasource
-data-source add --name=UnifiedPushDS --driver-name=psqlup --jndi-name=java:jboss/datasources/UnifiedPushDS --connection-url=jdbc:postgresql://localhost:5432/unifiedpush --user-name=unifiedpush --password=unifiedpush --use-ccm=false --max-pool-size=25 --blocking-timeout-wait-millis=5000 --enabled=true
-
-run-batch
-#:reload
+try
+  ## Add UnifiedPush Datasource
+  data-source add --name=UnifiedPushDS --driver-name=psqlup --jndi-name=java:jboss/datasources/UnifiedPushDS --connection-url=jdbc:postgresql://localhost:5432/unifiedpush --user-name=unifiedpush --password=unifiedpush --use-ccm=false --max-pool-size=25 --blocking-timeout-wait-millis=5000 --enabled=true
+catch
+  if (response-headers.process-state == reload-required) of /subsystem=datasources/data-source=UnifiedPushDS:remove
+    ## Reload the controller
+    reload 
+    ## Add UnifiedPush Datasource
+    data-source add --name=UnifiedPushDS --driver-name=psqlup --jndi-name=java:jboss/datasources/UnifiedPushDS --connection-url=jdbc:postgresql://localhost:5432/unifiedpush --user-name=unifiedpush --password=unifiedpush --use-ccm=false --max-pool-size=25 --blocking-timeout-wait-millis=5000 --enabled=true
+  else
+    ## Add UnifiedPush Datasource
+    data-source add --name=UnifiedPushDS --driver-name=psqlup --jndi-name=java:jboss/datasources/UnifiedPushDS --connection-url=jdbc:postgresql://localhost:5432/unifiedpush --user-name=unifiedpush --password=unifiedpush --use-ccm=false --max-pool-size=25 --blocking-timeout-wait-millis=5000 --enabled=true
+  end-if
+finally
+end-try


### PR DESCRIPTION
## Motivation
Currently the .cli scripts are very simple and don't handle exceptions well.  For example, when a duplicate resource error is thrown it is not handled nor is there any logging to give the user an explanation on how to fix this issue.

## Result
Add try/catch to the scripts to handle exceptions and errors. Extra logging is not needed as the scripts are able to handle the errors now and remove and add configurations as needed.  User's should be able to re-run these scripts when a config needs to be updated.

## Jira
https://issues.jboss.org/browse/AGPUSH-1023