### PR TITLE
fix: Check variant platform before deletion/secretReset/findById

### DIFF
--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/AbstractBaseEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/AbstractBaseEndpoint.java
@@ -42,14 +42,21 @@ public abstract class AbstractBaseEndpoint {
 
     protected final Logger logger = LoggerFactory.getLogger(getClass());
 
+    @Inject
     private Validator validator;
+
+    @Inject
     private SearchManager searchManager;
 
     @Context
     private HttpServletRequest httpServletRequest;
 
-    @Inject
-    public AbstractBaseEndpoint(Validator validator, SearchManager searchManager) {
+    // required for RESTEasy
+    public AbstractBaseEndpoint() {
+    }
+
+    // required for tests
+    protected AbstractBaseEndpoint(Validator validator, SearchManager searchManager) {
         this.validator = validator;
         this.searchManager = searchManager;
     }

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/AbstractBaseEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/AbstractBaseEndpoint.java
@@ -42,14 +42,17 @@ public abstract class AbstractBaseEndpoint {
 
     protected final Logger logger = LoggerFactory.getLogger(getClass());
 
-    @Inject
     private Validator validator;
-
-    @Inject
     private SearchManager searchManager;
 
     @Context
     private HttpServletRequest httpServletRequest;
+
+    @Inject
+    public AbstractBaseEndpoint(Validator validator, SearchManager searchManager) {
+        this.validator = validator;
+        this.searchManager = searchManager;
+    }
 
     /**
      * Generic validator used to identify constraint violations of the given model class. 

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/AbstractVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/AbstractVariantEndpoint.java
@@ -21,8 +21,10 @@ import org.jboss.aerogear.unifiedpush.api.Variant;
 import org.jboss.aerogear.unifiedpush.rest.AbstractBaseEndpoint;
 import org.jboss.aerogear.unifiedpush.service.GenericVariantService;
 import org.jboss.aerogear.unifiedpush.service.PushApplicationService;
+import org.jboss.aerogear.unifiedpush.service.impl.SearchManager;
 
 import javax.inject.Inject;
+import javax.validation.Validator;
 import javax.ws.rs.core.Response;
 import java.util.Objects;
 import java.util.Set;
@@ -40,6 +42,11 @@ public abstract class AbstractVariantEndpoint extends AbstractBaseEndpoint {
 
     @Inject
     protected GenericVariantService variantService;
+
+    @Inject
+    public AbstractVariantEndpoint(Validator validator, SearchManager searchManager) {
+        super(validator, searchManager);
+    }
 
     /**
      * Secret Reset

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/AbstractVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/AbstractVariantEndpoint.java
@@ -48,7 +48,8 @@ public abstract class AbstractVariantEndpoint extends AbstractBaseEndpoint {
      * @return          {@link Variant} with new secret
      *
      * @statuscode 200 The secret of Variant reset successfully
-     * @statuscode 404 The requested Variant resource does not exist or it is not of the given type
+     * @statuscode 400 The requested Variant resource exists but it is not of the given type
+     * @statuscode 404 The requested Variant resource does not exist
      */
     protected <T extends Variant> Response doResetSecret(String variantId, Class<T> type) {
 
@@ -59,7 +60,7 @@ public abstract class AbstractVariantEndpoint extends AbstractBaseEndpoint {
         }
 
         if (!type.isInstance(variant)) {
-            return Response.status(Response.Status.NOT_FOUND).entity("Requested Variant is of another type/platform").build();
+            return Response.status(Response.Status.BAD_REQUEST).entity("Requested Variant is of another type/platform").build();
         }
 
         logger.trace("Resetting secret for: {}", variant.getName());
@@ -79,7 +80,8 @@ public abstract class AbstractVariantEndpoint extends AbstractBaseEndpoint {
      * @param variantId id of {@link Variant}
      * @return          requested {@link Variant}
      *
-     * @statuscode 404 The requested Variant resource does not exist or it is not of the given type
+     * @statuscode 400 The requested Variant resource exists but it is not of the given type
+     * @statuscode 404 The requested Variant resource does not exist
      */
     protected <T extends Variant> Response doFindVariantById(String variantId, Class<T> type) {
 
@@ -90,7 +92,7 @@ public abstract class AbstractVariantEndpoint extends AbstractBaseEndpoint {
         }
 
         if (!type.isInstance(variant)) {
-            return Response.status(Response.Status.NOT_FOUND).entity("Requested Variant is of another type/platform").build();
+            return Response.status(Response.Status.BAD_REQUEST).entity("Requested Variant is of another type/platform").build();
         }
 
         return Response.ok(variant).build();
@@ -104,7 +106,8 @@ public abstract class AbstractVariantEndpoint extends AbstractBaseEndpoint {
      * @return no content or 404
      *
      * @statuscode 204 The Variant successfully deleted
-     * @statuscode 404 The requested Variant resource does not exist or it is not of the given type
+     * @statuscode 400 The requested Variant resource exists but it is not of the given type
+     * @statuscode 404 The requested Variant resource does not exist
      */
     protected <T extends Variant> Response doDeleteVariant(String variantId, Class<T> type) {
 
@@ -115,7 +118,7 @@ public abstract class AbstractVariantEndpoint extends AbstractBaseEndpoint {
         }
 
         if (!type.isInstance(variant)) {
-            return Response.status(Response.Status.NOT_FOUND).entity("Requested Variant is of another type/platform").build();
+            return Response.status(Response.Status.BAD_REQUEST).entity("Requested Variant is of another type/platform").build();
         }
 
         logger.trace("Deleting: {}", variant.getClass().getSimpleName());

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/AbstractVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/AbstractVariantEndpoint.java
@@ -47,7 +47,6 @@ public abstract class AbstractVariantEndpoint<T extends Variant> extends Abstrac
     @Inject
     protected GenericVariantService variantService;
 
-    // required for RESTEasy
     AbstractVariantEndpoint(Class<T> type) {
         this.type = type;
     }

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/AbstractVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/AbstractVariantEndpoint.java
@@ -43,8 +43,12 @@ public abstract class AbstractVariantEndpoint extends AbstractBaseEndpoint {
     @Inject
     protected GenericVariantService variantService;
 
-    @Inject
-    public AbstractVariantEndpoint(Validator validator, SearchManager searchManager) {
+    // required for RESTEasy
+    public AbstractVariantEndpoint() {
+    }
+
+    // required for tests
+    protected AbstractVariantEndpoint(Validator validator, SearchManager searchManager) {
         super(validator, searchManager);
     }
 

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/AbstractVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/AbstractVariantEndpoint.java
@@ -153,7 +153,7 @@ public abstract class AbstractVariantEndpoint<T extends Variant> extends Abstrac
         return Response.noContent().build();
     }
 
-    protected Set<T> getVariantsByType(PushApplication application) {
+    protected Set<T> getVariants(PushApplication application) {
         return application.getVariants().stream()
                 .filter(variant -> type.isAssignableFrom(variant.getClass()))
                 .map(variant -> (T) variant)

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/AndroidVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/AndroidVariantEndpoint.java
@@ -100,7 +100,7 @@ public class AndroidVariantEndpoint extends AbstractVariantEndpoint<AndroidVaria
     @Produces(MediaType.APPLICATION_JSON)
     public Response listAllAndroidVariationsForPushApp(@PathParam("pushAppID") String pushApplicationID) {
         final PushApplication application = getSearch().findByPushApplicationIDForDeveloper(pushApplicationID);
-        return Response.ok(getVariantsByType(application)).build();
+        return Response.ok(getVariants(application)).build();
     }
 
     /**

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/AndroidVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/AndroidVariantEndpoint.java
@@ -19,8 +19,11 @@ package org.jboss.aerogear.unifiedpush.rest.registry.applications;
 import org.jboss.aerogear.unifiedpush.api.AndroidVariant;
 import org.jboss.aerogear.unifiedpush.api.PushApplication;
 import org.jboss.aerogear.unifiedpush.api.Variant;
+import org.jboss.aerogear.unifiedpush.service.impl.SearchManager;
 
+import javax.inject.Inject;
 import javax.validation.ConstraintViolationException;
+import javax.validation.Validator;
 import javax.ws.rs.*;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
@@ -31,6 +34,11 @@ import javax.ws.rs.core.UriInfo;
 
 @Path("/applications/{pushAppID}/android")
 public class AndroidVariantEndpoint extends AbstractVariantEndpoint {
+
+    @Inject
+    public AndroidVariantEndpoint(Validator validator, SearchManager searchManager) {
+        super(validator, searchManager);
+    }
 
     /**
      * Add Android Variant
@@ -109,7 +117,7 @@ public class AndroidVariantEndpoint extends AbstractVariantEndpoint {
     @Path("/{androidID}")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    public Response updateAndroidVariation(
+    public Response updateAndroidVariant(
             @PathParam("pushAppID") String id,
             @PathParam("androidID") String androidID,
             AndroidVariant updatedAndroidApplication) {

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/AndroidVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/AndroidVariantEndpoint.java
@@ -148,7 +148,7 @@ public class AndroidVariantEndpoint extends AbstractVariantEndpoint {
      *
      * @param variantId id of {@link Variant}
      * @return          requested {@link Variant}
-     *
+     * @statuscode 400 The requested Variant resource exists but it is not for Android
      * @statuscode 404 The requested Android Variant resource does not exist
      */
     @GET
@@ -166,6 +166,7 @@ public class AndroidVariantEndpoint extends AbstractVariantEndpoint {
      * @return no content or 404
      *
      * @statuscode 204 The Variant successfully deleted
+     * @statuscode 400 The requested Variant resource exists but it is not for Android
      * @statuscode 404 The requested Android Variant resource does not exist
      */
     @DELETE
@@ -181,6 +182,7 @@ public class AndroidVariantEndpoint extends AbstractVariantEndpoint {
      * @return          {@link Variant} with new secret
      *
      * @statuscode 200 The secret of Android Variant reset successfully
+     * @statuscode 400 The requested Variant resource exists but it is not for Android
      * @statuscode 404 The requested Android Variant resource does not exist
      */
     @PUT

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/AndroidVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/AndroidVariantEndpoint.java
@@ -18,7 +18,6 @@ package org.jboss.aerogear.unifiedpush.rest.registry.applications;
 
 import org.jboss.aerogear.unifiedpush.api.AndroidVariant;
 import org.jboss.aerogear.unifiedpush.api.PushApplication;
-import org.jboss.aerogear.unifiedpush.api.Variant;
 import org.jboss.aerogear.unifiedpush.service.impl.SearchManager;
 
 import javax.validation.ConstraintViolationException;
@@ -32,15 +31,16 @@ import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriInfo;
 
 @Path("/applications/{pushAppID}/android")
-public class AndroidVariantEndpoint extends AbstractVariantEndpoint {
+public class AndroidVariantEndpoint extends AbstractVariantEndpoint<AndroidVariant> {
 
     // required for RESTEasy
     public AndroidVariantEndpoint() {
+        super(AndroidVariant.class);
     }
 
     // required for tests
-    protected AndroidVariantEndpoint(Validator validator, SearchManager searchManager) {
-        super(validator, searchManager);
+    AndroidVariantEndpoint(Validator validator, SearchManager searchManager) {
+        super(validator, searchManager, AndroidVariant.class);
     }
 
     /**
@@ -100,7 +100,7 @@ public class AndroidVariantEndpoint extends AbstractVariantEndpoint {
     @Produces(MediaType.APPLICATION_JSON)
     public Response listAllAndroidVariationsForPushApp(@PathParam("pushAppID") String pushApplicationID) {
         final PushApplication application = getSearch().findByPushApplicationIDForDeveloper(pushApplicationID);
-        return Response.ok(getVariantsByType(application, AndroidVariant.class)).build();
+        return Response.ok(getVariantsByType(application)).build();
     }
 
     /**
@@ -154,53 +154,4 @@ public class AndroidVariantEndpoint extends AbstractVariantEndpoint {
         return Response.status(Status.NOT_FOUND).entity("Could not find requested Variant").build();
     }
 
-    /**
-     * Get the Android Variant for the given ID
-     *
-     * @param variantId id of {@link Variant}
-     * @return          requested {@link Variant}
-     * @statuscode 400 The requested Variant resource exists but it is not for Android
-     * @statuscode 404 The requested Android Variant resource does not exist
-     */
-    @GET
-    @Path("/{variantId}")
-    @Produces(MediaType.APPLICATION_JSON)
-    public Response findVariantById(@PathParam("variantId") String variantId) {
-        return doFindVariantById(variantId, AndroidVariant.class);
-    }
-
-    /**
-     * Delete the Android Variant
-     *
-     * @param variantId id of {@link Variant}
-     *
-     * @return no content or 404
-     *
-     * @statuscode 204 The Variant successfully deleted
-     * @statuscode 400 The requested Variant resource exists but it is not for Android
-     * @statuscode 404 The requested Android Variant resource does not exist
-     */
-    @DELETE
-    @Path("/{variantId}")
-    public Response deleteVariant(@PathParam("variantId") String variantId) {
-        return this.doDeleteVariant(variantId, AndroidVariant.class);
-    }
-
-    /**
-     * Reset secret of the given Android Variant
-     *
-     * @param variantId id of {@link Variant}
-     * @return          {@link Variant} with new secret
-     *
-     * @statuscode 200 The secret of Android Variant reset successfully
-     * @statuscode 400 The requested Variant resource exists but it is not for Android
-     * @statuscode 404 The requested Android Variant resource does not exist
-     */
-    @PUT
-    @Path("/{variantId}/reset")
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
-    public Response resetSecret(@PathParam("variantId") String variantId) {
-        return doResetSecret(variantId, AndroidVariant.class);
-    }
 }

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/AndroidVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/AndroidVariantEndpoint.java
@@ -18,15 +18,10 @@ package org.jboss.aerogear.unifiedpush.rest.registry.applications;
 
 import org.jboss.aerogear.unifiedpush.api.AndroidVariant;
 import org.jboss.aerogear.unifiedpush.api.PushApplication;
+import org.jboss.aerogear.unifiedpush.api.Variant;
 
 import javax.validation.ConstraintViolationException;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
+import javax.ws.rs.*;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -146,5 +141,53 @@ public class AndroidVariantEndpoint extends AbstractVariantEndpoint {
         }
 
         return Response.status(Status.NOT_FOUND).entity("Could not find requested Variant").build();
+    }
+
+    /**
+     * Get the Android Variant for the given ID
+     *
+     * @param variantId id of {@link Variant}
+     * @return          requested {@link Variant}
+     *
+     * @statuscode 404 The requested Android Variant resource does not exist
+     */
+    @GET
+    @Path("/{variantId}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response findVariantById(@PathParam("variantId") String variantId) {
+        return doFindVariantById(variantId, AndroidVariant.class);
+    }
+
+    /**
+     * Delete the Android Variant
+     *
+     * @param variantId id of {@link Variant}
+     *
+     * @return no content or 404
+     *
+     * @statuscode 204 The Variant successfully deleted
+     * @statuscode 404 The requested Android Variant resource does not exist
+     */
+    @DELETE
+    @Path("/{variantId}")
+    public Response deleteVariant(@PathParam("variantId") String variantId) {
+        return this.doDeleteVariant(variantId, AndroidVariant.class);
+    }
+
+    /**
+     * Reset secret of the given Android Variant
+     *
+     * @param variantId id of {@link Variant}
+     * @return          {@link Variant} with new secret
+     *
+     * @statuscode 200 The secret of Android Variant reset successfully
+     * @statuscode 404 The requested Android Variant resource does not exist
+     */
+    @PUT
+    @Path("/{variantId}/reset")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response resetSecret(@PathParam("variantId") String variantId) {
+        return doResetSecret(variantId, AndroidVariant.class);
     }
 }

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/AndroidVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/AndroidVariantEndpoint.java
@@ -21,7 +21,6 @@ import org.jboss.aerogear.unifiedpush.api.PushApplication;
 import org.jboss.aerogear.unifiedpush.api.Variant;
 import org.jboss.aerogear.unifiedpush.service.impl.SearchManager;
 
-import javax.inject.Inject;
 import javax.validation.ConstraintViolationException;
 import javax.validation.Validator;
 import javax.ws.rs.*;
@@ -35,8 +34,12 @@ import javax.ws.rs.core.UriInfo;
 @Path("/applications/{pushAppID}/android")
 public class AndroidVariantEndpoint extends AbstractVariantEndpoint {
 
-    @Inject
-    public AndroidVariantEndpoint(Validator validator, SearchManager searchManager) {
+    // required for RESTEasy
+    public AndroidVariantEndpoint() {
+    }
+
+    // required for tests
+    protected AndroidVariantEndpoint(Validator validator, SearchManager searchManager) {
         super(validator, searchManager);
     }
 

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/InstallationManagementEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/InstallationManagementEndpoint.java
@@ -25,14 +25,7 @@ import org.jboss.resteasy.spi.Link;
 import org.jboss.resteasy.spi.LinkHeader;
 
 import javax.inject.Inject;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.GET;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
+import javax.ws.rs.*;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/PushApplicationEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/PushApplicationEndpoint.java
@@ -16,29 +16,6 @@
  */
 package org.jboss.aerogear.unifiedpush.rest.registry.applications;
 
-import java.net.URI;
-import java.util.Map;
-import java.util.UUID;
-
-import javax.inject.Inject;
-import javax.validation.ConstraintViolationException;
-import javax.validation.Validator;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.DefaultValue;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.ResponseBuilder;
-import javax.ws.rs.core.Response.Status;
-import javax.ws.rs.core.UriBuilder;
-
 import org.jboss.aerogear.unifiedpush.api.PushApplication;
 import org.jboss.aerogear.unifiedpush.api.Variant;
 import org.jboss.aerogear.unifiedpush.dao.InstallationDao;
@@ -48,6 +25,19 @@ import org.jboss.aerogear.unifiedpush.rest.AbstractBaseEndpoint;
 import org.jboss.aerogear.unifiedpush.service.PushApplicationService;
 import org.jboss.aerogear.unifiedpush.service.impl.SearchManager;
 import org.jboss.aerogear.unifiedpush.service.metrics.PushMessageMetricsService;
+
+import javax.inject.Inject;
+import javax.validation.ConstraintViolationException;
+import javax.validation.Validator;
+import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.ResponseBuilder;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.core.UriBuilder;
+import java.net.URI;
+import java.util.Map;
+import java.util.UUID;
 
 @Path("/applications")
 public class PushApplicationEndpoint extends AbstractBaseEndpoint {
@@ -63,8 +53,12 @@ public class PushApplicationEndpoint extends AbstractBaseEndpoint {
     @Inject
     private InstallationDao installationDao;
 
-    @Inject
-    public PushApplicationEndpoint(Validator validator, SearchManager searchManager) {
+    // required for RESTEasy
+    public PushApplicationEndpoint() {
+    }
+
+    // required for tests
+    protected PushApplicationEndpoint(Validator validator, SearchManager searchManager) {
         super(validator, searchManager);
     }
 

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/PushApplicationEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/PushApplicationEndpoint.java
@@ -22,6 +22,7 @@ import java.util.UUID;
 
 import javax.inject.Inject;
 import javax.validation.ConstraintViolationException;
+import javax.validation.Validator;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
@@ -45,6 +46,7 @@ import org.jboss.aerogear.unifiedpush.dao.PageResult;
 import org.jboss.aerogear.unifiedpush.dto.Count;
 import org.jboss.aerogear.unifiedpush.rest.AbstractBaseEndpoint;
 import org.jboss.aerogear.unifiedpush.service.PushApplicationService;
+import org.jboss.aerogear.unifiedpush.service.impl.SearchManager;
 import org.jboss.aerogear.unifiedpush.service.metrics.PushMessageMetricsService;
 
 @Path("/applications")
@@ -60,6 +62,11 @@ public class PushApplicationEndpoint extends AbstractBaseEndpoint {
 
     @Inject
     private InstallationDao installationDao;
+
+    @Inject
+    public PushApplicationEndpoint(Validator validator, SearchManager searchManager) {
+        super(validator, searchManager);
+    }
 
     /**
      * Create Push Application

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/WindowsVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/WindowsVariantEndpoint.java
@@ -16,10 +16,12 @@
  */
 package org.jboss.aerogear.unifiedpush.rest.registry.applications;
 
-import org.jboss.aerogear.unifiedpush.api.*;
+import org.jboss.aerogear.unifiedpush.api.PushApplication;
+import org.jboss.aerogear.unifiedpush.api.Variant;
+import org.jboss.aerogear.unifiedpush.api.WindowsVariant;
+import org.jboss.aerogear.unifiedpush.api.WindowsWNSVariant;
 import org.jboss.aerogear.unifiedpush.service.impl.SearchManager;
 
-import javax.inject.Inject;
 import javax.validation.ConstraintViolationException;
 import javax.validation.Validator;
 import javax.ws.rs.*;
@@ -31,8 +33,12 @@ import javax.ws.rs.core.UriInfo;
 @Path("/applications/{pushAppID}/windows{type}")
 public class WindowsVariantEndpoint extends AbstractVariantEndpoint {
 
-    @Inject
-    public WindowsVariantEndpoint(Validator validator, SearchManager searchManager) {
+    // required for RESTEasy
+    public WindowsVariantEndpoint() {
+    }
+
+    // required for tests
+    protected WindowsVariantEndpoint(Validator validator, SearchManager searchManager) {
         super(validator, searchManager);
     }
 

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/WindowsVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/WindowsVariantEndpoint.java
@@ -16,18 +16,10 @@
  */
 package org.jboss.aerogear.unifiedpush.rest.registry.applications;
 
-import org.jboss.aerogear.unifiedpush.api.PushApplication;
-import org.jboss.aerogear.unifiedpush.api.WindowsVariant;
-import org.jboss.aerogear.unifiedpush.api.WindowsWNSVariant;
+import org.jboss.aerogear.unifiedpush.api.*;
 
 import javax.validation.ConstraintViolationException;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
+import javax.ws.rs.*;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -149,6 +141,54 @@ public class WindowsVariantEndpoint extends AbstractVariantEndpoint {
         }
 
         return Response.status(Response.Status.NOT_FOUND).entity("Could not find requested Variant").build();
+    }
+
+    /**
+     * Get the Windows Variant for the given ID
+     *
+     * @param variantId id of {@link Variant}
+     * @return          requested {@link Variant}
+     *
+     * @statuscode 404 The requested Windows Variant resource does not exist
+     */
+    @GET
+    @Path("/{variantId}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response findVariantById(@PathParam("variantId") String variantId) {
+        return doFindVariantById(variantId, WindowsVariant.class);
+    }
+
+    /**
+     * Delete the Windows Variant
+     *
+     * @param variantId id of {@link Variant}
+     *
+     * @return no content or 404
+     *
+     * @statuscode 204 The Variant successfully deleted
+     * @statuscode 404 The requested Windows Variant resource does not exist
+     */
+    @DELETE
+    @Path("/{variantId}")
+    public Response deleteVariant(@PathParam("variantId") String variantId) {
+        return this.doDeleteVariant(variantId, WindowsVariant.class);
+    }
+
+    /**
+     * Reset secret of the given Windows Variant
+     *
+     * @param variantId id of {@link Variant}
+     * @return          {@link Variant} with new secret
+     *
+     * @statuscode 200 The secret of Windows Variant reset successfully
+     * @statuscode 404 The requested Windows Variant resource does not exist
+     */
+    @PUT
+    @Path("/{variantId}/reset")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response resetSecret(@PathParam("variantId") String variantId) {
+        return doResetSecret(variantId, WindowsVariant.class);
     }
 
 }

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/WindowsVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/WindowsVariantEndpoint.java
@@ -17,7 +17,6 @@
 package org.jboss.aerogear.unifiedpush.rest.registry.applications;
 
 import org.jboss.aerogear.unifiedpush.api.PushApplication;
-import org.jboss.aerogear.unifiedpush.api.Variant;
 import org.jboss.aerogear.unifiedpush.api.WindowsVariant;
 import org.jboss.aerogear.unifiedpush.api.WindowsWNSVariant;
 import org.jboss.aerogear.unifiedpush.service.impl.SearchManager;
@@ -31,15 +30,16 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
 @Path("/applications/{pushAppID}/windows{type}")
-public class WindowsVariantEndpoint extends AbstractVariantEndpoint {
+public class WindowsVariantEndpoint extends AbstractVariantEndpoint<WindowsVariant> {
 
     // required for RESTEasy
     public WindowsVariantEndpoint() {
+        super(WindowsVariant.class);
     }
 
     // required for tests
-    protected WindowsVariantEndpoint(Validator validator, SearchManager searchManager) {
-        super(validator, searchManager);
+    WindowsVariantEndpoint(Validator validator, SearchManager searchManager) {
+        super(validator, searchManager, WindowsVariant.class);
     }
 
     /**
@@ -100,7 +100,7 @@ public class WindowsVariantEndpoint extends AbstractVariantEndpoint {
     @Produces(MediaType.APPLICATION_JSON)
     public Response listAllWindowsVariationsForPushApp(@PathParam("pushAppID") String pushApplicationID) {
         final PushApplication application = getSearch().findByPushApplicationIDForDeveloper(pushApplicationID);
-        return Response.ok(getVariantsByType(application, WindowsVariant.class)).build();
+        return Response.ok(getVariantsByType(application)).build();
     }
 
     /**
@@ -155,56 +155,6 @@ public class WindowsVariantEndpoint extends AbstractVariantEndpoint {
         }
 
         return Response.status(Response.Status.NOT_FOUND).entity("Could not find requested Variant").build();
-    }
-
-    /**
-     * Get the Windows Variant for the given ID
-     *
-     * @param variantId id of {@link Variant}
-     * @return          requested {@link Variant}
-     *
-     * @statuscode 400 The requested Variant resource exists but it is not for Windows
-     * @statuscode 404 The requested Windows Variant resource does not exist
-     */
-    @GET
-    @Path("/{variantId}")
-    @Produces(MediaType.APPLICATION_JSON)
-    public Response findVariantById(@PathParam("variantId") String variantId) {
-        return doFindVariantById(variantId, WindowsVariant.class);
-    }
-
-    /**
-     * Delete the Windows Variant
-     *
-     * @param variantId id of {@link Variant}
-     *
-     * @return no content or 404
-     *
-     * @statuscode 204 The Variant successfully deleted
-     * @statuscode 400 The requested Variant resource exists but it is not for Windows
-     * @statuscode 404 The requested Windows Variant resource does not exist
-     */
-    @DELETE
-    @Path("/{variantId}")
-    public Response deleteVariant(@PathParam("variantId") String variantId) {
-        return this.doDeleteVariant(variantId, WindowsVariant.class);
-    }
-
-    /**
-     * Reset secret of the given Windows Variant
-     *
-     * @param variantId id of {@link Variant}
-     * @return          {@link Variant} with new secret
-     *
-     * @statuscode 200 The secret of Windows Variant reset successfully
-     * @statuscode 400 The requested Variant resource exists but it is not for Windows
-     * @statuscode 404 The requested Windows Variant resource does not exist
-     */
-    @PUT
-    @Path("/{variantId}/reset")@Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
-    public Response resetSecret(@PathParam("variantId") String variantId) {
-        return doResetSecret(variantId, WindowsVariant.class);
     }
 
 }

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/WindowsVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/WindowsVariantEndpoint.java
@@ -17,8 +17,11 @@
 package org.jboss.aerogear.unifiedpush.rest.registry.applications;
 
 import org.jboss.aerogear.unifiedpush.api.*;
+import org.jboss.aerogear.unifiedpush.service.impl.SearchManager;
 
+import javax.inject.Inject;
 import javax.validation.ConstraintViolationException;
+import javax.validation.Validator;
 import javax.ws.rs.*;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
@@ -27,6 +30,11 @@ import javax.ws.rs.core.UriInfo;
 
 @Path("/applications/{pushAppID}/windows{type}")
 public class WindowsVariantEndpoint extends AbstractVariantEndpoint {
+
+    @Inject
+    public WindowsVariantEndpoint(Validator validator, SearchManager searchManager) {
+        super(validator, searchManager);
+    }
 
     /**
      * Add Windows Variant
@@ -105,7 +113,7 @@ public class WindowsVariantEndpoint extends AbstractVariantEndpoint {
     @Path("/{windowsID}")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    public Response updateWindowsVariation(
+    public Response updateWindowsVariant(
             @PathParam("windowsID") String windowsID,
             WindowsVariant updatedWindowsVariant) {
 

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/WindowsVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/WindowsVariantEndpoint.java
@@ -100,7 +100,7 @@ public class WindowsVariantEndpoint extends AbstractVariantEndpoint<WindowsVaria
     @Produces(MediaType.APPLICATION_JSON)
     public Response listAllWindowsVariationsForPushApp(@PathParam("pushAppID") String pushApplicationID) {
         final PushApplication application = getSearch().findByPushApplicationIDForDeveloper(pushApplicationID);
-        return Response.ok(getVariantsByType(application)).build();
+        return Response.ok(getVariants(application)).build();
     }
 
     /**

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/WindowsVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/WindowsVariantEndpoint.java
@@ -149,6 +149,7 @@ public class WindowsVariantEndpoint extends AbstractVariantEndpoint {
      * @param variantId id of {@link Variant}
      * @return          requested {@link Variant}
      *
+     * @statuscode 400 The requested Variant resource exists but it is not for Windows
      * @statuscode 404 The requested Windows Variant resource does not exist
      */
     @GET
@@ -166,6 +167,7 @@ public class WindowsVariantEndpoint extends AbstractVariantEndpoint {
      * @return no content or 404
      *
      * @statuscode 204 The Variant successfully deleted
+     * @statuscode 400 The requested Variant resource exists but it is not for Windows
      * @statuscode 404 The requested Windows Variant resource does not exist
      */
     @DELETE
@@ -181,11 +183,11 @@ public class WindowsVariantEndpoint extends AbstractVariantEndpoint {
      * @return          {@link Variant} with new secret
      *
      * @statuscode 200 The secret of Windows Variant reset successfully
+     * @statuscode 400 The requested Variant resource exists but it is not for Windows
      * @statuscode 404 The requested Windows Variant resource does not exist
      */
     @PUT
-    @Path("/{variantId}/reset")
-    @Consumes(MediaType.APPLICATION_JSON)
+    @Path("/{variantId}/reset")@Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     public Response resetSecret(@PathParam("variantId") String variantId) {
         return doResetSecret(variantId, WindowsVariant.class);

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/iOSVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/iOSVariantEndpoint.java
@@ -17,7 +17,6 @@
 package org.jboss.aerogear.unifiedpush.rest.registry.applications;
 
 import org.jboss.aerogear.unifiedpush.api.PushApplication;
-import org.jboss.aerogear.unifiedpush.api.Variant;
 import org.jboss.aerogear.unifiedpush.api.iOSVariant;
 import org.jboss.aerogear.unifiedpush.event.iOSVariantUpdateEvent;
 import org.jboss.aerogear.unifiedpush.rest.annotations.PATCH;
@@ -38,18 +37,19 @@ import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriInfo;
 
 @Path("/applications/{pushAppID}/ios")
-public class iOSVariantEndpoint extends AbstractVariantEndpoint {
+public class iOSVariantEndpoint extends AbstractVariantEndpoint<iOSVariant> {
 
     @Inject
     protected Event<iOSVariantUpdateEvent> variantUpdateEventEvent;
 
     // required for RESTEasy
     public iOSVariantEndpoint() {
+        super(iOSVariant.class);
     }
 
     // required for tests
-    protected iOSVariantEndpoint(Validator validator, SearchManager searchManager) {
-        super(validator, searchManager);
+    iOSVariantEndpoint(Validator validator, SearchManager searchManager) {
+        super(validator, searchManager, iOSVariant.class);
     }
 
     /**
@@ -129,7 +129,7 @@ public class iOSVariantEndpoint extends AbstractVariantEndpoint {
     @Produces(MediaType.APPLICATION_JSON)
     public Response listAlliOSVariantsForPushApp(@PathParam("pushAppID") String pushApplicationID) {
         final PushApplication application = getSearch().findByPushApplicationIDForDeveloper(pushApplicationID);
-        return Response.ok(getVariantsByType(application, iOSVariant.class)).build();
+        return Response.ok(getVariantsByType(application)).build();
     }
 
     /**
@@ -230,56 +230,4 @@ public class iOSVariantEndpoint extends AbstractVariantEndpoint {
         }
         return Response.status(Status.NOT_FOUND).entity("Could not find requested Variant").build();
     }
-
-    /**
-     * Get the iOS Variant for the given ID
-     *
-     * @param variantId id of {@link Variant}
-     * @return          requested {@link Variant}
-     *
-     * @statuscode 400 The requested Variant resource exists but it is not for iOS
-     * @statuscode 404 The requested iOS Variant resource does not exist
-     */
-    @GET
-    @Path("/{variantId}")
-    @Produces(MediaType.APPLICATION_JSON)
-    public Response findVariantById(@PathParam("variantId") String variantId) {
-        return doFindVariantById(variantId, iOSVariant.class);
-    }
-
-    /**
-     * Delete the iOS Variant
-     *
-     * @param variantId id of {@link Variant}
-     *
-     * @return no content or 404
-     *
-     * @statuscode 204 The Variant successfully deleted
-     * @statuscode 400 The requested Variant resource exists but it is not for iOS
-     * @statuscode 404 The requested iOS Variant resource does not exist
-     */
-    @DELETE
-    @Path("/{variantId}")
-    public Response deleteVariant(@PathParam("variantId") String variantId) {
-        return this.doDeleteVariant(variantId, iOSVariant.class);
-    }
-
-    /**
-     * Reset secret of the given iOS Variant
-     *
-     * @param variantId id of {@link Variant}
-     * @return          {@link Variant} with new secret
-     *
-     * @statuscode 200 The secret of iOS Variant reset successfully
-     * @statuscode 400 The requested Variant resource exists but it is not for iOS
-     * @statuscode 404 The requested iOS Variant resource does not exist
-     */
-    @PUT
-    @Path("/{variantId}/reset")
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
-    public Response resetSecret(@PathParam("variantId") String variantId) {
-        return doResetSecret(variantId, iOSVariant.class);
-    }
-
 }

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/iOSVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/iOSVariantEndpoint.java
@@ -226,6 +226,7 @@ public class iOSVariantEndpoint extends AbstractVariantEndpoint {
      * @param variantId id of {@link Variant}
      * @return          requested {@link Variant}
      *
+     * @statuscode 400 The requested Variant resource exists but it is not for iOS
      * @statuscode 404 The requested iOS Variant resource does not exist
      */
     @GET
@@ -243,6 +244,7 @@ public class iOSVariantEndpoint extends AbstractVariantEndpoint {
      * @return no content or 404
      *
      * @statuscode 204 The Variant successfully deleted
+     * @statuscode 400 The requested Variant resource exists but it is not for iOS
      * @statuscode 404 The requested iOS Variant resource does not exist
      */
     @DELETE
@@ -258,6 +260,7 @@ public class iOSVariantEndpoint extends AbstractVariantEndpoint {
      * @return          {@link Variant} with new secret
      *
      * @statuscode 200 The secret of iOS Variant reset successfully
+     * @statuscode 400 The requested Variant resource exists but it is not for iOS
      * @statuscode 404 The requested iOS Variant resource does not exist
      */
     @PUT

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/iOSVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/iOSVariantEndpoint.java
@@ -43,8 +43,12 @@ public class iOSVariantEndpoint extends AbstractVariantEndpoint {
     @Inject
     protected Event<iOSVariantUpdateEvent> variantUpdateEventEvent;
 
-    @Inject
-    public iOSVariantEndpoint(Validator validator, SearchManager searchManager) {
+    // required for RESTEasy
+    public iOSVariantEndpoint() {
+    }
+
+    // required for tests
+    protected iOSVariantEndpoint(Validator validator, SearchManager searchManager) {
         super(validator, searchManager);
     }
 

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/iOSVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/iOSVariantEndpoint.java
@@ -22,11 +22,13 @@ import org.jboss.aerogear.unifiedpush.api.iOSVariant;
 import org.jboss.aerogear.unifiedpush.event.iOSVariantUpdateEvent;
 import org.jboss.aerogear.unifiedpush.rest.annotations.PATCH;
 import org.jboss.aerogear.unifiedpush.rest.util.iOSApplicationUploadForm;
+import org.jboss.aerogear.unifiedpush.service.impl.SearchManager;
 import org.jboss.resteasy.annotations.providers.multipart.MultipartForm;
 
 import javax.enterprise.event.Event;
 import javax.inject.Inject;
 import javax.validation.ConstraintViolationException;
+import javax.validation.Validator;
 import javax.ws.rs.*;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
@@ -39,7 +41,12 @@ import javax.ws.rs.core.UriInfo;
 public class iOSVariantEndpoint extends AbstractVariantEndpoint {
 
     @Inject
-    private Event<iOSVariantUpdateEvent> variantUpdateEventEvent;
+    protected Event<iOSVariantUpdateEvent> variantUpdateEventEvent;
+
+    @Inject
+    public iOSVariantEndpoint(Validator validator, SearchManager searchManager) {
+        super(validator, searchManager);
+    }
 
     /**
      * Add iOS Variant

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/iOSVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/iOSVariantEndpoint.java
@@ -17,6 +17,7 @@
 package org.jboss.aerogear.unifiedpush.rest.registry.applications;
 
 import org.jboss.aerogear.unifiedpush.api.PushApplication;
+import org.jboss.aerogear.unifiedpush.api.Variant;
 import org.jboss.aerogear.unifiedpush.api.iOSVariant;
 import org.jboss.aerogear.unifiedpush.event.iOSVariantUpdateEvent;
 import org.jboss.aerogear.unifiedpush.rest.annotations.PATCH;
@@ -26,13 +27,7 @@ import org.jboss.resteasy.annotations.providers.multipart.MultipartForm;
 import javax.enterprise.event.Event;
 import javax.inject.Inject;
 import javax.validation.ConstraintViolationException;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
+import javax.ws.rs.*;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -225,5 +220,52 @@ public class iOSVariantEndpoint extends AbstractVariantEndpoint {
         return Response.status(Status.NOT_FOUND).entity("Could not find requested Variant").build();
     }
 
+    /**
+     * Get the iOS Variant for the given ID
+     *
+     * @param variantId id of {@link Variant}
+     * @return          requested {@link Variant}
+     *
+     * @statuscode 404 The requested iOS Variant resource does not exist
+     */
+    @GET
+    @Path("/{variantId}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response findVariantById(@PathParam("variantId") String variantId) {
+        return doFindVariantById(variantId, iOSVariant.class);
+    }
+
+    /**
+     * Delete the iOS Variant
+     *
+     * @param variantId id of {@link Variant}
+     *
+     * @return no content or 404
+     *
+     * @statuscode 204 The Variant successfully deleted
+     * @statuscode 404 The requested iOS Variant resource does not exist
+     */
+    @DELETE
+    @Path("/{variantId}")
+    public Response deleteVariant(@PathParam("variantId") String variantId) {
+        return this.doDeleteVariant(variantId, iOSVariant.class);
+    }
+
+    /**
+     * Reset secret of the given iOS Variant
+     *
+     * @param variantId id of {@link Variant}
+     * @return          {@link Variant} with new secret
+     *
+     * @statuscode 200 The secret of iOS Variant reset successfully
+     * @statuscode 404 The requested iOS Variant resource does not exist
+     */
+    @PUT
+    @Path("/{variantId}/reset")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response resetSecret(@PathParam("variantId") String variantId) {
+        return doResetSecret(variantId, iOSVariant.class);
+    }
 
 }

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/iOSVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/iOSVariantEndpoint.java
@@ -129,7 +129,7 @@ public class iOSVariantEndpoint extends AbstractVariantEndpoint<iOSVariant> {
     @Produces(MediaType.APPLICATION_JSON)
     public Response listAlliOSVariantsForPushApp(@PathParam("pushAppID") String pushApplicationID) {
         final PushApplication application = getSearch().findByPushApplicationIDForDeveloper(pushApplicationID);
-        return Response.ok(getVariantsByType(application)).build();
+        return Response.ok(getVariants(application)).build();
     }
 
     /**

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/installations/ExportEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/installations/ExportEndpoint.java
@@ -16,7 +16,10 @@
  */
 package org.jboss.aerogear.unifiedpush.rest.registry.installations;
 
-import javax.inject.Inject;
+import org.jboss.aerogear.unifiedpush.rest.AbstractBaseEndpoint;
+import org.jboss.aerogear.unifiedpush.service.impl.SearchManager;
+import org.jboss.resteasy.annotations.GZIP;
+
 import javax.validation.Validator;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -25,15 +28,15 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-import org.jboss.aerogear.unifiedpush.rest.AbstractBaseEndpoint;
-import org.jboss.aerogear.unifiedpush.service.impl.SearchManager;
-import org.jboss.resteasy.annotations.GZIP;
-
 @Path("/export")
 public class ExportEndpoint extends AbstractBaseEndpoint {
 
-    @Inject
-    public ExportEndpoint(Validator validator, SearchManager searchManager) {
+    // required for RESTEasy
+    public ExportEndpoint() {
+    }
+
+    // required for tests
+    protected ExportEndpoint(Validator validator, SearchManager searchManager) {
         super(validator, searchManager);
     }
 

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/installations/ExportEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/installations/ExportEndpoint.java
@@ -16,6 +16,8 @@
  */
 package org.jboss.aerogear.unifiedpush.rest.registry.installations;
 
+import javax.inject.Inject;
+import javax.validation.Validator;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -24,10 +26,16 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.jboss.aerogear.unifiedpush.rest.AbstractBaseEndpoint;
+import org.jboss.aerogear.unifiedpush.service.impl.SearchManager;
 import org.jboss.resteasy.annotations.GZIP;
 
 @Path("/export")
 public class ExportEndpoint extends AbstractBaseEndpoint {
+
+    @Inject
+    public ExportEndpoint(Validator validator, SearchManager searchManager) {
+        super(validator, searchManager);
+    }
 
     /**
      * Endpoint for exporting as JSON file device installations for a given variant.

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/installations/InstallationRegistrationEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/installations/InstallationRegistrationEndpoint.java
@@ -22,12 +22,11 @@ import io.prometheus.client.Counter;
 import org.jboss.aerogear.unifiedpush.api.Installation;
 import org.jboss.aerogear.unifiedpush.api.Variant;
 import org.jboss.aerogear.unifiedpush.api.validation.DeviceTokenValidator;
+import org.jboss.aerogear.unifiedpush.auth.HttpBasicHelper;
 import org.jboss.aerogear.unifiedpush.rest.AbstractBaseEndpoint;
 import org.jboss.aerogear.unifiedpush.rest.EmptyJSON;
-import org.jboss.aerogear.unifiedpush.auth.HttpBasicHelper;
 import org.jboss.aerogear.unifiedpush.service.ClientInstallationService;
 import org.jboss.aerogear.unifiedpush.service.GenericVariantService;
-import org.jboss.aerogear.unifiedpush.service.impl.SearchManager;
 import org.jboss.aerogear.unifiedpush.service.metrics.PushMessageMetricsService;
 import org.jboss.resteasy.annotations.providers.multipart.MultipartForm;
 import org.slf4j.Logger;
@@ -35,17 +34,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
-import javax.validation.Validator;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.DefaultValue;
-import javax.ws.rs.HeaderParam;
-import javax.ws.rs.OPTIONS;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
+import javax.ws.rs.*;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
@@ -74,11 +63,6 @@ public class InstallationRegistrationEndpoint extends AbstractBaseEndpoint {
 
     @Inject
     private PushMessageMetricsService metricsService;
-
-    @Inject
-    public InstallationRegistrationEndpoint(Validator validator, SearchManager searchManager) {
-        super(validator, searchManager);
-    }
 
     /**
      * Cross Origin for Installations
@@ -151,7 +135,7 @@ public class InstallationRegistrationEndpoint extends AbstractBaseEndpoint {
      * @return          registered {@link Installation}
      *
      * @requestheader x-ag-old-token the old push service dependant token (ie InstanceID in FCM). If present these tokens will be forcefully unregistered before the new token is registered.
-     * 
+     *
      * @responseheader Access-Control-Allow-Origin      With host in your "Origin" header
      * @responseheader Access-Control-Allow-Credentials true
      * @responseheader WWW-Authenticate Basic realm="AeroGear UnifiedPush Server" (only for 401 response)

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/installations/InstallationRegistrationEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/installations/InstallationRegistrationEndpoint.java
@@ -27,6 +27,7 @@ import org.jboss.aerogear.unifiedpush.rest.EmptyJSON;
 import org.jboss.aerogear.unifiedpush.auth.HttpBasicHelper;
 import org.jboss.aerogear.unifiedpush.service.ClientInstallationService;
 import org.jboss.aerogear.unifiedpush.service.GenericVariantService;
+import org.jboss.aerogear.unifiedpush.service.impl.SearchManager;
 import org.jboss.aerogear.unifiedpush.service.metrics.PushMessageMetricsService;
 import org.jboss.resteasy.annotations.providers.multipart.MultipartForm;
 import org.slf4j.Logger;
@@ -34,6 +35,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
+import javax.validation.Validator;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
@@ -72,6 +74,11 @@ public class InstallationRegistrationEndpoint extends AbstractBaseEndpoint {
 
     @Inject
     private PushMessageMetricsService metricsService;
+
+    @Inject
+    public InstallationRegistrationEndpoint(Validator validator, SearchManager searchManager) {
+        super(validator, searchManager);
+    }
 
     /**
      * Cross Origin for Installations

--- a/jaxrs/src/test/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/AndroidVariantEndpointTest.java
+++ b/jaxrs/src/test/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/AndroidVariantEndpointTest.java
@@ -1,0 +1,121 @@
+package org.jboss.aerogear.unifiedpush.rest.registry.applications;
+
+import org.jboss.aerogear.unifiedpush.api.AndroidVariant;
+import org.jboss.aerogear.unifiedpush.api.iOSVariant;
+import org.jboss.aerogear.unifiedpush.service.GenericVariantService;
+import org.jboss.aerogear.unifiedpush.service.PushApplicationService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import javax.ws.rs.core.Response;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AndroidVariantEndpointTest {
+
+    AndroidVariantEndpoint endpoint;
+
+    @Mock
+    PushApplicationService pushAppService;
+
+    @Mock
+    GenericVariantService variantService;
+
+    @Before
+    public void before() {
+        this.endpoint = new AndroidVariantEndpoint();
+
+        this.endpoint.pushAppService = pushAppService;
+        this.endpoint.variantService = variantService;
+    }
+
+
+    @Test
+    public void shouldReturn404WhenFindVariantByIdCannotFindAnyVariants() {
+        when(variantService.findByVariantID("foo")).thenReturn(null);
+
+        final Response response = this.endpoint.findVariantById("foo");
+        assertEquals(response.getStatus(), 404);
+    }
+
+    @Test
+    public void shouldReturn400WhenFindVariantByIdFindsVariantOfAnotherPlatform() {
+        when(variantService.findByVariantID("123")).thenReturn(new iOSVariant());
+
+        final Response response = this.endpoint.findVariantById("123");
+        assertEquals(response.getStatus(), 400);
+    }
+
+    @Test
+    public void shouldReturn200WhenFindVariantByIdFindsAnAndroidVariant() {
+        final AndroidVariant variant = new AndroidVariant();
+        when(variantService.findByVariantID("123")).thenReturn(variant);
+
+        final Response response = this.endpoint.findVariantById("123");
+        assertEquals(response.getStatus(), 200);
+        assertTrue(variant == response.getEntity());    // identity check
+    }
+
+    @Test
+    public void shouldReturn404WhenDeleteVariantCannotFindAnyVariants() {
+        when(variantService.findByVariantID("foo")).thenReturn(null);
+
+        final Response response = this.endpoint.deleteVariant("foo");
+        assertEquals(response.getStatus(), 404);
+    }
+
+    @Test
+    public void shouldReturn400WhenDeleteVariantFindsVariantOfAnotherPlatform() {
+        when(variantService.findByVariantID("123")).thenReturn(new iOSVariant());
+
+        final Response response = this.endpoint.deleteVariant("123");
+        assertEquals(response.getStatus(), 400);
+    }
+
+    @Test
+    public void shouldReturn204WhenDeleteVariantDeletesAnAndroidVariant() {
+        final AndroidVariant variant = new AndroidVariant();
+        when(variantService.findByVariantID("123")).thenReturn(variant);
+
+        final Response response = this.endpoint.deleteVariant("123");
+        assertEquals(response.getStatus(), 204);
+
+        verify(variantService).removeVariant(variant);
+    }
+
+    @Test
+    public void shouldReturn404WhenResetSecretCannotFindAnyVariants() {
+        when(variantService.findByVariantID("foo")).thenReturn(null);
+
+        final Response response = this.endpoint.resetSecret("foo");
+        assertEquals(response.getStatus(), 404);
+    }
+
+    @Test
+    public void shouldReturn400WhenResetSecretFindsVariantOfAnotherPlatform() {
+        when(variantService.findByVariantID("123")).thenReturn(new iOSVariant());
+
+        final Response response = this.endpoint.resetSecret("123");
+        assertEquals(response.getStatus(), 400);
+    }
+
+    @Test
+    public void shouldReturn204WhenResetSecretFindsAnAndroidVariant() {
+        final AndroidVariant variant = new AndroidVariant();
+        variant.setSecret("The Secret");
+
+        when(variantService.findByVariantID("123")).thenReturn(variant);
+
+        final Response response = this.endpoint.resetSecret("123");
+        assertEquals(response.getStatus(), 200);
+
+        verify(variantService).updateVariant(variant);
+        assertNotEquals("The Secret", variant.getSecret());
+    }
+}

--- a/jaxrs/src/test/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/AndroidVariantEndpointTest.java
+++ b/jaxrs/src/test/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/AndroidVariantEndpointTest.java
@@ -1,20 +1,33 @@
 package org.jboss.aerogear.unifiedpush.rest.registry.applications;
 
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import org.jboss.aerogear.unifiedpush.api.AndroidVariant;
+import org.jboss.aerogear.unifiedpush.api.PushApplication;
+import org.jboss.aerogear.unifiedpush.api.Variant;
 import org.jboss.aerogear.unifiedpush.api.iOSVariant;
 import org.jboss.aerogear.unifiedpush.service.GenericVariantService;
 import org.jboss.aerogear.unifiedpush.service.PushApplicationService;
+import org.jboss.aerogear.unifiedpush.service.PushSearchService;
+import org.jboss.aerogear.unifiedpush.service.impl.SearchManager;
+import org.jboss.resteasy.spi.ResteasyUriInfo;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import javax.validation.ConstraintViolation;
+import javax.validation.Path;
+import javax.validation.Validator;
+import javax.validation.metadata.ConstraintDescriptor;
 import javax.ws.rs.core.Response;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
 
 import static org.junit.Assert.*;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AndroidVariantEndpointTest {
@@ -27,14 +40,114 @@ public class AndroidVariantEndpointTest {
     @Mock
     GenericVariantService variantService;
 
+    @Mock
+    SearchManager searchManager;
+
+    @Mock
+    PushSearchService searchService;
+
+    @Mock
+    Validator validator;
+
+    ConstraintViolation sampleViolation = new StubConstraintViolation();
+
     @Before
     public void before() {
-        this.endpoint = new AndroidVariantEndpoint();
+        this.endpoint = new AndroidVariantEndpoint(validator, searchManager);
 
         this.endpoint.pushAppService = pushAppService;
         this.endpoint.variantService = variantService;
+
+        when(searchManager.getSearchService()).thenReturn(searchService);
     }
 
+    @Test
+    public void shouldRegisterAndroidVariantSuccessfully() {
+        final AndroidVariant variant = new AndroidVariant();
+        final ResteasyUriInfo uriInfo = new ResteasyUriInfo("http://example.org/abc", "", "push");
+        final PushApplication pushApp = new PushApplication();
+
+        when(searchService.findByPushApplicationIDForDeveloper("push-app-id")).thenReturn(pushApp);
+        when(validator.validate(variant)).thenReturn(Collections.EMPTY_SET);
+
+        final Response response = this.endpoint.registerAndroidVariant(variant, "push-app-id", uriInfo);
+
+        assertEquals(response.getStatus(), 201);
+        assertTrue(response.getEntity() == variant);        // identity check
+        assertEquals(response.getMetadata().get("location").get(0).toString(), "http://example.org/abc/" + variant.getVariantID());
+
+        verify(variantService).addVariant(variant);
+        verify(pushAppService).addVariant(pushApp, variant);
+    }
+
+    @Test
+    public void registerAndroidVariantShouldReturn404WhenPushAppDoesNotExist() {
+        final AndroidVariant variant = new AndroidVariant();
+        final ResteasyUriInfo uriInfo = new ResteasyUriInfo("http://example.org/abc", "", "push");
+        final PushApplication pushApp = new PushApplication();
+
+        when(searchService.findByPushApplicationIDForDeveloper("push-app-id")).thenReturn(null);
+
+        final Response response = this.endpoint.registerAndroidVariant(variant, "push-app-id", uriInfo);
+
+        assertEquals(response.getStatus(), 404);
+
+        verify(variantService, never()).addVariant(any());
+        verify(validator, never()).validate(any());
+        verify(pushAppService, never()).addVariant(any(), any());
+    }
+
+    @Test
+    public void registerAndroidVariantShouldReturn400WhenVariantModelIsNotValid() {
+        final AndroidVariant variant = new AndroidVariant();
+        final ResteasyUriInfo uriInfo = new ResteasyUriInfo("http://example.org/abc", "", "push");
+        final PushApplication pushApp = new PushApplication();
+
+        when(searchService.findByPushApplicationIDForDeveloper("push-app-id")).thenReturn(pushApp);
+        when(validator.validate(variant)).thenReturn(Sets.newHashSet(sampleViolation));
+
+        final Response response = this.endpoint.registerAndroidVariant(variant, "push-app-id", uriInfo);
+
+        assertEquals(response.getStatus(), 400);
+
+        verify(variantService, never()).addVariant(variant);
+        verify(pushAppService, never()).addVariant(pushApp, variant);
+    }
+
+    @Test
+    public void shouldListAllAndroidVariationsForPushAppSuccessfully() {
+        final Variant androidVariant = new AndroidVariant();
+        final Variant iOSVariant = new iOSVariant();
+        final PushApplication pushApp = new PushApplication();
+        pushApp.setVariants(Lists.newArrayList(androidVariant, iOSVariant));
+
+        when(searchService.findByPushApplicationIDForDeveloper("push-app-id")).thenReturn(pushApp);
+
+        final Response response = this.endpoint.listAllAndroidVariationsForPushApp("push-app-id");
+
+        assertEquals(response.getStatus(), 200);
+        assertTrue(((Collection) response.getEntity()).iterator().next() == androidVariant);        // identity check
+    }
+
+    @Test
+    public void shouldUpdateAndroidVariantSuccessfully() {
+        final AndroidVariant originalVariant = new AndroidVariant();
+        final AndroidVariant updatedVariant = new AndroidVariant();
+
+        originalVariant.setGoogleKey("Original Google Key");
+        updatedVariant.setGoogleKey("Updated Google Key");
+
+        when(variantService.findByVariantID("variant-id")).thenReturn(originalVariant);
+        when(validator.validate(updatedVariant)).thenReturn(Collections.EMPTY_SET);
+
+        final Response response = this.endpoint.updateAndroidVariant("push-app-id", "variant-id", updatedVariant);
+
+        assertEquals(response.getStatus(), 200);
+        assertTrue(response.getEntity() == originalVariant);        // identity check
+        assertEquals(originalVariant.getGoogleKey(), "Updated Google Key");
+
+        verify(variantService).updateVariant(originalVariant);
+    }
 
     @Test
     public void shouldReturn404WhenFindVariantByIdCannotFindAnyVariants() {
@@ -117,5 +230,51 @@ public class AndroidVariantEndpointTest {
 
         verify(variantService).updateVariant(variant);
         assertNotEquals("The Secret", variant.getSecret());
+    }
+
+    // stub class to mock constraint violation
+    private static class StubConstraintViolation implements ConstraintViolation {
+
+        public String getMessage() {
+            return "stub violation message";
+        }
+
+        public Path getPropertyPath() {
+            return new Path() {
+                @Override
+                public Iterator<Node> iterator() {
+                    return null;
+                }
+
+                @Override
+                public String toString() {
+                    return "stub violation path";
+                }
+            };
+        }
+
+        public String getMessageTemplate() {
+            return null;
+        }
+
+        public Object getRootBean() {
+            return null;
+        }
+
+        public Class getRootBeanClass() {
+            return null;
+        }
+
+        public Object getLeafBean() {
+            return null;
+        }
+
+        public Object getInvalidValue() {
+            return null;
+        }
+
+        public ConstraintDescriptor<?> getConstraintDescriptor() {
+            return null;
+        }
     }
 }

--- a/jaxrs/src/test/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/WindowsVariantEndpointTest.java
+++ b/jaxrs/src/test/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/WindowsVariantEndpointTest.java
@@ -1,0 +1,81 @@
+package org.jboss.aerogear.unifiedpush.rest.registry.applications;
+
+import org.jboss.aerogear.unifiedpush.api.WindowsVariant;
+import org.jboss.aerogear.unifiedpush.api.WindowsWNSVariant;
+import org.jboss.aerogear.unifiedpush.service.GenericVariantService;
+import org.jboss.aerogear.unifiedpush.service.PushApplicationService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import javax.ws.rs.core.Response;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class WindowsVariantEndpointTest {
+    WindowsVariantEndpoint endpoint;
+
+    @Mock
+    PushApplicationService pushAppService;
+
+    @Mock
+    GenericVariantService variantService;
+
+    @Before
+    public void before() {
+        this.endpoint = new WindowsVariantEndpoint();
+
+        this.endpoint.pushAppService = pushAppService;
+        this.endpoint.variantService = variantService;
+    }
+
+    @Test
+    public void shouldFindVariantById() {
+        // base cases for findVariantById of WindowsVariantEndpoint is
+        // tested in AndroidVariantEndpointTest
+
+        final WindowsVariant variant = new WindowsWNSVariant();
+        when(variantService.findByVariantID("123")).thenReturn(variant);
+
+        final Response response = this.endpoint.findVariantById("123");
+        assertEquals(response.getStatus(), 200);
+        assertTrue(variant == response.getEntity());    // identity check
+    }
+
+    @Test
+    public void shouldDeleteVariant() {
+        // base cases for deleteVariant of WindowsVariantEndpoint is
+        // tested in AndroidVariantEndpointTest
+
+        final WindowsVariant variant = new WindowsWNSVariant();
+        when(variantService.findByVariantID("123")).thenReturn(variant);
+
+        final Response response = this.endpoint.deleteVariant("123");
+        assertEquals(response.getStatus(), 204);
+
+        verify(variantService).removeVariant(variant);
+    }
+
+    @Test
+    public void shouldResetSecret() {
+        // base cases for resetSecret of WindowsVariantEndpoint is
+        // tested in AndroidVariantEndpointTest
+
+        final WindowsVariant variant = new WindowsWNSVariant();
+        variant.setSecret("The Secret");
+
+        when(variantService.findByVariantID("123")).thenReturn(variant);
+
+        final Response response = this.endpoint.resetSecret("123");
+        assertEquals(response.getStatus(), 200);
+
+        verify(variantService).updateVariant(variant);
+        assertNotEquals("The Secret", variant.getSecret());
+    }
+
+}

--- a/jaxrs/src/test/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/WindowsVariantEndpointTest.java
+++ b/jaxrs/src/test/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/WindowsVariantEndpointTest.java
@@ -1,16 +1,22 @@
 package org.jboss.aerogear.unifiedpush.rest.registry.applications;
 
+import org.jboss.aerogear.unifiedpush.api.*;
 import org.jboss.aerogear.unifiedpush.api.WindowsVariant;
-import org.jboss.aerogear.unifiedpush.api.WindowsWNSVariant;
 import org.jboss.aerogear.unifiedpush.service.GenericVariantService;
 import org.jboss.aerogear.unifiedpush.service.PushApplicationService;
+import org.jboss.aerogear.unifiedpush.service.PushSearchService;
+import org.jboss.aerogear.unifiedpush.service.impl.SearchManager;
+import org.jboss.resteasy.spi.ResteasyUriInfo;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import javax.validation.Validator;
 import javax.ws.rs.core.Response;
+
+import java.util.Collections;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.verify;
@@ -26,12 +32,65 @@ public class WindowsVariantEndpointTest {
     @Mock
     GenericVariantService variantService;
 
+    @Mock
+    SearchManager searchManager;
+
+    @Mock
+    PushSearchService searchService;
+
+    @Mock
+    Validator validator;
+
     @Before
     public void before() {
-        this.endpoint = new WindowsVariantEndpoint();
+        this.endpoint = new WindowsVariantEndpoint(validator, searchManager);
 
         this.endpoint.pushAppService = pushAppService;
         this.endpoint.variantService = variantService;
+
+        when(searchManager.getSearchService()).thenReturn(searchService);
+    }
+
+    @Test
+    public void shouldRegisterWindowsVariantSuccessfully() {
+        final ResteasyUriInfo uriInfo = new ResteasyUriInfo("http://example.org/abc", "", "push");
+        final PushApplication pushApp = new PushApplication();
+
+        final WindowsVariant variant = new WindowsWNSVariant();
+        variant.setName("variant name");
+
+        when(searchService.findByPushApplicationIDForDeveloper("push-app-id")).thenReturn(pushApp);
+        when(validator.validate(variant)).thenReturn(Collections.EMPTY_SET);
+
+        final Response response = this.endpoint.registerWindowsVariant(variant, "push-app-id", uriInfo);
+
+        assertEquals(response.getStatus(), 201);
+        final WindowsVariant createdVariant = (WindowsVariant) response.getEntity();
+        assertEquals(createdVariant.getName(), "variant name");
+        assertEquals(response.getMetadata().get("location").get(0).toString(), "http://example.org/abc/" + createdVariant.getVariantID());
+
+        verify(variantService).addVariant(createdVariant);
+        verify(pushAppService).addVariant(pushApp, createdVariant);
+    }
+
+    @Test
+    public void shouldUpdateWindowsVariantSuccessfully() {
+        final WindowsWNSVariant original = new WindowsWNSVariant();
+
+        final WindowsWNSVariant update = new WindowsWNSVariant();
+        update.setName("variant name");
+        update.setClientSecret("client secret");
+
+        when(variantService.findByVariantID("variant-id")).thenReturn(original);
+        when(validator.validate(update)).thenReturn(Collections.EMPTY_SET);
+
+        final Response response = this.endpoint.updateWindowsVariant("variant-id", update);
+
+        assertEquals(response.getStatus(), 200);
+        assertEquals(original.getName(), "variant name");
+        assertEquals(original.getClientSecret(), "client secret");
+
+        verify(variantService).updateVariant(original);
     }
 
     @Test

--- a/jaxrs/src/test/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/iOSVariantEndpointTest.java
+++ b/jaxrs/src/test/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/iOSVariantEndpointTest.java
@@ -1,0 +1,79 @@
+package org.jboss.aerogear.unifiedpush.rest.registry.applications;
+
+import org.jboss.aerogear.unifiedpush.api.iOSVariant;
+import org.jboss.aerogear.unifiedpush.service.GenericVariantService;
+import org.jboss.aerogear.unifiedpush.service.PushApplicationService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import javax.ws.rs.core.Response;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class iOSVariantEndpointTest {
+    iOSVariantEndpoint endpoint;
+
+    @Mock
+    PushApplicationService pushAppService;
+
+    @Mock
+    GenericVariantService variantService;
+
+    @Before
+    public void before(){
+        this.endpoint = new iOSVariantEndpoint();
+
+        this.endpoint.pushAppService = pushAppService;
+        this.endpoint.variantService = variantService;
+    }
+
+    @Test
+    public void shouldFindVariantById(){
+        // base cases for findVariantById of iOSVariantEndpoint is
+        // tested in AndroidVariantEndpointTest
+
+        final iOSVariant variant = new iOSVariant();
+        when(variantService.findByVariantID("123")).thenReturn(variant);
+
+        final Response response = this.endpoint.findVariantById("123");
+        assertEquals(response.getStatus(), 200);
+        assertTrue(variant == response.getEntity());    // identity check
+    }
+
+    @Test
+    public void shouldDeleteVariant(){
+        // base cases for deleteVariant of iOSVariantEndpoint is
+        // tested in AndroidVariantEndpointTest
+
+        final iOSVariant variant = new iOSVariant();
+        when(variantService.findByVariantID("123")).thenReturn(variant);
+
+        final Response response = this.endpoint.deleteVariant("123");
+        assertEquals(response.getStatus(), 204);
+
+        verify(variantService).removeVariant(variant);
+    }
+
+    @Test
+    public void shouldResetSecret(){
+        // base cases for resetSecret of iOSVariantEndpoint is
+        // tested in AndroidVariantEndpointTest
+
+        final iOSVariant variant = new iOSVariant();
+        variant.setSecret("The Secret");
+
+        when(variantService.findByVariantID("123")).thenReturn(variant);
+
+        final Response response = this.endpoint.resetSecret("123");
+        assertEquals(response.getStatus(), 200);
+
+        verify(variantService).updateVariant(variant);
+        assertNotEquals("The Secret", variant.getSecret());
+    }
+}

--- a/model/api/src/main/java/org/jboss/aerogear/unifiedpush/event/iOSVariantUpdateEvent.java
+++ b/model/api/src/main/java/org/jboss/aerogear/unifiedpush/event/iOSVariantUpdateEvent.java
@@ -18,6 +18,8 @@ package org.jboss.aerogear.unifiedpush.event;
 
 import org.jboss.aerogear.unifiedpush.api.iOSVariant;
 
+import java.util.Objects;
+
 /**
  * Fired when the iOS variant is updated to contain a new .p12 file,
  * therefore the update event is used to trigger a removal from the internal connection cache.
@@ -32,5 +34,18 @@ public class iOSVariantUpdateEvent {
 
     public iOSVariant getiOSVariant() {
         return iOSVariant;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof iOSVariantUpdateEvent)) return false;
+        iOSVariantUpdateEvent that = (iOSVariantUpdateEvent) o;
+        return Objects.equals(iOSVariant, that.iOSVariant);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(iOSVariant);
     }
 }


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/AGDROID-810

UPS offers a REST API to delete variants in the form of 'https://SERVER:PORT/CONTEXT/rest/applications/pushAppID/<PLATFORM>/variantId/'.

However the <PLATFORM> part (android or ios) is not checked and you can use either either value to delete a variant of another kind. This is not a critical bug because you still need a valid variant ID but is should be fixed.

### Impl
Convert the endpoint implementations in the base class to common methods and use them in the variant endpoint implementations.

Commits:
* https://github.com/aerogear/aerogear-unifiedpush-server/pull/1002/commits/dd8b7f5cd0062364bc8253b9fca27929d9b8c50c: Initial work 
* https://github.com/aerogear/aerogear-unifiedpush-server/pull/1002/commits/c55c3c58505a901346ee79d218909a748a7c2f3d: Return 400 instead of 404 if found variant is of another type
* https://github.com/aerogear/aerogear-unifiedpush-server/pull/1002/commits/2b709729c44cfab7a219e7cbc519f7aab3c54467: Tests for the modified parts above
* https://github.com/aerogear/aerogear-unifiedpush-server/pull/1002/commits/a2bc938729cd1a1766e652b2d9c7b78036c5315b: Tests for other operations in the variant endpoints were missing, so I wrote them.
  * In order to not go crazy with tests, I only wrote base case tests for AndroidVariantEndpoint! IOS and Windows endpoints have tests for happy cases
  * Needed to convert some field injections to constructor injections for testability. I've used the strategy "mandatory shit in constructor injections, optionals in field injections"
* https://github.com/aerogear/aerogear-unifiedpush-server/pull/1002/commits/20c9fb861e86606ca1a1fe6bde2c10706303bea6: RESTEasy (JAX WS impl we use) requires no-arg constructors on endpoints and won't work with the `@Inject` constuctors. So, needed to revert constructor injectors to field injectors. But, in order to make things testable, I added additional `protected` constructors to pass params to those endpoints. RESTEasy seems happy about that.
* https://github.com/aerogear/aerogear-unifiedpush-server/pull/1002/commits/317b453b985236fa6ca436c4f3c4cc2d2ce2bd95: Generify variant endpoint base class

