### PR TITLE
We no longer build our own KC server

### DIFF
--- a/dependencies/server-dependencies/pom.xml
+++ b/dependencies/server-dependencies/pom.xml
@@ -85,12 +85,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- Keycloak dependencies -->
-        <dependency>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk16</artifactId>
-        </dependency>
-
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-core</artifactId>


### PR DESCRIPTION
we just leverage the adapter on the WAR file, hence no need to have Keycloak internal API referenced 