### PR TITLE
attempting to bring Aerogear to SonarCloud for more cross OSS visibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,12 @@ jdk:
   - oraclejdk8
   - oraclejdk9
 
+addons:
+  sonarcloud:
+    organization: "aerogear"
+    token:
+      secure: "G9JZpmpuYHSiPBnDH5SWRAomlpTi0+eBcTDKZT/ymGuR6oOR0OX+u7wXUGVb998MMt81VIjDz912sJJykFgzlx2THz8VHeUOu8QTbTBDbU/aNKJ+N7H52a5PDMxh2rPEs810JoyC7obgyrLSxyj/s2/xmJcnLTcjdBfP5hsxSBk="
+
 matrix:
   allow_failures:
     - jdk: oraclejdk9
@@ -27,4 +33,7 @@ branches:
 before_install: 
   - "npm install -g grunt-cli bower@1.3.9"
 
-script: "mvn verify javadoc:jar"
+script: 
+- mvn verify javadoc:jar
+- mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent package sonar:sonar
+

--- a/pom.xml
+++ b/pom.xml
@@ -124,8 +124,7 @@
                 <version>${slfj4.version}</version>
                 <scope>test</scope>
             </dependency>
-
-        </dependencies>
+         </dependencies>
     </dependencyManagement>
 
     <build>
@@ -170,7 +169,11 @@
                     </execution>
                 </executions>
             </plugin>
-
+            <plugin>
+                <groupId>org.sonarsource.scanner.maven</groupId>
+                <artifactId>sonar-maven-plugin</artifactId>
+                <version>3.3.0.603</version>
+             </plugin>
         </plugins>
         <pluginManagement>
             <plugins>


### PR DESCRIPTION
I would like to have UPS visible on SonarCloud, which gives us much more Open Source Visibility. SonarCloud (SonarQube) is a good way for developers to join a community and makes sniping at technical debt an easy entry to the community. The changes are two fold:

In the POM adding a one liner so you can run the Sonar Analysis through the Travis file. The travis file might need some work but I have included the main details with the secure hashed password to talk to and gain access to SonarCloud.

Would you see a benefit in adding local Sonar support? Very easy to stitch into the POM so that a user can locally execute it and point towards a local installation of Sonar. With the automation in Travis handling the more formal handover!

Ping @matzew 