### PR TITLE
Have APNSCertificate change events use a JMS topic instead of CDI event

### DIFF
--- a/docker-compose/artemis-overrides/broker-00.xml
+++ b/docker-compose/artemis-overrides/broker-00.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+
+<configuration xmlns="urn:activemq" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:activemq /schema/artemis-configuration.xsd">
+   <!-- from 1.0.0 to 1.5.5 the following line should be : <core xmlns="urn:activemq:core"> -->
+   <core xmlns="urn:activemq:core" xsi:schemaLocation="urn:activemq:core ">
+      <acceptors>
+        <acceptor name="netty-acceptor">tcp://0.0.0.0:61617?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576;protocols=CORE,AMQP,STOMP,HORNETQ,MQTT,OPENWIRE;useEpoll=true;amqpCredits=1000;amqpLowCredits=300;anycastPrefix=jms.queue.;multicastPrefix=jms.topic.</acceptor>
+        </acceptors>
+   </core>
+</configuration>

--- a/docker-compose/docker-compose-v2.1.yaml
+++ b/docker-compose/docker-compose-v2.1.yaml
@@ -2,7 +2,7 @@ version: '2.1'
 
 services:
   unifiedpushserver:
-    image: docker.io/aerogear/unifiedpush-wildfly:2.1.0
+    image: aerogear/unifiedpush-wildfly-plain:2.2.2-SNAPSHOT
     volumes:
        - ./helper:/ups-helper:z
     entrypoint: "/ups-helper/exportKeycloakHost.sh"
@@ -19,6 +19,7 @@ services:
         KEYCLOAK_SERVICE_PORT: ${KEYCLOAK_SERVICE_PORT}
     links:
       - unifiedpushDB:unifiedpush
+      - artemis:artemis
       - keycloakServer:keycloak
     ports:
       - 9999:8080
@@ -40,3 +41,12 @@ services:
     environment:
       KEYCLOAK_USER: ${KEYCLOAK_USER}
       KEYCLOAK_PASSWORD: ${KEYCLOAK_PASSWORD}
+  artemis:
+    image: vromero/activemq-artemis
+    volumes:
+      - ./artemis-overrides:/var/lib/artemis/etc-override:z
+    ports:
+      - 8161:8161
+      - 61616:61616
+      - 61617:61617
+ 

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/iOSVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/iOSVariantEndpoint.java
@@ -18,13 +18,12 @@ package org.jboss.aerogear.unifiedpush.rest.registry.applications;
 
 import org.jboss.aerogear.unifiedpush.api.PushApplication;
 import org.jboss.aerogear.unifiedpush.api.iOSVariant;
-import org.jboss.aerogear.unifiedpush.event.iOSVariantUpdateEvent;
+import org.jboss.aerogear.unifiedpush.message.jms.APNSClientProducer;
 import org.jboss.aerogear.unifiedpush.rest.annotations.PATCH;
 import org.jboss.aerogear.unifiedpush.rest.util.iOSApplicationUploadForm;
 import org.jboss.aerogear.unifiedpush.service.impl.SearchManager;
 import org.jboss.resteasy.annotations.providers.multipart.MultipartForm;
 
-import javax.enterprise.event.Event;
 import javax.inject.Inject;
 import javax.validation.ConstraintViolationException;
 import javax.validation.Validator;
@@ -40,7 +39,7 @@ import javax.ws.rs.core.UriInfo;
 public class iOSVariantEndpoint extends AbstractVariantEndpoint<iOSVariant> {
 
     @Inject
-    protected Event<iOSVariantUpdateEvent> variantUpdateEventEvent;
+    protected APNSClientProducer producer;
 
     // required for RESTEasy
     public iOSVariantEndpoint() {
@@ -224,7 +223,7 @@ public class iOSVariantEndpoint extends AbstractVariantEndpoint<iOSVariant> {
 
             // update performed, we now need to invalidate existing connection w/ APNs:
             logger.trace("Updating iOS Variant '{}'", iOSVariant.getVariantID());
-            variantUpdateEventEvent.fire(new iOSVariantUpdateEvent(iOSVariant));
+            producer.changeAPNClient(iOSVariant);
             variantService.updateVariant(iOSVariant);
             return Response.ok(iOSVariant).build();
         }

--- a/jaxrs/src/test/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/iOSVariantEndpointTest.java
+++ b/jaxrs/src/test/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/iOSVariantEndpointTest.java
@@ -53,7 +53,7 @@ public class iOSVariantEndpointTest {
 
         this.endpoint.pushAppService = pushAppService;
         this.endpoint.variantService = variantService;
-        this.endpoint.variantUpdateEventEvent = variantUpdateEventEvent;
+//        this.endpoint.variantUpdateEventEvent = variantUpdateEventEvent;
 
         when(searchManager.getSearchService()).thenReturn(searchService);
     }

--- a/model/jpa/pom.xml
+++ b/model/jpa/pom.xml
@@ -82,7 +82,12 @@
                     <artifactId>hibernate-entitymanager</artifactId>
                     <scope>test</scope>
                 </dependency>
-        
+        <dependency>
+    <groupId>javax.xml.bind</groupId>
+    <artifactId>jaxb-api</artifactId>
+    <version>2.2.11</version>
+                        <scope>test</scope>
+</dependency>
                 <dependency>
                     <groupId>org.hibernate</groupId>
                     <artifactId>hibernate-validator</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
       <dependency>
         <groupId>org.apache.openejb</groupId>
         <artifactId>openejb-core-hibernate</artifactId>
-        <version>4.7.0</version>
+        <version>4.7.5</version>
         <type>pom</type>
       </dependency>
 

--- a/push-sender/pom.xml
+++ b/push-sender/pom.xml
@@ -34,6 +34,13 @@
         </dependency>
 
         <dependency>
+            <groupId>jboss</groupId>
+            <artifactId>jboss-annotations-ejb3</artifactId>
+            <version>4.2.2.GA</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
             <scope>provided</scope>

--- a/push-sender/src/main/java/org/jboss/aerogear/unifiedpush/message/cache/SimpleApnsClientCache.java
+++ b/push-sender/src/main/java/org/jboss/aerogear/unifiedpush/message/cache/SimpleApnsClientCache.java
@@ -1,13 +1,13 @@
 /**
  * JBoss, Home of Professional Open Source
  * Copyright Red Hat, Inc., and individual contributors.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- * 	http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,13 +23,11 @@ import net.jodah.expiringmap.ExpirationListener;
 import net.jodah.expiringmap.ExpirationPolicy;
 import net.jodah.expiringmap.ExpiringMap;
 import org.jboss.aerogear.unifiedpush.api.iOSVariant;
-import org.jboss.aerogear.unifiedpush.event.iOSVariantUpdateEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.PreDestroy;
 import javax.ejb.Singleton;
-import javax.enterprise.event.Observes;
 import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
@@ -40,6 +38,7 @@ public class SimpleApnsClientCache {
     private static final Logger logger = LoggerFactory.getLogger(SimpleApnsClientCache.class);
 
     final ConcurrentMap<String, ApnsClient> apnsClientExpiringMap;
+
     {
         apnsClientExpiringMap = ExpiringMap.builder()
 
@@ -89,10 +88,9 @@ public class SimpleApnsClientCache {
 
     /**
      * Receives iOS variant change event to remove client from the cache and also tear down the connection.
-     * @param iOSVariantUpdateEvent event fired when updating the variant
+     * @param variant event fired when updating the variant
      */
-    public void disconnectOnChange(@Observes final iOSVariantUpdateEvent iOSVariantUpdateEvent) {
-        final iOSVariant variant = iOSVariantUpdateEvent.getiOSVariant();
+    public void disconnectOnChange(final iOSVariant variant) {
         final String connectionKey = extractConnectionKey(variant);
         final ApnsClient client = apnsClientExpiringMap.remove(connectionKey);
         logger.debug("Removed client from cache for {}", variant.getVariantID());
@@ -106,7 +104,7 @@ public class SimpleApnsClientCache {
                 .append(iOSVariant.getVariantID())
                 .append(iOSVariant.isProduction() ? "-prod" : "-dev");
 
-        return  sb.toString();
+        return sb.toString();
     }
 
     private void putApnsClientForVariantID(final String variantID, final ApnsClient apnsClient) {

--- a/push-sender/src/main/java/org/jboss/aerogear/unifiedpush/message/jms/APNSClientConsumer.java
+++ b/push-sender/src/main/java/org/jboss/aerogear/unifiedpush/message/jms/APNSClientConsumer.java
@@ -1,0 +1,24 @@
+package org.jboss.aerogear.unifiedpush.message.jms;
+
+import org.jboss.aerogear.unifiedpush.api.iOSVariant;
+import org.jboss.aerogear.unifiedpush.message.cache.SimpleApnsClientCache;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+import javax.inject.Inject;
+
+public class APNSClientConsumer extends AbstractJMSMessageListener<iOSVariant> {
+
+    @Inject
+    SimpleApnsClientCache apnsClientCache;
+
+    private static final Logger logger = LoggerFactory.getLogger(APNSClientConsumer.class);
+
+    @Override
+    public void onMessage(iOSVariant iOSVariant) {
+        logger.info("Resetting iOS with new cert");
+        apnsClientCache.disconnectOnChange(iOSVariant);
+    }
+
+}

--- a/push-sender/src/main/java/org/jboss/aerogear/unifiedpush/message/jms/APNSClientProducer.java
+++ b/push-sender/src/main/java/org/jboss/aerogear/unifiedpush/message/jms/APNSClientProducer.java
@@ -1,0 +1,16 @@
+package org.jboss.aerogear.unifiedpush.message.jms;
+
+import org.jboss.aerogear.unifiedpush.api.iOSVariant;
+
+import javax.ejb.Stateless;
+
+@Stateless
+public class APNSClientProducer extends AbstractJMSMessageProducer {
+
+    private String apnsClient = "topic/APNSClient";
+
+    public void changeAPNClient(iOSVariant iOSVariant) {
+        super.sendTransacted(apnsClient, iOSVariant, true);
+    }
+
+}

--- a/push-sender/src/main/java/org/jboss/aerogear/unifiedpush/message/jms/AbstractJMSMessageListener.java
+++ b/push-sender/src/main/java/org/jboss/aerogear/unifiedpush/message/jms/AbstractJMSMessageListener.java
@@ -16,8 +16,8 @@
  */
 package org.jboss.aerogear.unifiedpush.message.jms;
 
-import javax.annotation.Resource;
-import javax.jms.ConnectionFactory;
+import javax.ejb.TransactionAttributeType;
+import javax.ejb.TransactionAttribute;
 import javax.jms.Destination;
 import javax.jms.JMSException;
 import javax.jms.Message;
@@ -35,16 +35,15 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class AbstractJMSMessageListener<T> implements MessageListener {
 
-    @Resource(mappedName = "java:/ConnectionFactory")
-    private ConnectionFactory connectionFactory;
-
     private static final Logger logger = LoggerFactory.getLogger(AbstractJMSMessageListener.class);
 
     public abstract void onMessage(T message);
 
     @SuppressWarnings("unchecked")
     @Override
+    @TransactionAttribute(TransactionAttributeType.REQUIRED)
     public void onMessage(Message jmsMessage) {
+        logger.debug("message get " + jmsMessage.toString());
         try {
             if (jmsMessage instanceof ObjectMessage) {
                 Object messageObject = ((ObjectMessage) jmsMessage).getObject();

--- a/push-sender/src/main/java/org/jboss/aerogear/unifiedpush/message/jms/AbstractJMSMessageProducer.java
+++ b/push-sender/src/main/java/org/jboss/aerogear/unifiedpush/message/jms/AbstractJMSMessageProducer.java
@@ -23,7 +23,6 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Resource;
 import javax.jms.Connection;
 import javax.jms.ConnectionFactory;
-import javax.jms.Destination;
 import javax.jms.JMSException;
 import javax.jms.MessageProducer;
 import javax.jms.ObjectMessage;
@@ -40,10 +39,10 @@ public abstract class AbstractJMSMessageProducer {
     @Resource(mappedName = "java:/ConnectionFactory")
     private ConnectionFactory connectionFactory;
 
-    @Resource(mappedName = "java:/JmsXA")
+    @Resource(mappedName = "java:/jms/remoteXA")
     private ConnectionFactory xaConnectionFactory;
 
-    /**
+     /**
      * Sends message to the destination in non-transactional manner.
      *
      * @param destination where to send
@@ -51,7 +50,7 @@ public abstract class AbstractJMSMessageProducer {
      *
      * Since non-transacted session is used, the message is send immediately without requiring to commit enclosing transaction.
      */
-    protected void sendNonTransacted(Destination destination, Serializable message) {
+    protected void sendNonTransacted(String destination, Serializable message) {
         send(destination, message, null, null, false);
     }
 
@@ -63,7 +62,7 @@ public abstract class AbstractJMSMessageProducer {
      *
      * Since transacted session is used, the message won't be committed until whole enclosing transaction ends
      */
-    protected void sendTransacted(Destination destination, Serializable message) {
+    protected void sendTransacted(String destination, Serializable message) {
         send(destination, message, null, null, true);
     }
 
@@ -77,7 +76,7 @@ public abstract class AbstractJMSMessageProducer {
      *
      * Since non-transacted session is used, the message is send immediately without requiring to commit enclosing transaction.
      */
-    protected void sendNonTransacted(Destination destination, Serializable message, String propertyName, String propertValue) {
+    protected void sendNonTransacted(String destination, Serializable message, String propertyName, String propertValue) {
         send(destination, message, propertyName, propertValue, false);
     }
 
@@ -91,11 +90,11 @@ public abstract class AbstractJMSMessageProducer {
      *
      * Since transacted session is used, the message won't be committed until whole enclosing transaction ends.
      */
-    protected void sendTransacted(Destination destination, Serializable message, String propertyName, String propertValue) {
+    protected void sendTransacted(String destination, Serializable message, String propertyName, String propertValue) {
         send(destination, message, propertyName, propertValue, true);
     }
 
-    private void send(Destination destination, Serializable message, String propertyName, String propertValue, boolean transacted) {
+    private void send(String destination, Serializable message, String propertyName, String propertValue, boolean transacted) {
         Connection connection = null;
         try {
             if (transacted) {
@@ -104,14 +103,17 @@ public abstract class AbstractJMSMessageProducer {
                 connection = connectionFactory.createConnection();
             }
             Session session = connection.createSession(transacted, Session.AUTO_ACKNOWLEDGE);
-            MessageProducer messageProducer = session.createProducer(destination);
+            MessageProducer messageProducer = session.createProducer(session.createQueue(destination));
+            logger.debug("Destination is " + destination.toString());
             connection.start();
             ObjectMessage objectMessage = session.createObjectMessage(message);
             if (propertyName != null) {
                 objectMessage.setStringProperty(propertyName, propertValue);
             }
             messageProducer.send(objectMessage);
+            logger.debug("Sending complete");
         } catch (JMSException e) {
+            logger.error("Error sending", e.getMessage(), e);
             throw new MessageDeliveryException("Failed to queue push message for further processing", e);
         } finally {
             if (connection != null) {

--- a/push-sender/src/main/java/org/jboss/aerogear/unifiedpush/message/jms/AbstractJMSMessageProducer.java
+++ b/push-sender/src/main/java/org/jboss/aerogear/unifiedpush/message/jms/AbstractJMSMessageProducer.java
@@ -50,8 +50,8 @@ public abstract class AbstractJMSMessageProducer {
      *
      * Since non-transacted session is used, the message is send immediately without requiring to commit enclosing transaction.
      */
-    protected void sendNonTransacted(String destination, Serializable message) {
-        send(destination, message, null, null, false);
+    protected void sendNonTransacted(String destination, Serializable message, boolean useTopic) {
+        send(destination, message, null, null, false, useTopic);
     }
 
     /**
@@ -62,8 +62,8 @@ public abstract class AbstractJMSMessageProducer {
      *
      * Since transacted session is used, the message won't be committed until whole enclosing transaction ends
      */
-    protected void sendTransacted(String destination, Serializable message) {
-        send(destination, message, null, null, true);
+    protected void sendTransacted(String destination, Serializable message, boolean useTopic) {
+        send(destination, message, null, null, true, useTopic);
     }
 
     /**
@@ -76,8 +76,8 @@ public abstract class AbstractJMSMessageProducer {
      *
      * Since non-transacted session is used, the message is send immediately without requiring to commit enclosing transaction.
      */
-    protected void sendNonTransacted(String destination, Serializable message, String propertyName, String propertValue) {
-        send(destination, message, propertyName, propertValue, false);
+    protected void sendNonTransacted(String destination, Serializable message, String propertyName, String propertValue, boolean useTopic) {
+        send(destination, message, propertyName, propertValue, false, useTopic);
     }
 
     /**
@@ -90,11 +90,11 @@ public abstract class AbstractJMSMessageProducer {
      *
      * Since transacted session is used, the message won't be committed until whole enclosing transaction ends.
      */
-    protected void sendTransacted(String destination, Serializable message, String propertyName, String propertValue) {
-        send(destination, message, propertyName, propertValue, true);
+    protected void sendTransacted(String destination, Serializable message, String propertyName, String propertValue, boolean useTopic) {
+        send(destination, message, propertyName, propertValue, true, useTopic);
     }
 
-    private void send(String destination, Serializable message, String propertyName, String propertValue, boolean transacted) {
+    private void send(String destination, Serializable message, String propertyName, String propertValue, boolean transacted, boolean useTopic) {
         Connection connection = null;
         try {
             if (transacted) {
@@ -103,7 +103,12 @@ public abstract class AbstractJMSMessageProducer {
                 connection = connectionFactory.createConnection();
             }
             Session session = connection.createSession(transacted, Session.AUTO_ACKNOWLEDGE);
-            MessageProducer messageProducer = session.createProducer(session.createQueue(destination));
+            MessageProducer messageProducer;
+            if (useTopic) {
+                messageProducer = session.createProducer(session.createTopic(destination));
+            } else {
+                messageProducer = session.createProducer(session.createQueue(destination));
+            }
             logger.debug("Destination is " + destination.toString());
             connection.start();
             ObjectMessage objectMessage = session.createObjectMessage(message);

--- a/push-sender/src/main/java/org/jboss/aerogear/unifiedpush/message/jms/MessageHolderWithTokensConsumer.java
+++ b/push-sender/src/main/java/org/jboss/aerogear/unifiedpush/message/jms/MessageHolderWithTokensConsumer.java
@@ -46,7 +46,7 @@ public class MessageHolderWithTokensConsumer extends AbstractJMSMessageListener<
     @Override
     public void onMessage(MessageHolderWithTokens message) {
         try {
-            logger.trace("receiving tokens from queue, triggering Notification Dispatcher class to pick the right sender");
+            logger.debug("receiving tokens from queue, triggering Notification Dispatcher class to pick the right sender");
             dequeueEvent.fire(message);
         } catch (DispatchInitiationException e) {
             throw e;

--- a/push-sender/src/main/java/org/jboss/aerogear/unifiedpush/message/jms/MessageHolderWithTokensProducer.java
+++ b/push-sender/src/main/java/org/jboss/aerogear/unifiedpush/message/jms/MessageHolderWithTokensProducer.java
@@ -16,10 +16,8 @@
  */
 package org.jboss.aerogear.unifiedpush.message.jms;
 
-import javax.annotation.Resource;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
-import javax.jms.Queue;
 
 import org.jboss.aerogear.unifiedpush.api.VariantType;
 import org.jboss.aerogear.unifiedpush.message.holder.MessageHolderWithTokens;
@@ -39,14 +37,11 @@ public class MessageHolderWithTokensProducer extends AbstractJMSMessageProducer 
     @Inject
     private JmsClient jmsClient;
 
-    @Resource(mappedName = "java:/queue/APNsTokenBatchQueue")
-    private Queue apnsTokenBatchQueue;
+    private String apnsTokenBatchQueue = "APNsTokenBatchQueue";
 
-    @Resource(mappedName = "java:/queue/GCMTokenBatchQueue")
-    private Queue gcmTokenBatchQueue;
+    private String gcmTokenBatchQueue = "GCMTokenBatchQueue";
 
-    @Resource(mappedName = "java:/queue/WNSTokenBatchQueue")
-    private Queue wnsTokenBatchQueue;
+    private String wnsTokenBatchQueue = "WNSTokenBatchQueue";
 
     public void queueMessageVariantForProcessing(@Observes @DispatchToQueue MessageHolderWithTokens msg) {
         final VariantType variantType = msg.getVariant().getType();
@@ -55,7 +50,7 @@ public class MessageHolderWithTokensProducer extends AbstractJMSMessageProducer 
         jmsClient.send(msg).withDuplicateDetectionId(deduplicationId).to(selectQueue(variantType));
     }
 
-    private Queue selectQueue(VariantType variantType) {
+    private String selectQueue(VariantType variantType) {
         switch (variantType) {
             case ANDROID:
                 return gcmTokenBatchQueue;

--- a/push-sender/src/main/java/org/jboss/aerogear/unifiedpush/message/jms/MessageHolderWithVariantsConsumer.java
+++ b/push-sender/src/main/java/org/jboss/aerogear/unifiedpush/message/jms/MessageHolderWithVariantsConsumer.java
@@ -41,7 +41,7 @@ public class MessageHolderWithVariantsConsumer extends AbstractJMSMessageListene
 
     @Override
     public void onMessage(MessageHolderWithVariants message) {
-        logger.trace("receiving variant container from queue, triggering the TokenLoader class");
+        logger.info("receiving variant container from queue, triggering the TokenLoader class");
         dequeueEvent.fire(message);
     }
 }

--- a/push-sender/src/main/java/org/jboss/aerogear/unifiedpush/message/jms/MessageHolderWithVariantsProducer.java
+++ b/push-sender/src/main/java/org/jboss/aerogear/unifiedpush/message/jms/MessageHolderWithVariantsProducer.java
@@ -16,10 +16,8 @@
  */
 package org.jboss.aerogear.unifiedpush.message.jms;
 
-import javax.annotation.Resource;
 import javax.ejb.Stateless;
 import javax.enterprise.event.Observes;
-import javax.jms.Queue;
 
 import org.jboss.aerogear.unifiedpush.api.VariantType;
 import org.jboss.aerogear.unifiedpush.message.holder.MessageHolderWithVariants;
@@ -36,21 +34,21 @@ public class MessageHolderWithVariantsProducer extends AbstractJMSMessageProduce
 
     private static final Logger logger = LoggerFactory.getLogger(MessageHolderWithVariantsProducer.class);
 
-    @Resource(mappedName = "java:/queue/APNsPushMessageQueue")
-    private Queue apnsPushMessageQueue;
+    
+    private  final String apnsPushMessageQueue = "APNsPushMessageQueue";
 
-    @Resource(mappedName = "java:/queue/GCMPushMessageQueue")
-    private Queue gcmPushMessageQueue;
+    
+    private final String gcmPushMessageQueue = "GCMPushMessageQueue";
 
-    @Resource(mappedName = "java:/queue/WNSPushMessageQueue")
-    private Queue wnsPushMessageQueue;
+    
+    private final String wnsPushMessageQueue = "WNSPushMessageQueue";
 
     public void queueMessageVariantForProcessing(@Observes @DispatchToQueue MessageHolderWithVariants msg) {
-        logger.trace("dispatching for processing variants and trigger token querying/batching");
+        logger.debug("dispatching for processing variants and trigger token querying/batching");
         sendTransacted(selectQueue(msg.getVariantType()), msg);
     }
 
-    private Queue selectQueue(VariantType variantType) {
+    private String selectQueue(VariantType variantType) {
         switch (variantType) {
             case ANDROID:
                 return gcmPushMessageQueue;

--- a/push-sender/src/main/java/org/jboss/aerogear/unifiedpush/message/jms/MessageHolderWithVariantsProducer.java
+++ b/push-sender/src/main/java/org/jboss/aerogear/unifiedpush/message/jms/MessageHolderWithVariantsProducer.java
@@ -45,7 +45,7 @@ public class MessageHolderWithVariantsProducer extends AbstractJMSMessageProduce
 
     public void queueMessageVariantForProcessing(@Observes @DispatchToQueue MessageHolderWithVariants msg) {
         logger.debug("dispatching for processing variants and trigger token querying/batching");
-        sendTransacted(selectQueue(msg.getVariantType()), msg);
+        sendTransacted(selectQueue(msg.getVariantType()), msg, false);
     }
 
     private String selectQueue(VariantType variantType) {

--- a/push-sender/src/main/java/org/jboss/aerogear/unifiedpush/message/util/JmsClient.java
+++ b/push-sender/src/main/java/org/jboss/aerogear/unifiedpush/message/util/JmsClient.java
@@ -47,7 +47,7 @@ public class JmsClient {
     @Resource(mappedName = "java:/ConnectionFactory")
     private ConnectionFactory connectionFactory;
 
-    @Resource(mappedName = "java:/JmsXA")
+    @Resource(mappedName = "java:/jms/remoteXA")
     private ConnectionFactory xaConnectionFactory;
 
     /**
@@ -301,7 +301,7 @@ public class JmsClient {
          *
          * @param destination where to send
          */
-        public void to(Destination destination) {
+        public void to(String destination) {
             Connection connection = null;
             try {
                 if (transacted) {
@@ -310,7 +310,7 @@ public class JmsClient {
                     connection = connectionFactory.createConnection();
                 }
                 Session session = connection.createSession(transacted, autoAcknowledgeMode);
-                MessageProducer messageProducer = session.createProducer(destination);
+                MessageProducer messageProducer = session.createProducer(session.createQueue(destination));
                 connection.start();
                 ObjectMessage objectMessage = session.createObjectMessage(message);
                 for (Entry<String, Object> property : properties.entrySet()) {

--- a/servers/keycloak/src/main/docker/standalone-full.xml
+++ b/servers/keycloak/src/main/docker/standalone-full.xml
@@ -509,6 +509,7 @@
                 <jms-queue name="AllBatchesLoadedQueue" entries="queue/AllBatchesLoadedQueue"/>
                 <jms-queue name="FreeServiceSlotQueue" entries="queue/FreeServiceSlotQueue"/>
                 <jms-topic name="MetricsProcessingStartedTopic" entries="topic/MetricsProcessingStartedTopic"/>
+                <jms-topic name="APNSClientTopic" entries="topic/APNSClient"/>
                 <connection-factory name="InVmConnectionFactory" entries="java:/ConnectionFactory" connectors="in-vm"/>
                 <connection-factory name="RemoteConnectionFactory" entries="java:jboss/exported/jms/RemoteConnectionFactory" connectors="http-connector"/>
                 <pooled-connection-factory name="activemq-ra" entries="java:/JmsXA java:jboss/DefaultJMSConnectionFactory" connectors="in-vm" transaction="xa"/>

--- a/servers/keycloak/src/main/webapp/WEB-INF/jboss-ejb3.xml
+++ b/servers/keycloak/src/main/webapp/WEB-INF/jboss-ejb3.xml
@@ -83,7 +83,7 @@
                 </activation-config-property>
             </activation-config>
         </message-driven>
-        
+
         <!-- Token Batch Queue MDBs -->
         <message-driven>
             <ejb-name>APNsTokenBatchConsumer</ejb-name>
@@ -154,6 +154,28 @@
                 </activation-config-property>
             </activation-config>
         </message-driven>
-        
+        <message-driven>
+            <ejb-name>APNSClientConsumer</ejb-name>
+            <ejb-class>org.jboss.aerogear.unifiedpush.message.jms.APNSClientConsumer</ejb-class>
+            <transaction-type>Container</transaction-type>
+            <activation-config>
+                <activation-config-property>
+                    <activation-config-property-name>destination</activation-config-property-name>
+                    <activation-config-property-value>queue/APNSClient</activation-config-property-value>
+                </activation-config-property>
+                <activation-config-property>
+                    <activation-config-property-name>destinationType</activation-config-property-name>
+                    <activation-config-property-value>javax.jms.Topic</activation-config-property-value>
+                </activation-config-property>
+                <activation-config-property>
+                    <activation-config-property-name>acknowledgeMode</activation-config-property-name>
+                    <activation-config-property-value>Auto-acknowledge</activation-config-property-value>
+                </activation-config-property>
+                <activation-config-property>
+                    <activation-config-property-name>maxSession</activation-config-property-name>
+                    <activation-config-property-value>15</activation-config-property-value>
+                </activation-config-property>
+            </activation-config>
+        </message-driven>
     </enterprise-beans>
 </jboss:ejb-jar>

--- a/servers/plain/pom.xml
+++ b/servers/plain/pom.xml
@@ -29,7 +29,7 @@
     <name>UnifiedPush Server for Wildfly (Plain)</name>
 
     <properties>
-        <base>jboss/wildfly:13.0.0.Final</base>
+        <base>jboss/wildfly:16.0.0.Final</base>
         <configFile>standalone-full.xml</configFile>
         <postgresConfigFile>psql-module.xml</postgresConfigFile>    
         <project.artifactId>${project.artifactId}</project.artifactId>

--- a/servers/plain/src/main/docker/standalone-full.xml
+++ b/servers/plain/src/main/docker/standalone-full.xml
@@ -164,8 +164,8 @@
                     <connection-url>jdbc:postgresql://${env.POSTGRES_SERVICE_HOST}:${env.POSTGRES_SERVICE_PORT}/${env.POSTGRES_DATABASE}</connection-url>
                     <driver>postgresql</driver>
                     <security>
-                      <user-name>${env.POSTGRES_USER}</user-name>
-                      <password>${env.POSTGRES_PASSWORD}</password>
+                        <user-name>${env.POSTGRES_USER}</user-name>
+                        <password>${env.POSTGRES_PASSWORD}</password>
                     </security>
                     <validation>
                         <check-valid-connection-sql>SELECT 1</check-valid-connection-sql>
@@ -178,10 +178,10 @@
                 <drivers>
                     <driver name="h2" module="com.h2database.h2">
                         <xa-datasource-class>org.h2.jdbcx.JdbcDataSource</xa-datasource-class>
-                     </driver>
-                     <driver name="postgresql" module="org.postgresql">
+                    </driver>
+                    <driver name="postgresql" module="org.postgresql">
                         <xa-datasource-class>org.postgresql.xa.PGXADataSource</xa-datasource-class>
-	                </driver>
+                    </driver>
                 </drivers>
             </datasources>
         </subsystem>
@@ -473,13 +473,14 @@
                 <jms-queue name="GCMTokenBatchQueue" entries="queue/GCMTokenBatchQueue"/>
                 <!-- <jms-queue name="WNSPushMessageQueue" entries="queue/WNSPushMessageQueue"/> -->
                 <jms-queue name="WNSTokenBatchQueue" entries="queue/WNSTokenBatchQueue"/>
-                <jms-queue name="MetricsQueue" entries="queue/MetricsQueue"/>	
-                <jms-queue name="TriggerMetricCollectionQueue" entries="queue/TriggerMetricCollectionQueue"/>	
-                <jms-queue name="TriggerVariantMetricCollectionQueue" entries="queue/TriggerVariantMetricCollectionQueue"/>	
-                <jms-queue name="BatchLoadedQueue" entries="queue/BatchLoadedQueue"/>	
-                <jms-queue name="AllBatchesLoadedQueue" entries="queue/AllBatchesLoadedQueue"/>	
-                <jms-queue name="FreeServiceSlotQueue" entries="queue/FreeServiceSlotQueue"/>	
+                <jms-queue name="MetricsQueue" entries="queue/MetricsQueue"/>
+                <jms-queue name="TriggerMetricCollectionQueue" entries="queue/TriggerMetricCollectionQueue"/>
+                <jms-queue name="TriggerVariantMetricCollectionQueue" entries="queue/TriggerVariantMetricCollectionQueue"/>
+                <jms-queue name="BatchLoadedQueue" entries="queue/BatchLoadedQueue"/>
+                <jms-queue name="AllBatchesLoadedQueue" entries="queue/AllBatchesLoadedQueue"/>
+                <jms-queue name="FreeServiceSlotQueue" entries="queue/FreeServiceSlotQueue"/>
                 <jms-topic name="MetricsProcessingStartedTopic" entries="topic/MetricsProcessingStartedTopic"/>
+                <jms-topic name="topic/APNSClient" entries="java:/topic/APNSClient"/>
                 <connection-factory name="InVmConnectionFactory" entries="java:/ConnectionFactory2" connectors="in-vm"/>
                 <connection-factory name="RemoteConnectionFactory" entries="java:jboss/exported/jms/RemoteConnectionFactory" connectors="http-connector"/>
                 <pooled-connection-factory name="activemq-ra" entries="java:/JmsXA" connectors="in-vm" transaction="xa"/>
@@ -489,7 +490,7 @@
             </server>
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:naming:2.0">
-             <bindings>
+            <bindings>
                 <external-context name="java:global/remoteContext" module="org.apache.activemq.artemis" class="javax.naming.InitialContext">
                     <environment>
                         <property name="java.naming.factory.initial" value="org.apache.activemq.artemis.jndi.ActiveMQInitialContextFactory"/>
@@ -615,7 +616,7 @@
         <outbound-socket-binding name="mail-smtp">
             <remote-destination host="localhost" port="25"/>
         </outbound-socket-binding>
-         <outbound-socket-binding name="remote-artemis">
+        <outbound-socket-binding name="remote-artemis">
             <remote-destination host="artemis" port="61617"/>
         </outbound-socket-binding>
     </socket-binding-group>

--- a/servers/plain/src/main/docker/standalone-full.xml
+++ b/servers/plain/src/main/docker/standalone-full.xml
@@ -440,11 +440,11 @@
                     <role name="guest" send="true" consume="true" create-non-durable-queue="true" delete-non-durable-queue="true"/>
                 </security-setting>
                 <address-setting name="#" dead-letter-address="jms.queue.DLQ" expiry-address="jms.queue.ExpiryQueue" max-size-bytes="10485760" page-size-bytes="2097152" message-counter-history-day-limit="10"/>
-                <address-setting name="jms.queue.APNsPushMessageQueue" redelivery-delay="1500" redelivery-multiplier="1.5" max-delivery-attempts="-1" max-redelivery-delay="5000"/>
+                <!-- <address-setting name="jms.queue.APNsPushMessageQueue" redelivery-delay="1500" redelivery-multiplier="1.5" max-delivery-attempts="-1" max-redelivery-delay="5000"/> -->
                 <address-setting name="jms.queue.APNsTokenBatchQueue" max-size-bytes="40000" address-full-policy="FAIL"/>
-                <address-setting name="jms.queue.GCMPushMessageQueue" redelivery-delay="1500" redelivery-multiplier="1.5" max-delivery-attempts="-1" max-redelivery-delay="5000"/>
+                <!-- <address-setting name="jms.queue.GCMPushMessageQueue" redelivery-delay="1500" redelivery-multiplier="1.5" max-delivery-attempts="-1" max-redelivery-delay="5000"/> -->
                 <address-setting name="jms.queue.GCMTokenBatchQueue" max-size-bytes="40000" address-full-policy="FAIL"/>
-                <address-setting name="jms.queue.WNSPushMessageQueue" redelivery-delay="1500" redelivery-multiplier="1.5" max-delivery-attempts="-1" max-redelivery-delay="5000"/>
+                <!-- <address-setting name="jms.queue.WNSPushMessageQueue" redelivery-delay="1500" redelivery-multiplier="1.5" max-delivery-attempts="-1" max-redelivery-delay="5000"/> -->
                 <address-setting name="jms.queue.WNSTokenBatchQueue" max-size-bytes="40000" address-full-policy="FAIL"/>
                 <address-setting name="jms.queue.MetricsQueue" max-delivery-attempts="-1"/>
                 <address-setting name="jms.queue.TriggerMetricCollectionQueue" redelivery-delay="1000" max-delivery-attempts="-1"/>
@@ -467,11 +467,11 @@
                 </in-vm-acceptor>
                 <jms-queue name="ExpiryQueue" entries="java:/jms/queue/ExpiryQueue"/>
                 <jms-queue name="DLQ" entries="java:/jms/queue/DLQ"/>
-                <jms-queue name="APNsPushMessageQueue" entries="queue/APNsPushMessageQueue"/>
+                <!-- <jms-queue name="APNsPushMessageQueue" entries="queue/APNsPushMessageQueue"/> -->
                 <jms-queue name="APNsTokenBatchQueue" entries="queue/APNsTokenBatchQueue"/>
-                <jms-queue name="GCMPushMessageQueue" entries="queue/GCMPushMessageQueue"/>
+                <!-- <jms-queue name="GCMPushMessageQueue" entries="queue/GCMPushMessageQueue"/> -->
                 <jms-queue name="GCMTokenBatchQueue" entries="queue/GCMTokenBatchQueue"/>
-                <jms-queue name="WNSPushMessageQueue" entries="queue/WNSPushMessageQueue"/>
+                <!-- <jms-queue name="WNSPushMessageQueue" entries="queue/WNSPushMessageQueue"/> -->
                 <jms-queue name="WNSTokenBatchQueue" entries="queue/WNSTokenBatchQueue"/>
                 <jms-queue name="MetricsQueue" entries="queue/MetricsQueue"/>	
                 <jms-queue name="TriggerMetricCollectionQueue" entries="queue/TriggerMetricCollectionQueue"/>	
@@ -480,12 +480,24 @@
                 <jms-queue name="AllBatchesLoadedQueue" entries="queue/AllBatchesLoadedQueue"/>	
                 <jms-queue name="FreeServiceSlotQueue" entries="queue/FreeServiceSlotQueue"/>	
                 <jms-topic name="MetricsProcessingStartedTopic" entries="topic/MetricsProcessingStartedTopic"/>
-                <connection-factory name="InVmConnectionFactory" entries="java:/ConnectionFactory" connectors="in-vm"/>
+                <connection-factory name="InVmConnectionFactory" entries="java:/ConnectionFactory2" connectors="in-vm"/>
                 <connection-factory name="RemoteConnectionFactory" entries="java:jboss/exported/jms/RemoteConnectionFactory" connectors="http-connector"/>
-                <pooled-connection-factory name="activemq-ra" entries="java:/JmsXA java:jboss/DefaultJMSConnectionFactory" connectors="in-vm" transaction="xa"/>
+                <pooled-connection-factory name="activemq-ra" entries="java:/JmsXA" connectors="in-vm" transaction="xa"/>
+                <remote-connector name="remote-artemis" socket-binding="remote-artemis"/>
+                <pooled-connection-factory name="remote-artemis-xa" entries="java:/jms/remoteXA java:jboss/DefaultJMSConnectionFactory" connectors="remote-artemis" transaction="xa" user="artemis" password="simetraehcapa"/>
+                <pooled-connection-factory name="remote-artemis" entries="java:/ConnectionFactory" connectors="remote-artemis" user="artemis" password="simetraehcapa"/>
             </server>
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:naming:2.0">
+             <bindings>
+                <external-context name="java:global/remoteContext" module="org.apache.activemq.artemis" class="javax.naming.InitialContext">
+                    <environment>
+                        <property name="java.naming.factory.initial" value="org.apache.activemq.artemis.jndi.ActiveMQInitialContextFactory"/>
+                        <property name="GCMPushMessageQueue" value="GCMPushMessageQueue"/>
+                    </environment>
+                </external-context>
+                <lookup name="java:/GCMPushMessageQueue" lookup="java:global/remoteContext/GCMPushMessageQueue"/>
+            </bindings>
             <remote-naming/>
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:pojo:1.0"/>
@@ -602,6 +614,9 @@
         <socket-binding name="txn-status-manager" port="4713"/>
         <outbound-socket-binding name="mail-smtp">
             <remote-destination host="localhost" port="25"/>
+        </outbound-socket-binding>
+         <outbound-socket-binding name="remote-artemis">
+            <remote-destination host="artemis" port="61617"/>
         </outbound-socket-binding>
     </socket-binding-group>
 </server>

--- a/servers/plain/src/main/webapp/WEB-INF/jboss-ejb3.xml
+++ b/servers/plain/src/main/webapp/WEB-INF/jboss-ejb3.xml
@@ -20,7 +20,6 @@
 <jboss:ejb-jar xmlns:jboss="http://www.jboss.com/xml/ns/javaee"
                xmlns="http://java.sun.com/xml/ns/javaee"
                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-               xmlns:s="urn:security:1.1"
                xmlns:r="urn:resource-adapter-binding"
                xsi:schemaLocation="http://www.jboss.com/xml/ns/javaee http://www.jboss.org/j2ee/schema/jboss-ejb3-2_0.xsd http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/ejb-jar_3_1.xsd"
                version="3.1"
@@ -84,7 +83,7 @@
                 </activation-config-property>
             </activation-config>
         </message-driven>
-        
+
         <!-- Token Batch Queue MDBs -->
         <message-driven>
             <ejb-name>APNsTokenBatchConsumer</ejb-name>
@@ -155,8 +154,31 @@
                 </activation-config-property>
             </activation-config>
         </message-driven>
+        <message-driven>
+            <ejb-name>APNSClientConsumer</ejb-name>
+            <ejb-class>org.jboss.aerogear.unifiedpush.message.jms.APNSClientConsumer</ejb-class>
+            <transaction-type>Container</transaction-type>
+            <activation-config>
+                <activation-config-property>
+                    <activation-config-property-name>destination</activation-config-property-name>
+                    <activation-config-property-value>java:/topic/APNSClient</activation-config-property-value>
+                </activation-config-property>
+                <activation-config-property>
+                    <activation-config-property-name>destinationType</activation-config-property-name>
+                    <activation-config-property-value>javax.jms.Topic</activation-config-property-value>
+                </activation-config-property>
+                <activation-config-property>
+                    <activation-config-property-name>acknowledgeMode</activation-config-property-name>
+                    <activation-config-property-value>Auto-acknowledge</activation-config-property-value>
+                </activation-config-property>
+                <activation-config-property>
+                    <activation-config-property-name>maxSession</activation-config-property-name>
+                    <activation-config-property-value>15</activation-config-property-value>
+                </activation-config-property>
+            </activation-config>
+        </message-driven>
     </enterprise-beans>
-     <assembly-descriptor>        
+    <assembly-descriptor>
         <r:resource-adapter-binding>
             <ejb-name>GCMPushMessageConsumer</ejb-name>
             <r:resource-adapter-name>remote-artemis-xa</r:resource-adapter-name>
@@ -169,7 +191,7 @@
             <ejb-name>APNsPushMessageConsumer</ejb-name>
             <r:resource-adapter-name>remote-artemis-xa</r:resource-adapter-name>
         </r:resource-adapter-binding>
-                <r:resource-adapter-binding>
+        <r:resource-adapter-binding>
             <ejb-name>GCMTokenBatchConsumer</ejb-name>
             <r:resource-adapter-name>remote-artemis-xa</r:resource-adapter-name>
         </r:resource-adapter-binding>
@@ -181,6 +203,10 @@
             <ejb-name>APNsTokenBatchConsumer</ejb-name>
             <r:resource-adapter-name>remote-artemis-xa</r:resource-adapter-name>
         </r:resource-adapter-binding>
+        <r:resource-adapter-binding>
+            <ejb-name>APNSClientConsumer</ejb-name>
+            <r:resource-adapter-name>remote-artemis-xa</r:resource-adapter-name>
+        </r:resource-adapter-binding>
     </assembly-descriptor>
-    
+
 </jboss:ejb-jar>

--- a/servers/plain/src/main/webapp/WEB-INF/jboss-ejb3.xml
+++ b/servers/plain/src/main/webapp/WEB-INF/jboss-ejb3.xml
@@ -21,6 +21,7 @@
                xmlns="http://java.sun.com/xml/ns/javaee"
                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                xmlns:s="urn:security:1.1"
+               xmlns:r="urn:resource-adapter-binding"
                xsi:schemaLocation="http://www.jboss.com/xml/ns/javaee http://www.jboss.org/j2ee/schema/jboss-ejb3-2_0.xsd http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/ejb-jar_3_1.xsd"
                version="3.1"
                impl-version="2.0">
@@ -33,7 +34,7 @@
             <activation-config>
                 <activation-config-property>
                     <activation-config-property-name>destination</activation-config-property-name>
-                    <activation-config-property-value>queue/APNsPushMessageQueue</activation-config-property-value>
+                    <activation-config-property-value>APNsPushMessageQueue</activation-config-property-value>
                 </activation-config-property>
                 <activation-config-property>
                     <activation-config-property-name>destinationType</activation-config-property-name>
@@ -52,7 +53,7 @@
             <activation-config>
                 <activation-config-property>
                     <activation-config-property-name>destination</activation-config-property-name>
-                    <activation-config-property-value>queue/GCMPushMessageQueue</activation-config-property-value>
+                    <activation-config-property-value>GCMPushMessageQueue</activation-config-property-value>
                 </activation-config-property>
                 <activation-config-property>
                     <activation-config-property-name>destinationType</activation-config-property-name>
@@ -71,7 +72,7 @@
             <activation-config>
                 <activation-config-property>
                     <activation-config-property-name>destination</activation-config-property-name>
-                    <activation-config-property-value>queue/WNSPushMessageQueue</activation-config-property-value>
+                    <activation-config-property-value>WNSPushMessageQueue</activation-config-property-value>
                 </activation-config-property>
                 <activation-config-property>
                     <activation-config-property-name>destinationType</activation-config-property-name>
@@ -154,6 +155,32 @@
                 </activation-config-property>
             </activation-config>
         </message-driven>
-        
     </enterprise-beans>
+     <assembly-descriptor>        
+        <r:resource-adapter-binding>
+            <ejb-name>GCMPushMessageConsumer</ejb-name>
+            <r:resource-adapter-name>remote-artemis-xa</r:resource-adapter-name>
+        </r:resource-adapter-binding>
+        <r:resource-adapter-binding>
+            <ejb-name>WNSPushMessageConsumer</ejb-name>
+            <r:resource-adapter-name>remote-artemis-xa</r:resource-adapter-name>
+        </r:resource-adapter-binding>
+        <r:resource-adapter-binding>
+            <ejb-name>APNsPushMessageConsumer</ejb-name>
+            <r:resource-adapter-name>remote-artemis-xa</r:resource-adapter-name>
+        </r:resource-adapter-binding>
+                <r:resource-adapter-binding>
+            <ejb-name>GCMTokenBatchConsumer</ejb-name>
+            <r:resource-adapter-name>remote-artemis-xa</r:resource-adapter-name>
+        </r:resource-adapter-binding>
+        <r:resource-adapter-binding>
+            <ejb-name>WNSTokenBatchConsumer</ejb-name>
+            <r:resource-adapter-name>remote-artemis-xa</r:resource-adapter-name>
+        </r:resource-adapter-binding>
+        <r:resource-adapter-binding>
+            <ejb-name>APNsTokenBatchConsumer</ejb-name>
+            <r:resource-adapter-name>remote-artemis-xa</r:resource-adapter-name>
+        </r:resource-adapter-binding>
+    </assembly-descriptor>
+    
 </jboss:ejb-jar>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -34,6 +34,11 @@
             <artifactId>cdi-api</artifactId>
             <scope>provided</scope>
         </dependency>
+<dependency>
+    <groupId>javax.annotation</groupId>
+    <artifactId>javax.annotation-api</artifactId>
+    <version>1.3.2</version>
+</dependency>
 
         <!-- Import the EJB API, we use provided scope as the API is included
             in JBoss -->

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -81,6 +81,7 @@
                     <groupId>org.apache.openejb</groupId>
                     <artifactId>openejb-core-hibernate</artifactId>
                     <type>pom</type>
+                      <version>4.7.5</version>
                     <scope>test</scope>
                 </dependency>
 
@@ -89,6 +90,13 @@
                     <artifactId>junit</artifactId>
                     <scope>test</scope>
                 </dependency>
+<!-- https://mvnrepository.com/artifact/com.sun.corba/orb -->
+<dependency>
+  <groupId>org.glassfish.corba</groupId>
+  <artifactId>glassfish-corba-orb</artifactId>
+  <version>4.2.1</version>
+  <scope>test</scope>
+</dependency>
 
                 <dependency>
                     <groupId>org.hibernate</groupId>
@@ -111,7 +119,13 @@
                 <dependency>
                     <groupId>org.apache.openejb</groupId>
                     <artifactId>openejb-mockito</artifactId>
-                    <version>4.7.1</version>
+                    <version>4.7.5</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.openejb</groupId>
+                    <artifactId>openejb-core</artifactId>
+                    <version>4.7.5</version>
                     <scope>test</scope>
                 </dependency>
 

--- a/service/src/test/java/org/jboss/aerogear/unifiedpush/service/AbstractBaseServiceTest.java
+++ b/service/src/test/java/org/jboss/aerogear/unifiedpush/service/AbstractBaseServiceTest.java
@@ -33,6 +33,7 @@ import org.jboss.aerogear.unifiedpush.service.impl.PushSearchByDeveloperServiceI
 import org.jboss.aerogear.unifiedpush.service.impl.PushSearchServiceImpl;
 import org.jboss.aerogear.unifiedpush.service.impl.SearchManager;
 import org.jboss.aerogear.unifiedpush.service.metrics.PushMessageMetricsService;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.keycloak.KeycloakPrincipal;
@@ -42,9 +43,11 @@ import org.mockito.Mock;
 
 import javax.annotation.PreDestroy;
 import javax.ejb.Stateful;
+import javax.ejb.embeddable.EJBContainer;
 import javax.enterprise.context.SessionScoped;
 import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
+import javax.naming.NamingException;
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.Persistence;
@@ -55,6 +58,8 @@ import static org.mockito.Mockito.when;
 
 @RunWith(ApplicationComposer.class)
 public abstract class AbstractBaseServiceTest {
+
+    private  EJBContainer container;
 
     @Mock
     protected HttpServletRequest httpServletRequest;
@@ -75,6 +80,20 @@ public abstract class AbstractBaseServiceTest {
     protected PushSearchByDeveloperServiceImpl searchApplicationService;
 
     // ===================== JUnit hooks =====================
+    @Before
+    public  void start() {
+        container = EJBContainer.createEJBContainer();
+    }
+     
+    @Before
+    public void inject() throws NamingException {
+        container.getContext().bind("inject", this);
+    }
+     
+    @After
+    public  void stop() {
+        container.close();
+    }
 
     /**
      * Basic setup stuff, needed for all the UPS related service classes


### PR DESCRIPTION
Related issue: [AEROGEAR-9068](https://issues.jboss.org/browse/AEROGEAR-9068)

## How to test?

1. Build the project ignoring the tests
   ```shell
   mvn clean install -DskipTests
   ```
1. Add a new new instance of UniedPush Server in `docker-compose/docker-compose-v2.1.yaml` 
   ```yaml
     unifiedpushserver_2:
    image: aerogear/unifiedpush-wildfly-plain:2.2.2-SNAPSHOT
    volumes:
       - ./helper:/ups-helper:z
    entrypoint: "/ups-helper/exportKeycloakHost.sh"
    depends_on:
       unifiedpushDB:
         condition: service_healthy
    environment:
        POSTGRES_SERVICE_HOST: ${POSTGRES_SERVICE_HOST}
        POSTGRES_USER: ${POSTGRES_USER}
        POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
        POSTGRES_SERVICE_PORT: ${POSTGRES_SERVICE_PORT}
        POSTGRES_DATABASE: ${POSTGRES_DATABASE}
        KEYCLOAK_SERVICE_HOST: ${KEYCLOAK_SERVICE_HOST}
        KEYCLOAK_SERVICE_PORT: ${KEYCLOAK_SERVICE_PORT}
    links:
      - unifiedpushDB:unifiedpush
      - artemis:artemis
      - keycloakServer:keycloak
    ports:
      - 9998:8080      
   ```
1. Run the docker compose. It will run 2 instance of the UPS point to the same postgres and ActiveMQ simulating 2 Openshift pods.
   ```shell
   cd docker-compose && docker-compose -f ./docker-compose-v2.1.yaml up
   ```
1. Create a new project and a iOS variant.
1. Edit cert in the iOS variant (you can change it for the same with the previous one) 
1. See the magics happening between the 2 UPS instance
1. You can also check the ActiveMQ in `http://localhost:8161`. (artemis/simetraehcapa)

