### PR TITLE
Adding jms config file to distribution archive

### DIFF
--- a/dist/README.md
+++ b/dist/README.md
@@ -2,10 +2,9 @@
 
 The content of this archive contains:
 * Keycloak development setup, via docker-compose
-* database configuration files and modules for WildFly10/11
-* WAR file for UnifiedPush Server (for WildFly)
+* database configuration files and modules for WildFly11+
+* WAR file for UnifiedPush Server (for WildFly) with and without Keycloak
 * source JAR files of the UnifiedPush Server for debugging.
 
 To learn more about how to configure and install the UnifiedPush Server please visit our user guide:
 http://aerogear.org/push
-

--- a/dist/src/main/assembly/assembly.xml
+++ b/dist/src/main/assembly/assembly.xml
@@ -24,6 +24,11 @@
     </formats>
     
     <fileSets>
+        <!-- Bundle the JMS configuration files and modules -->
+        <fileSet>
+            <directory>${project.basedir}/../configuration</directory>
+            <outputDirectory>/configuration</outputDirectory>
+        </fileSet>
         <!-- Bundle the database configuration files and modules -->
         <fileSet>
             <directory>${project.basedir}/../databases</directory>


### PR DESCRIPTION
I noticed that the `cli` for the JMS config was missing in our distribution archives 