### PR TITLE
include env vars in property lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,17 @@ mvn clean install
 
 and start the latest build, locally, like `docker run -p 18081:8080 -it aerogear/ups:plain`
 
+## Configuration
+
+The Unified Push Server can be configured with either System Properties (passed to the Java commandline) or Environment Variables. The two options have different formats and the following list describes them using `System Property Name`/`Env Var Name`: `Purpose`.
+
+* _custom.aerogear.apns.push.host/CUSTOM_AEROGEAR_APNS_PUSH_HOST_: Custom host for sending Apple push notifications. Can be used for testing
+* _custom.aerogear.apns.push.port/CUSTOM_AEROGEAR_APNS_PUSH_PORT_: Custom port for the Apple Push Network host
+* _custom.aerogear.fcm.push.host/CUSTOM_AEROGEAR_FCM_PUSH_HOST_: Custom host for sending Google Firebase push notifications. Can be used for testing
+* _ups.realm.name/UPS_REALM_NAME_: Override Keycloak Realm
+* _ups.auth.server.url/UPS_AUTH_SERVER_URL_: Override Keycloak authentication redirect
+* _aerogear.metrics.storage.days/AEROGEAR_METRICS_STORAGE_DAYS_: Override the number of days the metrics are stored (default is 30 days)
+
 ## Releasing the UnifiedPush Server
 
 The content of the [Release Process](https://github.com/aerogear/collateral/wiki/Release-Process-(Java)) is valid for this project as well. However, to build the full `distribution` bundle, you need to fire off the release like:

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -26,6 +26,7 @@
     <artifactId>unifiedpush-common</artifactId>
     <name>UnifiedPush Common classes and utils</name>
 
+
     <dependencies>
 
        <dependency>
@@ -47,6 +48,21 @@
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>2.19.1</version>
+                        <configuration>
+                            <environmentVariables>
+                                <TEST_ENV_VAR>Ok</TEST_ENV_VAR>
+                            </environmentVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
 
             <dependencies>
                 <dependency>
@@ -74,6 +90,7 @@
 
 
             </dependencies>
+
         </profile>
     </profiles>
 

--- a/common/src/main/java/org/jboss/aerogear/unifiedpush/system/ConfigurationUtils.java
+++ b/common/src/main/java/org/jboss/aerogear/unifiedpush/system/ConfigurationUtils.java
@@ -66,7 +66,7 @@ public final class ConfigurationUtils {
      * @param key String System Property Key
      * @return String Key as environment variable
      */
-    private static String formatEnvironmentVariable(String key) {
+    public static String formatEnvironmentVariable(String key) {
         return key.toUpperCase().replaceAll("\\.", "_");
     }
 

--- a/common/src/main/java/org/jboss/aerogear/unifiedpush/system/ConfigurationUtils.java
+++ b/common/src/main/java/org/jboss/aerogear/unifiedpush/system/ConfigurationUtils.java
@@ -24,20 +24,7 @@ public final class ConfigurationUtils {
 
     private static final Logger logger = LoggerFactory.getLogger(ConfigurationUtils.class);
 
-    private ConfigurationUtils() {
-        // no-op
-    }
-
-    /**
-     * Try to retrieve a system property and returns null if SecurityManager blocks it.
-     *
-     * @param key Name of the system property to get the string for.
-     *
-     * @return the value of the System property
-     */
-    public static String tryGetProperty(String key) {
-        return tryGetProperty(key, null);
-    }
+    private ConfigurationUtils() { }
 
     /**
      * Try to retrieve a system property and returns the defaultValue if SecurityManager blocks it.
@@ -47,26 +34,16 @@ public final class ConfigurationUtils {
      *
      * @return the value of the System property
      */
-    public static String tryGetProperty(String key, String defaultValue) {
+    private static String tryGetProperty(String key, String defaultValue) {
         try {
             return System.getProperty(key, defaultValue);
         } catch (SecurityException e) {
-            logger.error("Could not get value of property {} due to SecurityManager. Using null value.", key);
+            logger.error("Could not get value of property {} due to SecurityManager. Using default value.", key);
             return null;
         }
     }
 
     /**
-     * Try to retrieve a system property and returns null if SecurityManager blocks it.
-     *
-     * @param key Name of the system property to get the integer for.
-     * @return the value of the System property
-     */
-    public static Integer tryGetIntegerProperty(String key) {
-        return tryGetIntegerProperty(key, null);
-    }
-
-    /**
      * Try to retrieve a system property and returns the defaultValue if SecurityManager blocks it.
      *
      * @param key Name of the system property to get the integer for.
@@ -74,15 +51,83 @@ public final class ConfigurationUtils {
      *
      * @return the value of the System property
      */
-    public static Integer tryGetIntegerProperty(String key, Integer defaultValue) {
+    private static Integer tryGetIntegerProperty(String key, Integer defaultValue) {
         try {
             return Integer.getInteger(key, defaultValue);
         } catch (SecurityException e) {
-            logger.error("Could not get value of property {} due to SecurityManager. Using null value.", key, e);
+            logger.error("Could not get value of property {} due to SecurityManager. Using default value.", key, e);
             return defaultValue;
         }
     }
 
+    /**
+     * Format a key given system property key as an environment variable, e.g.:
+     * custom.aerogear.apns.push.host would become CUSTOM_AEROGEAR_APNS_PUSH_HOST
+     * @param key String System Property Key
+     * @return String Key as environment variable
+     */
+    private static String formatEnvironmentVariable(String key) {
+        return key.toUpperCase().replaceAll("\\.", "_");
+    }
 
+    /**
+     * Get a global string property. This method will first try to get the value from an
+     * environment variable and if that does not exist it will look up a system property.
+     * @param key Name of the variable
+     * @param defaultValue Returned if neither env var nor system property are defined
+     * @return String the value of the Environment or System Property if defined, the given
+     * default value otherwise
+     */
+    public static String tryGetGlobalProperty(String key, String defaultValue) {
+        try {
+            String value = System.getenv(formatEnvironmentVariable(key));
+            if (value == null) {
+                value = tryGetProperty(key, defaultValue);
+            }
+            return value;
+        } catch (SecurityException e) {
+            logger.error("Could not get value of global property {} due to SecurityManager. Using default value.", key, e);
+            return defaultValue;
+        }
+    }
 
+    /**
+     * Same as `tryGetGlobalProperty` but with null as implicit default value
+     * @param key Variable name
+     * @return Environment or System property value or null if not found
+     */
+    public static String tryGetGlobalProperty(String key) {
+        return tryGetGlobalProperty(key, null);
+    }
+
+    /**
+     * Get a global integer property. This method will first try to get the value from an
+     * environment variable and if that does not exist it will look up a system property.
+     * @param key Name of the variable
+     * @param defaultValue Returned if neither env var nor system property are defined
+     * @return String the value of the Environment or System Property if defined, the given
+     * default value otherwise
+     */
+    public static Integer tryGetGlobalIntegerProperty(String key, Integer defaultValue) {
+        try {
+            String value = System.getenv(formatEnvironmentVariable(key));
+            if (value == null) {
+                return tryGetIntegerProperty(key, defaultValue);
+            } else {
+                return Integer.parseInt(value);
+            }
+        } catch (SecurityException | NumberFormatException e) {
+            logger.error("Could not get value of global property {} due to SecurityManager. Using default value.", key, e);
+            return defaultValue;
+        }
+    }
+
+    /**
+     * Same as `tryGetGlobalIntegerProperty` but with null as implicit default value
+     * @param key Variable name
+     * @return Environment or System property value or null if not found
+     */
+    public static Integer tryGetGlobalIntegerProperty(String key) {
+        return tryGetGlobalIntegerProperty(key, null);
+    }
 }

--- a/common/src/test/java/org/jboss/aerogear/unifiedpush/system/ConfigurationUtilsTest.java
+++ b/common/src/test/java/org/jboss/aerogear/unifiedpush/system/ConfigurationUtilsTest.java
@@ -72,4 +72,10 @@ public class ConfigurationUtilsTest {
         assertThat(ConfigurationUtils.tryGetGlobalProperty("test.env.var"))
           .isEqualTo("Ok");
     }
+
+    @Test
+    public void testEnvVarUppercaseLookup() {
+        assertThat(ConfigurationUtils.tryGetGlobalProperty("TEST_ENV_VAR"))
+          .isEqualTo("Ok");
+    }
 }

--- a/common/src/test/java/org/jboss/aerogear/unifiedpush/system/ConfigurationUtilsTest.java
+++ b/common/src/test/java/org/jboss/aerogear/unifiedpush/system/ConfigurationUtilsTest.java
@@ -61,4 +61,15 @@ public class ConfigurationUtilsTest {
         assertThat(ConfigurationUtils.tryGetGlobalIntegerProperty(TEST_PROPERTY_NAME, 123)).isEqualTo(123);
     }
 
+    @Test
+    public void testEnvVarFormat() {
+        assertThat(ConfigurationUtils.formatEnvironmentVariable("custom.aerogear.apns.push.host"))
+          .isEqualTo("CUSTOM_AEROGEAR_APNS_PUSH_HOST");
+    }
+
+    @Test
+    public void testEnvVarLookup() {
+        assertThat(ConfigurationUtils.tryGetGlobalProperty("test.env.var"))
+          .isEqualTo("Ok");
+    }
 }

--- a/common/src/test/java/org/jboss/aerogear/unifiedpush/system/ConfigurationUtilsTest.java
+++ b/common/src/test/java/org/jboss/aerogear/unifiedpush/system/ConfigurationUtilsTest.java
@@ -37,28 +37,28 @@ public class ConfigurationUtilsTest {
     @Test
     public void testExistingTryGetProperty(){
         System.setProperty(TEST_PROPERTY_NAME, "MyNiceValue");
-        assertThat(ConfigurationUtils.tryGetProperty(TEST_PROPERTY_NAME)).isEqualTo("MyNiceValue");
+        assertThat(ConfigurationUtils.tryGetGlobalProperty(TEST_PROPERTY_NAME)).isEqualTo("MyNiceValue");
     }
 
     @Test
     public void testNonExistingTryGetProperty(){
-        assertThat(ConfigurationUtils.tryGetProperty(TEST_PROPERTY_NAME)).isNull();
+        assertThat(ConfigurationUtils.tryGetGlobalProperty(TEST_PROPERTY_NAME)).isNull();
     }
 
     @Test
     public void testExistingTryGetIntegerProperty() {
         System.setProperty(TEST_PROPERTY_NAME, "123456");
-        assertThat(ConfigurationUtils.tryGetIntegerProperty(TEST_PROPERTY_NAME)).isEqualTo(123456);
+        assertThat(ConfigurationUtils.tryGetGlobalIntegerProperty(TEST_PROPERTY_NAME)).isEqualTo(123456);
     }
 
     @Test
     public void testNonExistingTryGetIntegerProperty() {
-        assertThat(ConfigurationUtils.tryGetIntegerProperty(TEST_PROPERTY_NAME)).isNull();
+        assertThat(ConfigurationUtils.tryGetGlobalIntegerProperty(TEST_PROPERTY_NAME)).isNull();
     }
 
     @Test
     public void testNonExistingTryGetIntegerPropertyWithDefaultValue() {
-        assertThat(ConfigurationUtils.tryGetIntegerProperty(TEST_PROPERTY_NAME, 123)).isEqualTo(123);
+        assertThat(ConfigurationUtils.tryGetGlobalIntegerProperty(TEST_PROPERTY_NAME, 123)).isEqualTo(123);
     }
 
 }

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/config/KeycloakConfigurationEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/config/KeycloakConfigurationEndpoint.java
@@ -44,8 +44,8 @@ public class KeycloakConfigurationEndpoint {
     @Produces(MediaType.APPLICATION_JSON)
     public Response configurationFile() throws JsonProcessingException {
 
-        final String realmName = ConfigurationUtils.tryGetProperty(REALM_NAME_PROPERTY);
-        final String keycloakServerURL = removeDefaultHttpPorts(ConfigurationUtils.tryGetProperty(REALM_URL_PROPERTY));
+        final String realmName = ConfigurationUtils.tryGetGlobalProperty(REALM_NAME_PROPERTY);
+        final String keycloakServerURL = removeDefaultHttpPorts(ConfigurationUtils.tryGetGlobalProperty(REALM_URL_PROPERTY));
 
         final Config config = new Config(realmName, keycloakServerURL);
 

--- a/push-sender/src/main/java/org/jboss/aerogear/unifiedpush/message/configuration/SenderConfigurationProvider.java
+++ b/push-sender/src/main/java/org/jboss/aerogear/unifiedpush/message/configuration/SenderConfigurationProvider.java
@@ -91,9 +91,9 @@ public class SenderConfigurationProvider {
             Class<T> expectedType) {
         String systemPropertyName = getSystemPropertyName(type, property);
         if (expectedType == String.class) {
-            return (T) ConfigurationUtils.tryGetProperty(systemPropertyName, (String) defaultValue);
+            return (T) ConfigurationUtils.tryGetGlobalProperty(systemPropertyName, (String) defaultValue);
         } else if (expectedType == Integer.class) {
-            return (T) ConfigurationUtils.tryGetIntegerProperty(systemPropertyName, (Integer) defaultValue);
+            return (T) ConfigurationUtils.tryGetGlobalIntegerProperty(systemPropertyName, (Integer) defaultValue);
         } else {
             throw new IllegalStateException("Unexpected type: " + expectedType);
         }

--- a/push-sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/apns/PushyApnsSender.java
+++ b/push-sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/apns/PushyApnsSender.java
@@ -50,8 +50,8 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.ConcurrentSkipListSet;
 
-import static org.jboss.aerogear.unifiedpush.system.ConfigurationUtils.tryGetIntegerProperty;
-import static org.jboss.aerogear.unifiedpush.system.ConfigurationUtils.tryGetProperty;
+import static org.jboss.aerogear.unifiedpush.system.ConfigurationUtils.tryGetGlobalIntegerProperty;
+import static org.jboss.aerogear.unifiedpush.system.ConfigurationUtils.tryGetGlobalProperty;
 
 @Stateless
 @SenderType(VariantType.IOS)
@@ -61,8 +61,8 @@ public class PushyApnsSender implements PushNotificationSender {
 
     public static final String CUSTOM_AEROGEAR_APNS_PUSH_HOST = "custom.aerogear.apns.push.host";
     public static final String CUSTOM_AEROGEAR_APNS_PUSH_PORT = "custom.aerogear.apns.push.port";
-    private static final String customAerogearApnsPushHost = tryGetProperty(CUSTOM_AEROGEAR_APNS_PUSH_HOST);
-    private static final Integer customAerogearApnsPushPort = tryGetIntegerProperty(CUSTOM_AEROGEAR_APNS_PUSH_PORT);
+    private static final String customAerogearApnsPushHost = tryGetGlobalProperty(CUSTOM_AEROGEAR_APNS_PUSH_HOST);
+    private static final Integer customAerogearApnsPushPort = tryGetGlobalIntegerProperty(CUSTOM_AEROGEAR_APNS_PUSH_PORT);
 
     private static final Counter promPrushRequestsIOS = Counter.build()
             .name("aerogear_ups_push_requests_ios")

--- a/push-sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/fcm/ConfigurableFCMSender.java
+++ b/push-sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/fcm/ConfigurableFCMSender.java
@@ -38,7 +38,7 @@ public class ConfigurableFCMSender extends Sender {
 	protected HttpURLConnection getConnection(String url) throws IOException {
 		
 		// let's see if there is a different URL we should post to (e.g. load/stress testing)
-		final String fcmURL = ConfigurationUtils.tryGetProperty(CUSTOM_AEROGEAR_FCM_PUSH_HOST, FCM_ENDPOINT_HOST);
+		final String fcmURL = ConfigurationUtils.tryGetGlobalProperty(CUSTOM_AEROGEAR_FCM_PUSH_HOST, FCM_ENDPOINT_HOST);
 		
 		return (HttpURLConnection) new URL(fcmURL).openConnection();
 	}

--- a/push-sender/src/main/java/org/jboss/aerogear/unifiedpush/message/util/HealthNetworkServiceImpl.java
+++ b/push-sender/src/main/java/org/jboss/aerogear/unifiedpush/message/util/HealthNetworkServiceImpl.java
@@ -34,16 +34,16 @@ import java.util.concurrent.Future;
 
 import static org.jboss.aerogear.unifiedpush.message.sender.apns.PushyApnsSender.CUSTOM_AEROGEAR_APNS_PUSH_HOST;
 import static org.jboss.aerogear.unifiedpush.message.sender.apns.PushyApnsSender.CUSTOM_AEROGEAR_APNS_PUSH_PORT;
-import static org.jboss.aerogear.unifiedpush.system.ConfigurationUtils.tryGetIntegerProperty;
-import static org.jboss.aerogear.unifiedpush.system.ConfigurationUtils.tryGetProperty;
+import static org.jboss.aerogear.unifiedpush.system.ConfigurationUtils.tryGetGlobalIntegerProperty;
+import static org.jboss.aerogear.unifiedpush.system.ConfigurationUtils.tryGetGlobalProperty;
 
 /**
  * Checks the health of the push networks.
  */
 @Stateless
 public class HealthNetworkServiceImpl implements HealthNetworkService {
-    private static final String customAerogearApnsPushHost = tryGetProperty(CUSTOM_AEROGEAR_APNS_PUSH_HOST);
-    private static final Integer customAerogearApnsPushPort = tryGetIntegerProperty(CUSTOM_AEROGEAR_APNS_PUSH_PORT);
+    private static final String customAerogearApnsPushHost = tryGetGlobalProperty(CUSTOM_AEROGEAR_APNS_PUSH_HOST);
+    private static final Integer customAerogearApnsPushPort = tryGetGlobalIntegerProperty(CUSTOM_AEROGEAR_APNS_PUSH_PORT);
 
     private static final String FCM_SEND_ENDPOINT = ConfigurableFCMSender.FCM_ENDPOINT_HOST.substring("https://".length(), ConfigurableFCMSender.FCM_ENDPOINT_HOST.indexOf('/', "https://".length()));
     public static final String WNS_SEND_ENDPOINT = "db3.notify.windows.com";

--- a/service/src/main/java/org/jboss/aerogear/unifiedpush/service/metrics/PushMessageMetricsService.java
+++ b/service/src/main/java/org/jboss/aerogear/unifiedpush/service/metrics/PushMessageMetricsService.java
@@ -97,7 +97,7 @@ public class PushMessageMetricsService {
      *  <i>older</i> than 30 days!
      */
     public void deleteOutdatedFlatPushInformationData() {
-        final Date historyDate = DateUtils.calculatePastDate(ConfigurationUtils.tryGetIntegerProperty(AEROGEAR_METRICS_STORAGE_MAX_DAYS, 30));
+        final Date historyDate = DateUtils.calculatePastDate(ConfigurationUtils.tryGetGlobalIntegerProperty(AEROGEAR_METRICS_STORAGE_MAX_DAYS, 30));
         logger.trace("Delete all until {}", historyDate.getTime());
         flatPushMessageInformationDao.deletePushInformationOlderThan(historyDate);
     }


### PR DESCRIPTION
Support environment variables in addition to system properties for configuration variables. Env var names will be converted to adhere naming conventions, e.g. `custom.aerogear.fcm.push.host` will be converted into `CUSTOM_AEROGEAR_FCM_PUSH_HOST` before trying to resolve the env var.