### PR TITLE
better organization of the dmp and latest version

### DIFF
--- a/servers/keycloak/pom.xml
+++ b/servers/keycloak/pom.xml
@@ -136,7 +136,6 @@
             <plugin>
                 <groupId>io.fabric8</groupId>
                 <artifactId>docker-maven-plugin</artifactId>
-                <version>0.24.0</version>
                 <executions>
                     <execution>
                         <id>dmp</id>

--- a/servers/plain/pom.xml
+++ b/servers/plain/pom.xml
@@ -116,7 +116,6 @@
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>docker-maven-plugin</artifactId>
-        <version>0.24.0</version>
           <executions>
               <execution>
                   <id>dmp</id>

--- a/servers/pom.xml
+++ b/servers/pom.xml
@@ -25,6 +25,16 @@
     <artifactId>unifiedpush-servers</artifactId>
     <packaging>pom</packaging>
     <build>
+        <pluginManagement>
+            <plugins>
+              <plugin>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <version>0.26.0</version>
+              </plugin>
+            </plugins>
+        </pluginManagement>
+
         <plugins>
             <plugin>
               <groupId>org.wildfly.plugins</groupId>


### PR DESCRIPTION
Moved the `dmp` to the plugin management section of the servers artifact.

This allows to quick updates (e.g. version) for all nested projects 