### PR TITLE
Fixing tests on EDT

### DIFF
--- a/migrator/src/test/java/org/jboss/aerogear/unifiedpush/migrator/EmbeddedMysqlDatabase.java
+++ b/migrator/src/test/java/org/jboss/aerogear/unifiedpush/migrator/EmbeddedMysqlDatabase.java
@@ -44,7 +44,7 @@ public class EmbeddedMysqlDatabase {
         mysqldResource = new MysqldResource(baseDir);
         mysqldResource.start("mysql", databaseOptions);
 
-        url = "jdbc:mysql://localhost:" + port + "/" + databaseName + "?" + "createDatabaseIfNotExist=true";
+        url = "jdbc:mysql://localhost:" + port + "/" + databaseName + "?" + "createDatabaseIfNotExist=true&useJDBCCompliantTimezoneShift=true&useLegacyDatetimeCode=false&serverTimezone=UTC";
     }
 
     public void close() {


### PR DESCRIPTION
## Motivation
Seems like the mirgator tests don't like being run in EDT with the newest mysql versions.

## What
I've changed the connection url for the tests to hardcode to UTC

## Why
I got an error, and this so question was an answer https://stackoverflow.com/questions/26515700/mysql-jdbc-driver-5-1-33-time-zone-issue/44720416#44720416

## Verification Steps
mvn clean install
 