### PR TITLE
Removing http from our sources

### DIFF
--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -126,7 +126,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
-                    <!-- Adds custom Miredot tags (required for JDK 8 DocLint: http://openjdk.java.net/jeps/172) -->
                     <tags>
                         <tag>
                             <name>statuscode</name>
@@ -185,20 +184,5 @@
         </profile>
     </profiles>
 
-    <pluginRepositories>
-        <pluginRepository>
-            <id>miredot</id>
-            <name>MireDot Releases</name>
-            <url>http://nexus.qmino.com/content/repositories/miredot</url>
-        </pluginRepository>
-    </pluginRepositories>
-
-    <repositories>
-        <repository>
-            <id>miredot</id>
-            <name>MireDot Releases</name>
-            <url>http://nexus.qmino.com/content/repositories/miredot</url>
-        </repository>
-    </repositories>
 
 </project>

--- a/servers/keycloak/pom.xml
+++ b/servers/keycloak/pom.xml
@@ -82,7 +82,7 @@
     <repositories>
         <repository>
             <id>JBOSS_NEXUS</id>
-            <url>http://repository.jboss.org/nexus/content/groups/public</url>
+            <url>https://repository.jboss.org/nexus/content/groups/public</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
## Motivation
Some dependencies were dowenloaded over http instead of https.

## How
The miredot repositories were removed; we stopped using their tools long ago.  The Jboss Nexus repository URL was replaced with https.

## Verification Steps
 
1. rm -rf ~/.m2/repository #Remove your old dependencies to force a download
2. mvn clean install # Build the project from scratch
3. Verify no dependencies were downloaded via http
