### PR TITLE
Apns push type

### DIFF
--- a/push-sender/pom.xml
+++ b/push-sender/pom.xml
@@ -108,7 +108,7 @@
         <dependency>
             <groupId>com.turo</groupId>
             <artifactId>pushy</artifactId>
-            <version>0.13.2</version>
+            <version>0.13.9</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Motivation
This PR addresses two aspects (1 feature and 1 bug)
- https://groups.google.com/forum/#!topic/aerogear/CENxfhFVnYk
- https://issues.jboss.org/browse/AEROGEAR-9889


## What
- Add support for apns-push-type field required by ios 13
- Consider ttl for apns pushes

## Why
- apns-push-type is required in apns pushes in ios13. If not set pushes may be delayed or even dropped
- ttl: PushyApnsSender ignores Config#timeToLive, instead it uses a fix TTL of 1 day (default used by Pushy's SimpleApnsPushNotification class). It would be good to consider the ttl provided in org.jboss.aerogear.unifiedpush.message.Config#timeToLive.
BTW: This seems like a regression. In former times this worked correctly before switching from notnoop.apns to pushy. See former solution in UPS 1.1.3 (method: createFutureDateBasedOnTTL): https://github.com/aerogear/aerogear-unifiedpush-server/blob/1.1.3.Final/push/sender/src/main/java/org/jboss/aerogear/unifiedpush/message/sender/APNsPushNotificationSender.java

## How
- apns-push-type: Upgrade pushy to 0.13.9 which allows specifying PushType as a constructor parameter. Internally it will be sent with the http header
- ttl: use the implementation used back in UPS 1.1.3

## Verification Steps
apns-push-type:
1. Send a push message to an ios13 device with at least sound or alter field set
2. Push is expected to be delivered

ttl:
1. turn of ios device (or flight mode)
2. send push to ios device with a ttl of multiple days
3. wait more than 1 day (and <28 days)
4. turn on device
5.  push must be received

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress
?

## Additional Notes
None
 

