### PR TITLE
Allow Search Manager to work in different security contexts/environments

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -34,7 +34,11 @@
             <version>${project.version}</version>
             <scope>compile</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.jboss.spec.javax.servlet</groupId>
+            <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <profiles>
@@ -56,6 +60,18 @@
                     <artifactId>assertj-core</artifactId>
                     <scope>test</scope>
                 </dependency>
+                <dependency>
+                    <groupId>org.assertj</groupId>
+                    <artifactId>assertj-core</artifactId>
+                    <scope>test</scope>
+                </dependency>
+
+                <dependency>
+                    <groupId>org.mockito</groupId>
+                    <artifactId>mockito-core</artifactId>
+                    <scope>test</scope>
+                </dependency>
+
 
             </dependencies>
         </profile>

--- a/common/src/main/java/org/jboss/aerogear/unifiedpush/auth/HttpBasicHelper.java
+++ b/common/src/main/java/org/jboss/aerogear/unifiedpush/auth/HttpBasicHelper.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.aerogear.unifiedpush.rest.util;
+package org.jboss.aerogear.unifiedpush.auth;
 
 
 import javax.servlet.http.HttpServletRequest;
@@ -29,24 +29,24 @@ public final class HttpBasicHelper {
     private HttpBasicHelper() {
     }
 
-    private static boolean isBasic(String authorizationHeader) {
+    private static boolean isBasic(final String authorizationHeader) {
         return authorizationHeader.startsWith(HTTP_BASIC_SCHEME);
     }
 
-    private static String getAuthorizationHeader(HttpServletRequest request) {
+    private static String getAuthorizationHeader(final HttpServletRequest request) {
         return request.getHeader("Authorization");
     }
 
-    public static String[] extractUsernameAndPasswordFromBasicHeader(HttpServletRequest request) {
+    public static String[] extractUsernameAndPasswordFromBasicHeader(final HttpServletRequest request) {
         String username = "";
         String password = "";
-        String authorizationHeader = getAuthorizationHeader(request);
+        final String authorizationHeader = getAuthorizationHeader(request);
 
         if (authorizationHeader != null && isBasic(authorizationHeader)) {
             final String base64Token = authorizationHeader.substring(HTTP_BASIC_SCHEME.length());
             final String token = new String(Base64.getDecoder().decode(base64Token), StandardCharsets.UTF_8);
 
-            int delimiter = token.indexOf(':');
+            final int delimiter = token.indexOf(':');
 
             if (delimiter != -1) {
                 username = token.substring(0, delimiter);

--- a/common/src/test/java/org/jboss/aerogear/unifiedpush/auth/HttpBasicHelperTest.java
+++ b/common/src/test/java/org/jboss/aerogear/unifiedpush/auth/HttpBasicHelperTest.java
@@ -14,8 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.aerogear.unifiedpush.rest.util;
+package org.jboss.aerogear.unifiedpush.auth;
 
+import org.jboss.aerogear.unifiedpush.auth.HttpBasicHelper;
 import org.junit.Test;
 import org.mockito.Mockito;
 

--- a/dependencies/server-dependencies/pom.xml
+++ b/dependencies/server-dependencies/pom.xml
@@ -85,6 +85,32 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- Keycloak dependencies -->
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk16</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-core</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.codehaus.jackson</groupId>
+                    <artifactId>jackson-core-asl</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.jackson</groupId>
+                    <artifactId>jackson-mapper-asl</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-adapter-core</artifactId>
+        </dependency>
+
         <!-- resteasy -->
         <dependency>
             <groupId>org.jboss.resteasy</groupId>

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/installations/InstallationRegistrationEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/installations/InstallationRegistrationEndpoint.java
@@ -24,7 +24,7 @@ import org.jboss.aerogear.unifiedpush.api.Variant;
 import org.jboss.aerogear.unifiedpush.api.validation.DeviceTokenValidator;
 import org.jboss.aerogear.unifiedpush.rest.AbstractBaseEndpoint;
 import org.jboss.aerogear.unifiedpush.rest.EmptyJSON;
-import org.jboss.aerogear.unifiedpush.rest.util.HttpBasicHelper;
+import org.jboss.aerogear.unifiedpush.auth.HttpBasicHelper;
 import org.jboss.aerogear.unifiedpush.service.ClientInstallationService;
 import org.jboss.aerogear.unifiedpush.service.GenericVariantService;
 import org.jboss.aerogear.unifiedpush.service.metrics.PushMessageMetricsService;

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/sender/PushNotificationSenderEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/sender/PushNotificationSenderEndpoint.java
@@ -21,7 +21,7 @@ import org.jboss.aerogear.unifiedpush.api.PushApplication;
 import org.jboss.aerogear.unifiedpush.message.InternalUnifiedPushMessage;
 import org.jboss.aerogear.unifiedpush.message.NotificationRouter;
 import org.jboss.aerogear.unifiedpush.rest.EmptyJSON;
-import org.jboss.aerogear.unifiedpush.rest.util.HttpBasicHelper;
+import org.jboss.aerogear.unifiedpush.auth.HttpBasicHelper;
 import org.jboss.aerogear.unifiedpush.rest.util.HttpRequestUtil;
 import org.jboss.aerogear.unifiedpush.service.PushApplicationService;
 import org.slf4j.Logger;

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -135,6 +135,12 @@
                     <scope>provided</scope>
                 </dependency>
 
+                <dependency>
+                    <groupId>org.keycloak</groupId>
+                    <artifactId>keycloak-core</artifactId>
+                    <scope>provided</scope>
+                </dependency>
+
             </dependencies>
         </profile>
     </profiles>


### PR DESCRIPTION
* re-adding KC APIs to program against them, for env. checks
* refactoring: Moving `HttpBasicHelper` to our `common` module
* changing SearchManager to work in different envs