### PR TITLE
Add support for mutable-content key

### DIFF
--- a/model/push/src/main/java/org/jboss/aerogear/unifiedpush/message/apns/APNs.java
+++ b/model/push/src/main/java/org/jboss/aerogear/unifiedpush/message/apns/APNs.java
@@ -52,6 +52,9 @@ public class APNs implements Serializable {
     @JsonProperty("content-available")
     private boolean contentAvailable;
 
+    @JsonProperty("mutable-content")
+    private boolean mutableContent;
+
     /**
      * Returns the value of the 'action-category', which is used on the client (iOS for now),
      * to invoke a certain "user action" on the device, based on the push message. Implemented for iOS8
@@ -94,6 +97,18 @@ public class APNs implements Serializable {
 
     public void setContentAvailable(boolean contentAvailable) {
         this.contentAvailable = contentAvailable;
+    }
+
+    /**
+     * Returns the value of the 'mutable-content' key from the submitted payload.
+     * This key was introduced in iOS 10 and indicates if the remote notification’s content should be modified.
+     */
+    public boolean hasMutableContent() {
+        return mutableContent;
+    }
+
+    public void setMutableContent(boolean mutableContent) {
+        this.mutableContent = mutableContent;
     }
 
     /**

--- a/model/push/src/test/resources/message-format.json
+++ b/model/push/src/test/resources/message-format.json
@@ -23,6 +23,7 @@
       "action-category": "some value",
       "url-args": null,
       "content-available": true,
+      "mutable-content": false,
       "localized-key": null,
       "localized-arguments": null,
       "localized-title-key": null,

--- a/push-sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/apns/PushyApnsSender.java
+++ b/push-sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/apns/PushyApnsSender.java
@@ -185,7 +185,8 @@ public class PushyApnsSender implements PushNotificationSender {
                 .setActionButtonLabel(apns.getAction())
                 .setUrlArguments(apns.getUrlArgs())
                 .setCategoryName(apns.getActionCategory())
-                .setContentAvailable(apns.isContentAvailable());
+                .setContentAvailable(apns.isContentAvailable())
+                .setMutableContent(apns.hasMutableContent());
 
         // custom fields
         final Map<String, Object> userData = message.getUserData();


### PR DESCRIPTION
The [UNNotificationServiceExtension](https://developer.apple.com/documentation/usernotifications/unnotificationserviceextension) was introduced in iOS 10 which adds the possibility to modify the remote notification’s content before displaying it. But the extension gets called only if the mutable-content key’s value is set to 1.

Since the underlying pushy supports the key the changes are very small.