### PR TITLE
feature: allow iOS registration to set variantID and secret

### DIFF
--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/iOSVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/iOSVariantEndpoint.java
@@ -95,7 +95,9 @@ public class iOSVariantEndpoint extends AbstractVariantEndpoint<iOSVariant> {
         iOSVariant.setPassphrase(form.getPassphrase());
         iOSVariant.setCertificate(form.getCertificate());
         iOSVariant.setProduction(form.getProduction());
-
+        iOSVariant.setVariantID(form.getVariantID());
+        iOSVariant.setSecret(form.getSecret());
+        
         // some model validation on the entity:
         try {
             validateModelClass(iOSVariant);

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/util/iOSApplicationUploadForm.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/util/iOSApplicationUploadForm.java
@@ -20,6 +20,8 @@ import org.jboss.aerogear.crypto.util.PKCS12;
 import org.jboss.aerogear.unifiedpush.api.iOSVariant;
 import org.jboss.resteasy.annotations.providers.multipart.PartType;
 
+import java.util.UUID;
+
 import javax.validation.constraints.AssertTrue;
 import javax.ws.rs.FormParam;
 
@@ -37,6 +39,8 @@ public class iOSApplicationUploadForm {
     private byte[] certificate;
     private String name;
     private String description;
+    private String variantID = UUID.randomUUID().toString();
+    private String secret = UUID.randomUUID().toString();
 
     public Boolean getProduction() {
         return production;
@@ -58,6 +62,31 @@ public class iOSApplicationUploadForm {
 
     public String getName() {
         return name;
+    }
+
+/**
+     * Identifier used to register an {@link Installation} with this Variant
+     *
+     * @param variantID the variant ID
+     */
+    @FormParam("variantID")
+    public void setVariantID(String variantID) {
+        this.variantID = variantID;
+    }
+    @FormParam("secret")
+    public void setSecret(String secret) {
+        this.secret = secret;
+    }
+
+    public String getSecret() {
+        return secret;
+    }
+
+    /**
+     * @return the variantID
+     */
+    public String getVariantID() {
+        return variantID;
     }
 
     /**


### PR DESCRIPTION
## Motivation
Allows a iOS variant to select a variantID and secret.  This bring parity with Android.

## What
The iOS upload form was given a variantID and push id field.  These fields are initialized to random uuids and may be override by a rest post.

## Why
It is helpful for testing if we can set iOS fields to known values as in Android


## Verification Steps
Use the rest API to create an iOS variant and confirm the fields.

### Example
```
curl --verbose --location --request POST "http://localhost:9999/rest/applications/B868CC08-BCC8-4A0A-B21E-1AC56AF0C734/ios"   --header "Content-Type: multipart/form-data"   --form "id=E7C3DFCE-D7C0-4819-B966-06477566BBC3"   --form "name=iO 2S"   --form "description=iOS variant"   --form "variantID=896F2EF5-826C-40D0-95A9-6D395C99CD07"   --form "secret=CB8B2619-C37C-4E08-9D53-1E493E442A01"   --form "developer=Daniel Passos"   --form "type=ios"   --form "production=false"   --form "passphrase=redhat"   --form "certificate=@/home/summerspittman/Downloads/PushDevelopmentProfile.p12"
```
 