### PR TITLE
Initial support for some Prometheus Metrics

### DIFF
--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -95,6 +95,13 @@
             <version>1.3.1</version>
             <scope>compile</scope>
         </dependency>
+
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient_common</artifactId>
+            <version>${prometheus.simpleclient.version}</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/prometheus/SimplePrometheusEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/prometheus/SimplePrometheusEndpoint.java
@@ -1,0 +1,46 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright Red Hat, Inc., and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.aerogear.unifiedpush.rest.prometheus;
+
+import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.exporter.common.TextFormat;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.StreamingOutput;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+
+@Path("/prometheus")
+public class SimplePrometheusEndpoint {
+
+
+    @GET
+    @Path("/metrics")
+    @Produces(MediaType.TEXT_PLAIN)
+    public StreamingOutput metrics() {
+
+        return output -> {
+            try (final Writer writer = new OutputStreamWriter(output)) {
+                TextFormat.write004(writer, CollectorRegistry.defaultRegistry.metricFamilySamples());
+            }
+        };
+    }
+
+}

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/installations/InstallationRegistrationEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/installations/InstallationRegistrationEndpoint.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.qmino.miredot.annotations.BodyType;
 import com.qmino.miredot.annotations.ReturnType;
+import io.prometheus.client.Counter;
 import org.jboss.aerogear.unifiedpush.api.Installation;
 import org.jboss.aerogear.unifiedpush.api.Variant;
 import org.jboss.aerogear.unifiedpush.api.validation.DeviceTokenValidator;
@@ -59,6 +60,11 @@ public class InstallationRegistrationEndpoint extends AbstractBaseEndpoint {
 
     // at some point we should move the mapper to a util class.?
     public static final ObjectMapper mapper = new ObjectMapper();
+
+    private static final Counter promDeviceRegisterRequestsTotal = Counter.build()
+            .name("device_register_requests_total")
+            .help("Total number of Device register requests.")
+            .register();
 
     private final Logger logger = LoggerFactory.getLogger(InstallationRegistrationEndpoint.class);
     @Inject
@@ -160,6 +166,8 @@ public class InstallationRegistrationEndpoint extends AbstractBaseEndpoint {
             @DefaultValue("") @HeaderParam("x-ag-old-token") final String oldToken,
             Installation entity,
             @Context HttpServletRequest request) {
+
+        promDeviceRegisterRequestsTotal.inc();
 
         // find the matching variation:
         final Variant variant = loadVariantWhenAuthorized(request);

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/sender/PushNotificationSenderEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/sender/PushNotificationSenderEndpoint.java
@@ -18,6 +18,7 @@ package org.jboss.aerogear.unifiedpush.rest.sender;
 
 import com.qmino.miredot.annotations.BodyType;
 import com.qmino.miredot.annotations.ReturnType;
+import io.prometheus.client.Counter;
 import org.jboss.aerogear.unifiedpush.api.PushApplication;
 import org.jboss.aerogear.unifiedpush.message.InternalUnifiedPushMessage;
 import org.jboss.aerogear.unifiedpush.message.NotificationRouter;
@@ -43,6 +44,12 @@ import javax.ws.rs.core.Response.Status;
 public class PushNotificationSenderEndpoint {
 
     private final Logger logger = LoggerFactory.getLogger(PushNotificationSenderEndpoint.class);
+
+    private static final Counter promPrushRequestsTotal = Counter.build()
+            .name("push_requests_total")
+            .help("Total number of push requests.")
+            .register();
+
     @Inject
     private PushApplicationService pushApplicationService;
     @Inject
@@ -89,6 +96,8 @@ public class PushNotificationSenderEndpoint {
     @BodyType("org.jboss.aerogear.unifiedpush.message.UnifiedPushMessage")
     @ReturnType("org.jboss.aerogear.unifiedpush.rest.EmptyJSON")
     public Response send(final InternalUnifiedPushMessage message, @Context HttpServletRequest request) {
+
+        promPrushRequestsTotal.inc();
 
         final PushApplication pushApplication = loadPushApplicationWhenAuthorized(request);
         if (pushApplication == null) {

--- a/pom.xml
+++ b/pom.xml
@@ -222,6 +222,7 @@
         <org.jacoco.jacoco-maven-plugin.version>0.7.9</org.jacoco.jacoco-maven-plugin.version>
         <ant.contrib.version>20020829</ant.contrib.version>
         <aerogear.crypto.version>0.1.5</aerogear.crypto.version>
+        <prometheus.simpleclient.version>0.1.0</prometheus.simpleclient.version>
         <ups.ddl_value>update</ups.ddl_value>
     </properties>
 

--- a/servers/src/main/webapp/WEB-INF/web.xml
+++ b/servers/src/main/webapp/WEB-INF/web.xml
@@ -30,6 +30,7 @@
             <description>Matches a few special URLs, not protected by Keycloak</description>
             <url-pattern>/rest/registry/device/*</url-pattern>
             <url-pattern>/rest/sender/*</url-pattern>
+            <url-pattern>/rest/prometheus/*</url-pattern>
         </web-resource-collection>
     </security-constraint>
 


### PR DESCRIPTION
Two metrics currently implemented:
* calls of the "Sender", seen here:
![screenshot from 2017-12-11 14-03-47](https://user-images.githubusercontent.com/157646/33832499-ad09ebe6-de7c-11e7-9971-2a2cea6f6365.png)

* calls to the "Device registration" 

**NOTE:** The URL of the endpoint is `HOST:PORT/ag-push/rest/prometheus/metrics` 

So, calling `curl http://192.168.0.45:9191/ag-push/rest/prometheus/metrics` will give you something like this:
```
# HELP device_register_requests_total Total number of Device register requests.
# TYPE device_register_requests_total counter
device_register_requests_total 2.0
# HELP push_requests_total Total number of push requests.
# TYPE push_requests_total counter
push_requests_total 1.0
```
