### PR TITLE
Adding maven remote resources plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,26 @@
                 </configuration>
             </plugin>
 
+            <plugin>
+                <artifactId>maven-remote-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>process</goal>
+                        </goals>
+                        <configuration>
+                            <resourceBundles>
+                                <resourceBundle>org.apache:apache-jar-resource-bundle:1.4</resourceBundle>
+                            </resourceBundles>
+                            <properties>
+                                <addLicense>true</addLicense>
+                            </properties>
+                            <excludeScope>provided</excludeScope>
+                            <excludeArtifactIds>servlet-api,jstl</excludeArtifactIds>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
 
         </plugins>
         <pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,7 @@
                         </goals>
                         <configuration>
                             <resourceBundles>
-                                <resourceBundle>org.apache:apache-jar-resource-bundle:1.4</resourceBundle>
+                                <resourceBundle>org.aerogear:aerogear-jar-resource-bundle:1.0.0-SNAPSHOT</resourceBundle>
                             </resourceBundles>
                             <properties>
                                 <addLicense>true</addLicense>

--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,7 @@
                         </goals>
                         <configuration>
                             <resourceBundles>
-                                <resourceBundle>org.aerogear:aerogear-jar-resource-bundle:1.0.0-SNAPSHOT</resourceBundle>
+                                <resourceBundle>org.aerogear:aerogear-jar-resource-bundle:1.0.0</resourceBundle>
                             </resourceBundles>
                             <properties>
                                 <addLicense>true</addLicense>


### PR DESCRIPTION
## Adding licenses.xml and bundles resources

For each `jar` or `war` file of the project builds we are adding the following files to the `META-INF` folder inside the `jar` or `war` file:
* `licenses.xml`
* `NOTICE`
* `LICENSE` (Apache License v2, since that's the UPS license)

For the `licenses.xml` the format is like:
```
<?xml version="1.0"?>
<licenseSummary>
  <dependencies>
    <dependency>
      <groupId>com.fasterxml.jackson.core</groupId>
      <artifactId>jackson-annotations</artifactId>
      <version>2.8.9</version>
      <licenses>
        <license>
          <name>The Apache Software License, Version 2.0</name>
          <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
        </license>
      </licenses>
    </dependency>
    <dependency>
      <groupId>org.jboss.aerogear.unifiedpush</groupId>
      <artifactId>unifiedpush-model-api</artifactId>
      <version>1.2.1-SNAPSHOT</version>
      <licenses>
        <license>
          <name>The Apache Software License, Version 2.0</name>
          <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
        </license>
      </licenses>
    </dependency>
    <dependency>
      <groupId>org.slf4j</groupId>
      <artifactId>slf4j-api</artifactId>
      <version>1.7.21</version>
      <licenses>
        <license>
          <name>MIT License</name>
          <url>http://www.opensource.org/licenses/mit-license.php</url>
        </license>
      </licenses>
    </dependency>
    <dependency>
      <groupId>org.slf4j</groupId>
      <artifactId>slf4j-nop</artifactId>
      <version>1.6.4</version>
      <licenses>
        <license>
          <name>MIT License</name>
          <url>http://www.opensource.org/licenses/mit-license.php</url>
        </license>
      </licenses>
    </dependency>
  </dependencies>
</licenseSummary>
```

and for the `NOTICE` file, it looks like:
```
UnifiedPush Server Model JPA implementation
Copyright 2017 JBoss by Red Hat

This product includes software developed at 
Red Hat, Inc (http://www.redhat.com/).
```

