### PR TITLE
Fix and upgrade of OpenShift template

### DIFF
--- a/openshift/README.md
+++ b/openshift/README.md
@@ -1,15 +1,46 @@
-# UnifiedPush Server in OpenShift 
+# UnifiedPush Server in OpenShift
 
 Make sure you have at least two 1G persistent volumes provisioned, then create a new project:
+
 ```bash
 $ oc new-project ups
 ```
 
-Create the OpenShift UPS application: 
+UPS Templates for OpenShift comes in 2 flavors:
+* `ups-template.json` is there for deploying UPS components only and relies on an existing Keycloak instance,
+* `ups-keycloak-template.yaml` is a convenient template that deploys UPS and a new Keycloak instance within the same OpenShift project.
+
+Create the OpenShift UPS application using chosen template with parameters:
+
 ```bash
-$ oc new-app -f ups-template.json -n ups
+$ oc new-app -f ups-template.json --param=NAME=VALUE [...] -n ups
 ```
 
-Run `oc get pods -w` and monitor until all pods are in the `Running` state, and you're good to go. 
-The UnifiedPush server should be available at `http://ups.127.0.0.1.nip.io/ag-push`.
+Or register template within namespace for a later instanciation of components through OpenShift console:
 
+```bash
+$ oc create -f ups-template.json  -n ups
+```
+
+Run `oc get pods -w` and monitor until all pods are in the `Running` state, and you're good to go.
+The UnifiedPush server should be available at URL your specify with `UPS_URL` explained below.
+
+Databases user and password settings are stored within Secrets into OpenShift.
+
+## Common parameters
+
+These are the common mandatory parameters for the templates:
+* `UPS_URL` is the URL of UPS as reachable through the OpenShift route. Example: `ups-<project>.apps.domain.com`
+* `KEYCLOAK_HOSTNAME` is the hostname of Keycloak instance to use. Example: `keycloak-<project>.apps.domain.com`
+* `KEYCLOAK_PORT` is the port of Keycloak route. `80` for HTTP route (not production ready!), `443` for HTTPS route.
+
+These are the common optional parameters for the templates that can overwritten:
+* `UPS_IMAGE` references the container image used for UPS server.
+* `UPS_DB_SIZE` is the default size of PV claim for UPS database (1Gi is the default).
+* `MYSQL_IMAGE` references the container image used for database.
+
+## Specific parameters for Keycloak template
+
+These are optional parameters for the complete template:
+* `KEYCLOAK_IMAGE` references the container image used for Keycloak server.
+* `KEYCLOAK_DB_SIZE` is the default size of PV claim for Keycloak database (1Gi is the default).

--- a/openshift/ups-keycloak-template.yaml
+++ b/openshift/ups-keycloak-template.yaml
@@ -1,7 +1,7 @@
 kind: "Template"
 apiVersion: "v1"
 metadata:
-  name: "aerogear-unified-push-wit-keycloak"
+  name: "aerogear-unified-push-with-keycloak"
   annotations:
     description: "The AeroGear Unified Push Server provides an API and web console for sending push messages to Android, iOS, Windows Phone, and other push messaging services. This templates embeds the deployment of a Keycloak server."
     tags: mobile
@@ -35,12 +35,12 @@ parameters:
   - name: KEYCLOAK_IMAGE
     displayName: Keycloak Image
     description: Docker image to use for the Keycloak Server
-    value: jboss/keycloak-openshift:3.4.0.Final
+    value: jboss/keycloak-openshift:3.4.3.Final
     required: true
   - name: UPS_IMAGE
     displayName: UPS Image
     description: Docker image to use for the UPS Server
-    value: aerogear/unifiedpush-wildfly:1.2.1.3
+    value: aerogear/unifiedpush-wildfly:1.2.3
     required: true
   - name: UPS_DB_SIZE
     displayName: UPS DB Size

--- a/openshift/ups-keycloak-template.yaml
+++ b/openshift/ups-keycloak-template.yaml
@@ -1,0 +1,555 @@
+kind: "Template"
+apiVersion: "v1"
+metadata:
+  name: "aerogear-unified-push-wit-keycloak"
+  annotations:
+    description: "The AeroGear Unified Push Server provides an API and web console for sending push messages to Android, iOS, Windows Phone, and other push messaging services. This templates embeds the deployment of a Keycloak server."
+    tags: mobile
+    iconClass: icon-node
+parameters:
+  - name: NAMESPACE
+    displayName: Namespace
+    description: The OpenShift Namespace where the ImageStream resides.
+    value: openshift
+    required: true
+  - name: UPS_URL
+    displayName: UPS URL
+    description: This is the url that will be the base route to the UPS server.
+    value: ups-namespace.pro-eu-west-1.openshiftapps.com
+    required: true
+  - name: KEYCLOAK_HOSTNAME
+    displayName: Keycloak URL
+    description: The URL of the running keycloak service with the aerogear realm.
+    value: keycloak-namespace.pro-eu-west-1.openshiftapps.com
+    required: true
+  - name: KEYCLOAK_PORT
+    displayName: Keycloak Port
+    description: The Port of the running keycloak service with the aerogear realm.
+    value:  '80'
+    required: true
+  - name: MYSQL_IMAGE
+    displayName: MySQL Image
+    description: Docker image to use for the MySQL database servers
+    value: centos/mysql-57-centos7
+    required: true
+  - name: KEYCLOAK_IMAGE
+    displayName: Keycloak Image
+    description: Docker image to use for the Keycloak Server
+    value: jboss/keycloak-openshift:3.4.0.Final
+    required: true
+  - name: UPS_IMAGE
+    displayName: UPS Image
+    description: Docker image to use for the UPS Server
+    value: aerogear/unifiedpush-wildfly:1.2.1.3
+    required: true
+  - name: UPS_DB_SIZE
+    displayName: UPS DB Size
+    description: Size of Persistent Volume dedicated to UPS database
+    value: 1Gi
+    required: true
+  - name: UPS_DB_USER
+    displayName: Username for DB
+    description: Username for UPS MySQL database
+    generate: expression
+    from: user[A-Z0-9]{8}
+    required: true
+  - name: UPS_DB_PASSWORD
+    displayName: Password for DB
+    description: Password for UPS MySQL database
+    generate: expression
+    from: '[a-zA-Z0-9]{16}'
+    required: true
+  - name: UPS_DB_ROOT_PASSWORD
+    displayName: Root Password for DB
+    description: Root Password for UPS MySQL database
+    generate: expression
+    from: '[a-zA-Z0-9]{16}'
+    required: true
+  - name: KEYCLOAK_DB_SIZE
+    displayName: Keycloak DB Size
+    description: Size of Persistent Volume dedicated to Keycloak database
+    value: 1Gi
+    required: true
+  - name: KEYCLOAK_DB_USER
+    displayName: Username for Keycloak DB
+    description: Username for Keycloak MySQL database
+    generate: expression
+    from: 'user[A-Z0-9]{8}'
+    required: true
+  - name: KEYCLOAK_DB_PASSWORD
+    displayName: Password for Keycloak DB
+    description: Password for Keycloak MySQL database
+    generate: expression
+    from: '[a-zA-Z0-9]{16}'
+    required: true
+  - name: KEYCLOAK_DB_ROOT_PASSWORD
+    displayName: Root Password for Keycloak DB
+    description: Root Password for Keycloak MySQL database
+    generate: expression
+    from: '[a-zA-Z0-9]{16}'
+    required: true
+objects:
+  - kind: Secret
+    apiVersion: v1
+    metadata:
+      name: unifiedpush
+    stringData:
+      database-user: "${UPS_DB_USER}"
+      database-password: "${UPS_DB_PASSWORD}"
+      database-root-password: "${UPS_DB_ROOT_PASSWORD}"
+  - kind: Secret
+    apiVersion: v1
+    metadata:
+      name: keycloak-mysql
+    stringData:
+      database-user: "${KEYCLOAK_DB_USER}"
+      database-password: "${KEYCLOAK_DB_PASSWORD}"
+      database-root-password: "${KEYCLOAK_DB_ROOT_PASSWORD}"
+  - kind: Service
+    apiVersion: v1
+    metadata:
+      name: unifiedpush
+    spec:
+      ports:
+        - name: mysql
+          port: 3306
+      selector:
+        name: unifiedpush
+  - kind: Service
+    apiVersion: v1
+    metadata:
+      name: keycloak-mysql
+    spec:
+      ports:
+        - name: mysql
+          port: 3306
+      selector:
+        name: keycloak-mysql
+  - kind: PersistentVolumeClaim
+    apiVersion: v1
+    metadata:
+      name: unifiedpush
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: "${UPS_DB_SIZE}"
+  - kind: PersistentVolumeClaim
+    apiVersion: v1
+    metadata:
+      name: keycloak-mysql
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: "${KEYCLOAK_DB_SIZE}"
+  - kind: DeploymentConfig
+    apiVersion: v1
+    metadata:
+      name: unifiedpush
+    spec:
+      strategy:
+        type: Recreate
+      triggers:
+        - type: ConfigChange
+      replicas: 1
+      selector:
+        name: unifiedpush
+      template:
+        metadata:
+          labels:
+            name: unifiedpush
+        spec:
+          containers:
+            - name: mysql
+              image: "${MYSQL_IMAGE}"
+              ports:
+                - containerPort: 3306
+              readinessProbe:
+                timeoutSeconds: 1
+                initialDelaySeconds: 5
+                exec:
+                  command:
+                    - "/bin/sh"
+                    - "-i"
+                    - "-c"
+                    - MYSQL_PWD="$MYSQL_PASSWORD" mysql -h 127.0.0.1 -u $MYSQL_USER -D unifiedpush
+                      -e 'SELECT 1'
+              livenessProbe:
+                timeoutSeconds: 1
+                initialDelaySeconds: 30
+                tcpSocket:
+                  port: 3306
+              env:
+                - name: MYSQL_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: unifiedpush
+                      key: database-user
+                - name: MYSQL_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: unifiedpush
+                      key: database-password
+                - name: MYSQL_ROOT_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: unifiedpush
+                      key: database-root-password
+                - name: MYSQL_DATABASE
+                  value: unifiedpush
+              resources:
+                limits:
+                  memory: 512Mi
+              volumeMounts:
+                - name: unifiedpush-data
+                  mountPath: "/var/lib/mysql/data"
+              imagePullPolicy: IfNotPresent
+          volumes:
+            - name: unifiedpush-data
+              persistentVolumeClaim:
+                claimName: unifiedpush
+  - kind: DeploymentConfig
+    apiVersion: v1
+    metadata:
+      name: keycloak-mysql
+    spec:
+      strategy:
+        type: Recreate
+      triggers:
+        - type: ConfigChange
+      replicas: 1
+      selector:
+        name: keycloak-mysql
+      template:
+        metadata:
+          labels:
+            name: keycloak-mysql
+        spec:
+          containers:
+            - name: mysql
+              image: "${MYSQL_IMAGE}"
+              ports:
+                - containerPort: 3306
+              readinessProbe:
+                timeoutSeconds: 1
+                initialDelaySeconds: 5
+                exec:
+                  command:
+                    - "/bin/sh"
+                    - "-i"
+                    - "-c"
+                    - MYSQL_PWD="$MYSQL_PASSWORD" mysql -h 127.0.0.1 -u $MYSQL_USER -D keycloak
+                      -e 'SELECT 1'
+              livenessProbe:
+                timeoutSeconds: 1
+                initialDelaySeconds: 30
+                tcpSocket:
+                  port: 3306
+              env:
+                - name: MYSQL_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: keycloak-mysql
+                      key: database-user
+                - name: MYSQL_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: keycloak-mysql
+                      key: database-password
+                - name: MYSQL_ROOT_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: keycloak-mysql
+                      key: database-root-password
+                - name: MYSQL_DATABASE
+                  value: keycloak
+              resources:
+                limits:
+                  memory: 512Mi
+              volumeMounts:
+                - name: keycloak-data
+                  mountPath: "/var/lib/mysql/data"
+              imagePullPolicy: IfNotPresent
+          volumes:
+            - name: keycloak-data
+              persistentVolumeClaim:
+                claimName: keycloak-mysql
+  - kind: Route
+    apiVersion: v1
+    metadata:
+      name: ups-localhost-unsecure
+    spec:
+      host: "${UPS_URL}"
+      to:
+        kind: Service
+        name: unifiedpush-server
+        weight: 100
+      port:
+        targetPort: 8080-tcp
+      wildcardPolicy: None
+  - kind: Route
+    apiVersion: v1
+    metadata:
+      name: keycloak-localhost-unsecure
+    spec:
+      host: "${KEYCLOAK_HOSTNAME}"
+      to:
+        kind: Service
+        name: keycloak
+      port:
+        targetPort: keycloak
+  - kind: Service
+    apiVersion: v1
+    metadata:
+      name: unifiedpush-server
+    spec:
+      ports:
+        - name: 8080-tcp
+          protocol: TCP
+          port: 8080
+          targetPort: 8080
+        - name: 8443-tcp
+          protocol: TCP
+          port: 8443
+          targetPort: 8443
+      selector:
+        deploymentconfig: unifiedpush-server
+  - kind: Service
+    apiVersion: v1
+    metadata:
+      name: keycloak
+    spec:
+      ports:
+      - protocol: TCP
+        port: 8080
+        targetPort: 8080
+        name: keycloak
+      - name: 8443-tcp
+        protocol: TCP
+        port: 8443
+        targetPort: 8443
+      selector:
+        deploymentconfig: keycloak
+  - kind: DeploymentConfig
+    apiVersion: v1
+    metadata:
+      name: unifiedpush-server
+    spec:
+      triggers:
+        - type: ConfigChange
+      replicas: 1
+      test: false
+      selector:
+        app: unifiedpush-server
+        deploymentconfig: unifiedpush-server
+      template:
+        metadata:
+          labels:
+            app: unifiedpush-server
+            deploymentconfig: unifiedpush-server
+        spec:
+          containers:
+            - name: unifiedpush-server
+              image: "${UPS_IMAGE}"
+              imagePullPolicy: Always
+              ports:
+                - name: 8080-tcp
+                  containerPort: 8080
+                  protocol: TCP
+                - name: 8443-tcp
+                  containerPort: 8443
+                  protocol: TCP
+              readinessProbe:
+                timeoutSeconds: 1
+                initialDelaySeconds: 90
+                exec:
+                  command:
+                    - "/bin/sh"
+                    - "-i"
+                    - "-c"
+                    - 'wget http://localhost:8080/ag-push '
+              env:
+                - name: MYSQL_SERVICE_HOST
+                  value: unifiedpush
+                - name: MYSQL_SERVICE_PORT
+                  value: '3306'
+                - name: MYSQL_DATABASE
+                  value: unifiedpush
+                - name: MYSQL_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: unifiedpush
+                      key: database-user
+                - name: MYSQL_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: unifiedpush
+                      key: database-password
+                - name: KEYCLOAK_SERVICE_HOST
+                  value: ${KEYCLOAK_HOSTNAME}
+                - name: KEYCLOAK_SERVICE_PORT
+                  value: "${KEYCLOAK_PORT}"
+              resources:
+                limits:
+                  memory: 800Mi
+  - kind: ConfigMap
+    apiVersion: v1
+    metadata:
+      name: "unifiedpush-keycloak-config"
+    data:
+      unifiedpush-realm.json: |-
+        {
+          "realm": "aerogear",
+          "enabled": true,
+          "accessTokenLifespan": 60,
+          "accessCodeLifespan": 60,
+          "accessCodeLifespanUserAction": 300,
+          "ssoSessionIdleTimeout": 600,
+          "ssoSessionMaxLifespan": 36000,
+          "sslRequired": "external",
+          "registrationAllowed": false,
+          "social": false,
+          "updateProfileOnInitialSocialLogin": false,
+          "requiredCredentials": [ "password" ],
+          "defaultRoles": [ "developer" ],
+          "users" : [
+            {
+              "username" : "admin",
+              "enabled": true,
+              "credentials" : [
+                  { "type" : "password",
+                  "value" : "123" }
+              ],
+              "requiredActions": [
+                  "UPDATE_PASSWORD"
+              ],
+              "realmRoles": [ "admin" ],
+              "applicationRoles": {
+                 "realm-management": [ "realm-admin" ],
+                 "account": [ "manage-account" ]
+              }
+            }
+          ],
+          "roles" : {
+            "realm" : [
+              {
+                "name": "admin",
+                "description": "Administrator privileges"
+              },
+              {
+                "name": "developer",
+                "description": "Developer privileges"
+              }
+            ]
+          },
+          "scopeMappings": [
+            {
+              "client": "unified-push-server-js",
+              "roles": ["admin", "developer"]
+            }
+          ],
+          "applications": [
+            {
+              "name": "unified-push-server",
+              "enabled": true,
+              "bearerOnly": true
+            },
+            {
+              "name": "unified-push-server-js",
+              "enabled": true,
+              "publicClient": true,
+              "webOrigins": [
+                "+"
+              ],
+              "redirectUris": [
+                "http://${UPS_URL}/*"
+              ]
+            }
+          ]
+        }
+  - kind: DeploymentConfig
+    apiVersion: v1
+    metadata:
+      name: "keycloak"
+    spec:
+      strategy:
+        type: Recreate
+      triggers:
+      - type: ConfigChange
+      replicas: 1
+      selector:
+        name: keycloak
+      template:
+        metadata:
+          creationTimestamp:
+          labels:
+            name: keycloak
+        spec:
+          containers:
+          - name: keycloak-server
+            image: "${KEYCLOAK_IMAGE}"
+            ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+            - name: 8443-tcp
+              containerPort: 8443
+              protocol: TCP
+            - name: jolokia
+              containerPort: 8778
+              protocol: TCP
+            args:
+            - start-keycloak.sh
+            - "-b $(INTERNAL_POD_IP)"
+            - "-Djgroups.bind_addr=global"
+            - "-Djboss.node.name=$(INTERNAL_POD_IP)"
+            - "-Dkeycloak.import=/opt/jboss/keycloak/standalone/configuration/realm/unifiedpush-realm.json"
+            env:
+            - name: INTERNAL_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: KEYCLOAK_USER
+              value: admin
+            - name: KEYCLOAK_PASSWORD
+              value: "123"
+            - name: OPERATING_MODE
+              value: clustered
+            - name: DB_VENDOR
+              value: MYSQL
+            - name: MYSQL_USER
+              valueFrom:
+                secretKeyRef:
+                  name: keycloak-mysql
+                  key: database-user
+            - name: MYSQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: keycloak-mysql
+                  key: database-password
+            - name: MYSQL_DATABASE
+              value: keycloak
+            - name: MYSQL_PORT_3306_TCP_ADDR
+              value: keycloak-mysql
+            - name: MYSQL_PORT_3306_TCP_PORT
+              value: "3306"
+            - name: OPENSHIFT_KUBE_PING_LABELS
+              value: deploymentconfig=keycloak
+            - name: OPENSHIFT_KUBE_PING_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            volumeMounts:
+            - name: unifiedpush-keycloak-config
+              mountPath: "/opt/jboss/keycloak/standalone/configuration/realm"
+            securityContext:
+              privileged: false
+          volumes:
+          - name: "unifiedpush-keycloak-config"
+            configMap:
+              name: "unifiedpush-keycloak-config"
+          restartPolicy: Always
+          dnsPolicy: ClusterFirst

--- a/openshift/ups-template.json
+++ b/openshift/ups-template.json
@@ -44,7 +44,7 @@
       "name": "UPS_IMAGE",
       "displayName": "UPS Image",
       "description": "Docker image to use for the UPS Server",
-      "value": "aerogear/unifiedpush-wildfly:1.2.1.3"
+      "value": "aerogear/unifiedpush-wildfly:1.2.3"
     },
     {
       "name": "UPS_DB_SIZE",

--- a/openshift/ups-template.json
+++ b/openshift/ups-template.json
@@ -23,6 +23,18 @@
       "value": "ups.127.0.0.1.nip.io"
     },
     {
+      "name": "KEYCLOAK_HOSTNAME",
+      "displayName": "Keycloak Hostame",
+      "description": "The URL of the running Keycloak with the Aerogear UPS realm.",
+      "value": "keycloak.127.0.0.1.nip.io"
+    },
+    {
+      "name": "KEYCLOAK_PORT",
+      "displayName": "Keycloak Port",
+      "description": "The port the running Keycloak with the Aerogear UPS realm (80 for http route, 443 for https route).",
+      "value": "443"
+    },
+    {
       "name": "MYSQL_IMAGE",
       "displayName": "MySQL Image",
       "description": "Docker image to use for the MySQL database servers",
@@ -32,7 +44,38 @@
       "name": "UPS_IMAGE",
       "displayName": "UPS Image",
       "description": "Docker image to use for the UPS Server",
-      "value": "aerogear/unifiedpush-wildfly"
+      "value": "aerogear/unifiedpush-wildfly:1.2.1.3"
+    },
+    {
+      "name": "UPS_DB_SIZE",
+      "displayName": "UPS DB Size",
+      "description": "Size of Persistent Volume dedicated to UPS database",
+      "value": "1Gi",
+      "required": true
+    },
+    {
+      "name": "UPS_DB_USER",
+      "displayName": "Username for DB",
+      "description": "Username for UPS MySQL database",
+      "generate": "expression",
+      "from": "user[A-Z0-9]{8}",
+      "required": true
+    },
+    {
+      "name": "UPS_DB_PASSWORD",
+      "displayName": "Password for DB",
+      "description": "Password for UPS MySQL database",
+      "generate": "expression",
+      "from": "[a-zA-Z0-9]{16}",
+      "required": true
+    },
+    {
+      "name": "UPS_DB_ROOT_PASSWORD",
+      "displayName": "Root Password for DB",
+      "description": "Root Password for UPS MySQL database",
+      "generate": "expression",
+      "from": "[a-zA-Z0-9]{16}",
+      "required": true
     }
   ],
   "objects": [
@@ -43,9 +86,9 @@
         "name": "unifiedpush"
       },
       "stringData": {
-        "database-user": "unifiedpush",
-        "database-password": "unifiedpush",
-        "database-root-password": "unifiedpush"
+        "database-user": "${UPS_DB_USER}",
+        "database-password": "${UPS_DB_PASSWORD}",
+        "database-root-password": "${UPS_DB_ROOT_PASSWORD}"
       }
     },
     {
@@ -78,7 +121,7 @@
         ],
         "resources": {
           "requests": {
-            "storage": "1Gi"
+            "storage": "${UPS_DB_SIZE}"
           }
         }
       }
@@ -126,7 +169,7 @@
                       "/bin/sh",
                       "-i",
                       "-c",
-                      "MYSQL_PWD=\"unifiedpush\" mysql -h 127.0.0.1 -u $MYSQL_USER -D unifiedpush -e 'SELECT 1'"
+                      "MYSQL_PWD=\"$MYSQL_PASSWORD\" mysql -h 127.0.0.1 -u $MYSQL_USER -D unifiedpush -e 'SELECT 1'"
                     ]
                   }
                 },
@@ -140,15 +183,29 @@
                 "env": [
                   {
                     "name": "MYSQL_USER",
-                    "value": "unifiedpush"
+                    "valueFrom": {
+                      "secretKeyRef": {
+                        "name": "unifiedpush",
+                        "key": "database-user"
+                      }
+                    }
                   },
                   {
                     "name": "MYSQL_PASSWORD",
-                    "value": "unifiedpush"
-                  },
+                    "valueFrom": {
+                      "secretKeyRef": {
+                        "name": "unifiedpush",
+                        "key": "database-password"
+                      }
+                    }
                   {
                     "name": "MYSQL_ROOT_PASSWORD",
-                    "value": "unifiedpush"
+                    "valueFrom": {
+                      "secretKeyRef": {
+                        "name": "unifiedpush",
+                        "key": "database-root-password"
+                      }
+                    }
                   },
                   {
                     "name": "MYSQL_DATABASE",
@@ -174,151 +231,6 @@
                 "name": "unifiedpush-data",
                 "persistentVolumeClaim": {
                   "claimName": "unifiedpush"
-                }
-              }
-            ]
-          }
-        }
-      }
-    },
-    {
-      "kind": "Secret",
-      "apiVersion": "v1",
-      "metadata": {
-        "name": "keycloak-mysql"
-      },
-      "stringData": {
-        "database-user": "keycloak",
-        "database-password": "keycloak",
-        "database-root-password": "keycloak"
-      }
-    },
-    {
-      "kind": "Service",
-      "apiVersion": "v1",
-      "metadata": {
-        "name": "keycloak-mysql"
-      },
-      "spec": {
-        "ports": [
-          {
-            "name": "mysql",
-            "port": 3306
-          }
-        ],
-        "selector": {
-          "name": "keycloak-mysql"
-        }
-      }
-    },
-    {
-      "kind": "PersistentVolumeClaim",
-      "apiVersion": "v1",
-      "metadata": {
-        "name": "keycloak-mysql"
-      },
-      "spec": {
-        "accessModes": [
-          "ReadWriteOnce"
-        ],
-        "resources": {
-          "requests": {
-            "storage": "1Gi"
-          }
-        }
-      }
-    },
-    {
-      "kind": "DeploymentConfig",
-      "apiVersion": "v1",
-      "metadata": {
-        "name": "keycloak-mysql"
-      },
-      "spec": {
-        "strategy": {
-          "type": "Recreate"
-        },
-        "triggers": [
-          {
-            "type": "ConfigChange"
-          }
-        ],
-        "replicas": 1,
-        "selector": {
-          "name": "keycloak-mysql"
-        },
-        "template": {
-          "metadata": {
-            "labels": {
-              "name": "keycloak-mysql"
-            }
-          },
-          "spec": {
-            "containers": [
-              {
-                "name": "mysql",
-                "image": "${MYSQL_IMAGE}",
-                "ports": [
-                  {
-                    "containerPort": 3306
-                  }
-                ],
-                "readinessProbe": {
-                  "timeoutSeconds": 1,
-                  "initialDelaySeconds": 5,
-                  "exec": {
-                    "command": [
-                      "/bin/sh",
-                      "-i",
-                      "-c",
-                      "MYSQL_PWD=\"keycloak\" mysql -h 127.0.0.1 -u $MYSQL_USER -D keycloak -e 'SELECT 1'"
-                    ]
-                  }
-                },
-                "livenessProbe": {
-                  "timeoutSeconds": 1,
-                  "initialDelaySeconds": 30,
-                  "tcpSocket": {
-                    "port": 3306
-                  }
-                },
-                "env": [
-                  {
-                    "name": "MYSQL_USER",
-                    "value": "keycloak"
-                  },
-                  {
-                    "name": "MYSQL_PASSWORD",
-                    "value": "keycloak"
-                  },
-                  {
-                    "name": "MYSQL_ROOT_PASSWORD",
-                    "value": "keycloak"
-                  },
-                  {
-                    "name": "MYSQL_DATABASE",
-                    "value": "keycloak"
-                  }
-                ],
-                "resources": {
-                  "limits": {
-                    "memory": "512Mi"
-                  }
-                },
-                "volumeMounts": [
-                  {
-                    "name": "keycloak-data",
-                    "mountPath": "/var/lib/mysql/data"
-                  }
-                ],
-                "imagePullPolicy": "IfNotPresent"
-              }
-            ],
-            "volumes": [
-              {
-                "name": "keycloak-data",
-                "persistentVolumeClaim": {
-                  "claimName": "keycloak-mysql"
                 }
               }
             ]
@@ -439,32 +351,30 @@
                     "value": "unifiedpush"
                   },
                   {
-                    "name": "KEYCLOAK_PORT_3306_TCP_ADDR",
-                    "value": "keycloak-mysql"
-                  },
-                  {
-                    "name": "KEYCLOAK_PORT_3306_TCP_PORT",
-                    "value": "3306"
-                  },
-                  {
-                    "name": "KEYCLOAK_ENV_MYSQL_DATABASE",
-                    "value": "keycloak"
-                  },
-                  {
                     "name": "UNIFIEDPUSH_ENV_MYSQL_USER",
-                    "value": "unifiedpush"
+                    "valueFrom": {
+                      "secretKeyRef": {
+                        "name": "unifiedpush",
+                        "key": "database-user"
+                      }
+                    }
                   },
                   {
                     "name": "UNIFIEDPUSH_ENV_MYSQL_PASSWORD",
-                    "value": "unifiedpush"
+                    "valueFrom": {
+                      "secretKeyRef": {
+                        "name": "unifiedpush",
+                        "key": "database-password"
+                      }
+                    }
                   },
                   {
-                    "name": "KEYCLOAK_ENV_MYSQL_USER",
-                    "value": "keycloak"
+                    "name": "KEYCLOAK_SERVICE_HOST",
+                    "value": "${KEYCLOAK_HOSTNAME}"
                   },
                   {
-                    "name": "KEYCLOAK_ENV_MYSQL_PASSWORD",
-                    "value": "keycloak"
+                    "name": "KEYCLOAK_SERVICE_PORT",
+                    "value": "${KEYCLOAK_PORT}"
                   }
                 ],
                 "resources": {}


### PR DESCRIPTION
Hi, 

I've had to deploy UPS in production on OpenShift Online lately, and provided template was not "production-ready" (was not using Secret) and actually a little buggy.

I've patched the provided one by:
* adding secret management for provided templates
* removing Keycloak parameters that are now in dedicated external deployment

I have also added a new template embedding Keycloak for convenience.

This PR is related to https://github.com/aerogear/dockerfiles/pull/39 that should be applied to produce a Docker image able to reference a Keycloak instance running into OpenShift and reached through a Route (though on default http and https ports).