### PR TITLE
Latest UPS image and updating to Postgres

### DIFF
--- a/docker-compose/.env
+++ b/docker-compose/.env
@@ -1,10 +1,9 @@
 # env vars for interpolate mysql and app server services
-MYSQL_USER=unifiedpush
-MYSQL_PASSWORD=unifiedpush
-MYSQL_ROOT_PASSWORD=supersecret
-MYSQL_DATABASE=unifiedpush
-MYSQL_SERVICE_HOST=unifiedpush
-MYSQL_SERVICE_PORT=3306
+POSTGRES_USER=unifiedpush
+POSTGRES_PASSWORD=unifiedpush
+POSTGRES_DATABASE=unifiedpush
+POSTGRES_SERVICE_HOST=unifiedpush
+POSTGRES_SERVICE_PORT=5432
 KEYCLOAK_USER=admin
 KEYCLOAK_PASSWORD=admin
 KEYCLOAK_SERVICE_HOST=keycloak

--- a/docker-compose/docker-compose-v2.1.yaml
+++ b/docker-compose/docker-compose-v2.1.yaml
@@ -2,7 +2,7 @@ version: '2.1'
 
 services:
   unifiedpushserver:
-    image: docker.io/aerogear/unifiedpush-wildfly:1.3.0
+    image: docker.io/aerogear/unifiedpush-wildfly:2.0.0
     volumes:
        - ./helper:/ups-helper:z
     entrypoint: "/ups-helper/exportKeycloakHost.sh"
@@ -10,11 +10,11 @@ services:
        unifiedpushDB:
          condition: service_healthy
     environment:
-        MYSQL_SERVICE_HOST: ${MYSQL_SERVICE_HOST}
-        MYSQL_USER: ${MYSQL_USER}
-        MYSQL_PASSWORD: ${MYSQL_PASSWORD}
-        MYSQL_SERVICE_PORT: ${MYSQL_SERVICE_PORT}
-        MYSQL_DATABASE: ${MYSQL_DATABASE}
+        POSTGRES_SERVICE_HOST: ${POSTGRES_SERVICE_HOST}
+        POSTGRES_USER: ${POSTGRES_USER}
+        POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+        POSTGRES_SERVICE_PORT: ${POSTGRES_SERVICE_PORT}
+        POSTGRES_DATABASE: ${POSTGRES_DATABASE}
         KEYCLOAK_SERVICE_HOST: ${KEYCLOAK_SERVICE_HOST}
         KEYCLOAK_SERVICE_PORT: ${KEYCLOAK_SERVICE_PORT}
     links:
@@ -23,18 +23,15 @@ services:
     ports:
       - 9999:8080
   unifiedpushDB:
-    image: mysql:5.5
+    image: postgres:9.6
     environment:
-      MYSQL_USER: ${MYSQL_USER}
-      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
-      MYSQL_DATABASE: ${MYSQL_DATABASE}
-      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DATABASE}
     healthcheck:
-      test: ["CMD", "mysqladmin" ,"ping", "-h", "localhost"]
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
       timeout: 20s
       retries: 10
-    ports:
-      - 4306:3306
   keycloakServer:
     image: docker.io/jboss/keycloak:3.4.3.Final
     command: "-b 0.0.0.0 -Dkeycloak.import=/ups-keycloak-config/ups-realm-sample.json"


### PR DESCRIPTION
Updating to `unifiedpush-wildfly:2.0.0` (which is KC protected) and using Postgres DB (now our new default)

**NOTE:** this works fine on Linux