### PR TITLE
Dev/plain image using WF 13 release

### DIFF
--- a/servers/plain/pom.xml
+++ b/servers/plain/pom.xml
@@ -29,7 +29,7 @@
     <name>UnifiedPush Server for Wildfly (Plain)</name>
 
     <properties>
-        <base>jboss/wildfly:12.0.0.Final</base>
+        <base>jboss/wildfly:13.0.0.Final</base>
         <configFile>standalone-full.xml</configFile>
         <project.artifactId>${project.artifactId}</project.artifactId>
     </properties>


### PR DESCRIPTION
Latest WF release got containerized.

build the project, run the `plain` image, like:
```
docker run aerogear/ups:plain
```

and notice something like at the end of the startup:
```
08:00:27,382 INFO  [org.jboss.as] (Controller Boot Thread) WFLYSRV0025: WildFly Full 13.0.0.Final (WildFly Core 5.0.0.Final) started in 7903ms - Started 783 of 973 services (359 services are lazy, passive or on-demand)
```