### PR TITLE
WebPush Variant and tests

### DIFF
--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '2.1'
 
 services:
   unifiedpushserver:
-    image: aerogear/unifiedpush-configurable-container:latest
+    image: aerogear/unifiedpush-configurable-container:2.3.3-SNAPSHOT
     volumes:
        - ./helper:/ups-helper:z
     entrypoint: "/ups-helper/exportKeycloakHost.sh"

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/AbstractBaseEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/AbstractBaseEndpoint.java
@@ -1,13 +1,13 @@
 /**
  * JBoss, Home of Professional Open Source
  * Copyright Red Hat, Inc., and individual contributors
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -63,7 +63,7 @@ public abstract class AbstractBaseEndpoint {
 
     /**
      * Generic validator used to identify constraint violations of the given model class. 
-     * 
+     *
      * @param model object to validate
      * @throws ConstraintViolationException if constraint violations on the given model have been identified.
      */
@@ -79,7 +79,7 @@ public abstract class AbstractBaseEndpoint {
 
     /**
      * Helper function to create a 400 Bad Request response, containing a JSON map giving details about the violations
-     * 
+     *
      * @param violations set of occurred constraint violations
      * @return 400 Bad Request response, containing details on the constraint violations 
      */
@@ -88,7 +88,7 @@ public abstract class AbstractBaseEndpoint {
                 .collect(Collectors.toMap(v -> v.getPropertyPath().toString(), ConstraintViolation::getMessage));
 
         return Response.status(Response.Status.BAD_REQUEST)
-                           .entity(responseObj);
+                .entity(responseObj);
     }
 
     /**
@@ -96,7 +96,7 @@ public abstract class AbstractBaseEndpoint {
      *
      * @return the push search service
      */
-    protected PushSearchService getSearch(){
+    protected PushSearchService getSearch() {
         return searchManager.getSearchService();
     }
 

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/WebPushVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/WebPushVariantEndpoint.java
@@ -1,0 +1,138 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright Red Hat, Inc., and individual contributors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.aerogear.unifiedpush.rest.registry.applications;
+
+import org.jboss.aerogear.unifiedpush.api.PushApplication;
+import org.jboss.aerogear.unifiedpush.api.WebPushVariant;
+import org.jboss.aerogear.unifiedpush.service.impl.SearchManager;
+
+import javax.validation.ConstraintViolationException;
+import javax.validation.Validator;
+import javax.ws.rs.*;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+@Path("/applications/{pushAppID}/webpush")
+public class WebPushVariantEndpoint extends AbstractVariantEndpoint<WebPushVariant> {
+
+    public WebPushVariantEndpoint() {
+        super(WebPushVariant.class);
+    }
+
+    // required for tests
+    WebPushVariantEndpoint(Validator validator, SearchManager searchManager) {
+        super(validator, searchManager, WebPushVariant.class);
+    }
+
+    /**
+     * Add Webpush Variant
+     *
+     * @param webPushVariant    new {@link WebPushVariant}
+     * @param pushApplicationID id of {@link PushApplication}
+     * @param uriInfo           the uri
+     * @return created {@link WebPushVariant}
+     *
+     * @statuscode 201 The WebPush Variant created successfully
+     * @statuscode 400 The format of the client request was incorrect
+     * @statuscode 404 The requested PushApplication resource does not exist
+     */
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response registerWebPushVariant(
+            WebPushVariant webPushVariant,
+            @PathParam("pushAppID") String pushApplicationID,
+            @Context UriInfo uriInfo) {
+
+        // find the root push app
+        PushApplication pushApp = getSearch().findByPushApplicationIDForDeveloper(pushApplicationID);
+
+        if (pushApp == null) {
+            return Response.status(Response.Status.NOT_FOUND).entity("Could not find requested PushApplicationEntity").build();
+        }
+
+        // some validation
+        try {
+            validateModelClass(webPushVariant);
+        } catch (ConstraintViolationException cve) {
+            logger.trace("Unable to create WebPush variant");
+            // Build and return the 400 (Bad Request) response
+            Response.ResponseBuilder builder = createBadRequestResponse(cve.getConstraintViolations());
+
+            return builder.build();
+        }
+
+        logger.trace("Register WebPush variant with Push Application '{}'", pushApplicationID);
+        // store the webPushVariant :
+        variantService.addVariant(webPushVariant);
+        // add webPushVariant, and merge:
+        pushAppService.addVariant(pushApp, webPushVariant);
+
+        return Response.created(uriInfo.getAbsolutePathBuilder().path(String.valueOf(webPushVariant.getVariantID())).build()).entity(webPushVariant).build();
+    }
+
+
+    /**
+     * List WebPush Variants for Push Application
+     *
+     * @param pushApplicationID id of {@link PushApplication}
+     * @return list of {@link WebPushVariant}s
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response listAllWebPushVariationsForPushApp(@PathParam("pushAppID") String pushApplicationID) {
+        final PushApplication application = getSearch().findByPushApplicationIDForDeveloper(pushApplicationID);
+        return Response.ok(getVariants(application)).build();
+    }
+
+    @PUT
+    @Path("/{webPushID}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response updateWebPushVariant(@PathParam("pushAppID") String id,
+                                         @PathParam("webPushID") String webPushID, WebPushVariant updatedVariant) {
+        WebPushVariant webPushVariant = (WebPushVariant) variantService.findByVariantID(webPushID);
+        if (webPushVariant != null) {
+
+            // some validation
+            try {
+                validateModelClass(updatedVariant);
+            } catch (ConstraintViolationException cve) {
+                logger.info("Unable to update WebPush Variant '{}'", webPushVariant.getVariantID());
+                logger.debug("Details: {}", cve);
+
+                // Build and return the 400 (Bad Request) response
+                Response.ResponseBuilder builder = createBadRequestResponse(cve.getConstraintViolations());
+
+                return builder.build();
+            }
+
+            // apply updated data:
+            webPushVariant.setPublicKey(updatedVariant.getPublicKey());
+            webPushVariant.setPrivateKey(updatedVariant.getPrivateKey());
+            webPushVariant.setName(updatedVariant.getName());
+            webPushVariant.setDescription(updatedVariant.getDescription());
+            logger.trace("Updating WebPush Variant '{}'", webPushID);
+            variantService.updateVariant(webPushVariant);
+            return Response.ok(webPushVariant).build();
+        }
+
+        return Response.status(Response.Status.NOT_FOUND).entity("Could not find requested Variant").build();
+    }
+}

--- a/jaxrs/src/test/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/WebPushVariantEndpointTest.java
+++ b/jaxrs/src/test/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/WebPushVariantEndpointTest.java
@@ -1,0 +1,286 @@
+package org.jboss.aerogear.unifiedpush.rest.registry.applications;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import org.jboss.aerogear.unifiedpush.api.PushApplication;
+import org.jboss.aerogear.unifiedpush.api.Variant;
+import org.jboss.aerogear.unifiedpush.api.WebPushVariant;
+import org.jboss.aerogear.unifiedpush.api.iOSVariant;
+import org.jboss.aerogear.unifiedpush.service.GenericVariantService;
+import org.jboss.aerogear.unifiedpush.service.PushApplicationService;
+import org.jboss.aerogear.unifiedpush.service.PushSearchService;
+import org.jboss.aerogear.unifiedpush.service.impl.SearchManager;
+import org.jboss.resteasy.spi.ResteasyUriInfo;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Path;
+import javax.validation.Validator;
+import javax.validation.metadata.ConstraintDescriptor;
+import javax.ws.rs.core.Response;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.never;
+
+@RunWith(MockitoJUnitRunner.class)
+public class WebPushVariantEndpointTest {
+
+    WebPushVariantEndpoint endpoint;
+
+
+    @Mock
+    PushApplicationService pushAppService;
+
+    @Mock
+    GenericVariantService variantService;
+
+    @Mock
+    SearchManager searchManager;
+
+    @Mock
+    PushSearchService searchService;
+
+    @Mock
+    Validator validator;
+
+    ConstraintViolation sampleViolation = new WebPushVariantEndpointTest.StubConstraintViolation();
+
+    @Before
+    public void before() {
+        this.endpoint = new WebPushVariantEndpoint(validator, searchManager);
+
+        this.endpoint.pushAppService = pushAppService;
+        this.endpoint.variantService = variantService;
+
+        when(searchManager.getSearchService()).thenReturn(searchService);
+    }
+
+    @Test
+    public void shouldRegisterWebPushVariantSuccessfully() {
+        final WebPushVariant variant = new WebPushVariant();
+        final ResteasyUriInfo uriInfo = new ResteasyUriInfo("http://example.org/abc", "", "push");
+        final PushApplication pushApp = new PushApplication();
+
+        when(searchService.findByPushApplicationIDForDeveloper("push-app-id")).thenReturn(pushApp);
+        when(validator.validate(variant)).thenReturn(Collections.EMPTY_SET);
+
+        final Response response = this.endpoint.registerWebPushVariant(variant, "push-app-id", uriInfo);
+
+        assertEquals(response.getStatus(), 201);
+        assertTrue(response.getEntity() == variant);        // identity check
+        assertEquals(response.getMetadata().get("location").get(0).toString(), "http://example.org/abc/" + variant.getVariantID());
+
+        verify(variantService).addVariant(variant);
+        verify(pushAppService).addVariant(pushApp, variant);
+    }
+
+
+    @Test
+    public void registerWebPushVariantShouldReturn404WhenPushAppDoesNotExist() {
+        final WebPushVariant variant = new WebPushVariant();
+        final ResteasyUriInfo uriInfo = new ResteasyUriInfo("http://example.org/abc", "", "push");
+        final PushApplication pushApp = new PushApplication();
+
+        when(searchService.findByPushApplicationIDForDeveloper("push-app-id")).thenReturn(null);
+
+        final Response response = this.endpoint.registerWebPushVariant(variant, "push-app-id", uriInfo);
+
+        assertEquals(response.getStatus(), 404);
+
+        verify(variantService, never()).addVariant(any());
+        verify(validator, never()).validate(any());
+        verify(pushAppService, never()).addVariant(any(), any());
+    }
+
+    @Test
+    public void registerWebPushVariantShouldReturn400WhenVariantModelIsNotValid() {
+        final WebPushVariant variant = new WebPushVariant();
+        final ResteasyUriInfo uriInfo = new ResteasyUriInfo("http://example.org/abc", "", "push");
+        final PushApplication pushApp = new PushApplication();
+
+        when(searchService.findByPushApplicationIDForDeveloper("push-app-id")).thenReturn(pushApp);
+        when(validator.validate(variant)).thenReturn(Sets.newHashSet(sampleViolation));
+
+        final Response response = this.endpoint.registerWebPushVariant(variant, "push-app-id", uriInfo);
+
+        assertEquals(response.getStatus(), 400);
+
+        verify(variantService, never()).addVariant(variant);
+        verify(pushAppService, never()).addVariant(pushApp, variant);
+    }
+
+    @Test
+    public void shouldListAllAndroidVariationsForPushAppSuccessfully() {
+        final WebPushVariant webPushVariant = new WebPushVariant();
+        final Variant iOSVariant = new iOSVariant();
+        final PushApplication pushApp = new PushApplication();
+        pushApp.setVariants(Lists.newArrayList(webPushVariant, iOSVariant));
+
+        when(searchService.findByPushApplicationIDForDeveloper("push-app-id")).thenReturn(pushApp);
+
+        final Response response = this.endpoint.listAllWebPushVariationsForPushApp("push-app-id");
+
+        assertEquals(response.getStatus(), 200);
+        assertTrue(((Collection) response.getEntity()).iterator().next() == webPushVariant);        // identity check
+    }
+
+    @Test
+    public void shouldUpdateWebPushVariantSuccessfully() {
+        final WebPushVariant originalVariant = new WebPushVariant();
+        final WebPushVariant updatedVariant = new WebPushVariant();
+
+        originalVariant.setPublicKey("test public Key");
+        updatedVariant.setPublicKey("update public Key");
+
+        when(variantService.findByVariantID("variant-id")).thenReturn(originalVariant);
+        when(validator.validate(updatedVariant)).thenReturn(Collections.EMPTY_SET);
+
+        final Response response = this.endpoint.updateWebPushVariant("push-app-id", "variant-id", updatedVariant);
+
+        assertEquals(response.getStatus(), 200);
+        assertTrue(response.getEntity() == originalVariant);        // identity check
+        assertEquals(originalVariant.getPublicKey(), "update public Key");
+
+        verify(variantService).updateVariant(originalVariant);
+    }
+
+    @Test
+    public void shouldReturn404WhenFindVariantByIdCannotFindAnyVariants() {
+        when(variantService.findByVariantID("foo")).thenReturn(null);
+
+        final Response response = this.endpoint.findVariantById("foo");
+        assertEquals(response.getStatus(), 404);
+    }
+
+    @Test
+    public void shouldReturn400WhenFindVariantByIdFindsVariantOfAnotherPlatform() {
+        when(variantService.findByVariantID("123")).thenReturn(new iOSVariant());
+
+        final Response response = this.endpoint.findVariantById("123");
+        assertEquals(response.getStatus(), 400);
+    }
+
+    @Test
+    public void shouldReturn200WhenFindVariantByIdFindsAnWebPushVariant() {
+        final WebPushVariant variant = new WebPushVariant();
+        when(variantService.findByVariantID("123")).thenReturn(variant);
+
+        final Response response = this.endpoint.findVariantById("123");
+        assertEquals(response.getStatus(), 200);
+        assertTrue(variant == response.getEntity());    // identity check
+    }
+
+    @Test
+    public void shouldReturn404WhenDeleteVariantCannotFindAnyVariants() {
+        when(variantService.findByVariantID("foo")).thenReturn(null);
+
+        final Response response = this.endpoint.deleteVariant("foo");
+        assertEquals(response.getStatus(), 404);
+    }
+
+    @Test
+    public void shouldReturn400WhenDeleteVariantFindsVariantOfAnotherPlatform() {
+        when(variantService.findByVariantID("123")).thenReturn(new iOSVariant());
+
+        final Response response = this.endpoint.deleteVariant("123");
+        assertEquals(response.getStatus(), 400);
+    }
+
+    @Test
+    public void shouldReturn204WhenDeleteVariantDeletesAnWebPushVariant() {
+        final WebPushVariant variant = new WebPushVariant();
+        when(variantService.findByVariantID("123")).thenReturn(variant);
+
+        final Response response = this.endpoint.deleteVariant("123");
+        assertEquals(response.getStatus(), 204);
+
+        verify(variantService).removeVariant(variant);
+    }
+
+    @Test
+    public void shouldReturn404WhenResetSecretCannotFindAnyVariants() {
+        when(variantService.findByVariantID("foo")).thenReturn(null);
+
+        final Response response = this.endpoint.resetSecret("foo");
+        assertEquals(response.getStatus(), 404);
+    }
+
+    @Test
+    public void shouldReturn400WhenResetSecretFindsVariantOfAnotherPlatform() {
+        when(variantService.findByVariantID("123")).thenReturn(new iOSVariant());
+
+        final Response response = this.endpoint.resetSecret("123");
+        assertEquals(response.getStatus(), 400);
+    }
+
+    @Test
+    public void shouldReturn204WhenResetSecretFindsAnWebPushVariant() {
+        final WebPushVariant variant = new WebPushVariant();
+        variant.setSecret("The Secret");
+
+        when(variantService.findByVariantID("123")).thenReturn(variant);
+
+        final Response response = this.endpoint.resetSecret("123");
+        assertEquals(response.getStatus(), 200);
+
+        verify(variantService).updateVariant(variant);
+        assertNotEquals("The Secret", variant.getSecret());
+    }
+
+    // stub class to mock constraint violation
+    private static class StubConstraintViolation implements ConstraintViolation {
+
+        public String getMessage() {
+            return "stub violation message";
+        }
+
+        public Path getPropertyPath() {
+            return new Path() {
+                @Override
+                public Iterator<Node> iterator() {
+                    return null;
+                }
+
+                @Override
+                public String toString() {
+                    return "stub violation path";
+                }
+            };
+        }
+
+        public String getMessageTemplate() {
+            return null;
+        }
+
+        public Object getRootBean() {
+            return null;
+        }
+
+        public Class getRootBeanClass() {
+            return null;
+        }
+
+        public Object getLeafBean() {
+            return null;
+        }
+
+        public Object getInvalidValue() {
+            return null;
+        }
+
+        public ConstraintDescriptor<?> getConstraintDescriptor() {
+            return null;
+        }
+    }
+
+}

--- a/jaxrs/src/test/java/org/jboss/aerogear/unifiedpush/rest/util/WebPushVariantTest.java
+++ b/jaxrs/src/test/java/org/jboss/aerogear/unifiedpush/rest/util/WebPushVariantTest.java
@@ -1,0 +1,73 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright Red Hat, Inc., and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.aerogear.unifiedpush.rest.util;
+
+import org.jboss.aerogear.unifiedpush.api.WebPushVariant;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+import java.util.Locale;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class WebPushVariantTest {
+
+    static Validator validator;
+
+    @BeforeClass
+    public static void before() throws Exception {
+        Locale.setDefault(Locale.ENGLISH);
+        ValidatorFactory config = Validation.buildDefaultValidatorFactory();
+        validator = config.getValidator();
+    }
+
+    @Test
+    public void testIsKeypairNotValid() throws Exception {
+        //given
+        WebPushVariant form = new WebPushVariant();
+        form.setName("webPush");
+        form.setPrivateKey("gibberishKey");
+        form.setPublicKey("BIk8YK3iWC3BfMt3GLEghzY4v5GwaZsTWKxDKm-FZry3Nx2E_q-4VW3501DkQ5TX1Pe7c3yIsajUk9hQAo3sT-0");
+        //when
+        final Set<ConstraintViolation<WebPushVariant>> constraintViolations = validator.validate(form);
+
+
+        //then
+        assertThat(constraintViolations).hasSize(1);
+        assertThat(constraintViolations.iterator().next().getMessage())
+                .isEqualTo("the provided private key does not match with the public key");
+    }
+
+    @Test
+    public void testIsCertificatePassPhraseValid() throws Exception {
+        //given
+        WebPushVariant form = new WebPushVariant();
+        form.setName("webPush");
+        form.setPrivateKey("FTg6q0-BXP6m-i6cNpg8P6JKccCUwWaD4yuirotxqXo");
+        form.setPublicKey("BIk8YK3iWC3BfMt3GLEghzY4v5GwaZsTWKxDKm-FZry3Nx2E_q-4VW3501DkQ5TX1Pe7c3yIsajUk9hQAo3sT-0");
+        //when
+        final Set<ConstraintViolation<WebPushVariant>> constraintViolations = validator.validate(form);
+
+        //then
+        assertThat(constraintViolations).isEmpty();
+    }
+}

--- a/model/api/pom.xml
+++ b/model/api/pom.xml
@@ -37,7 +37,14 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk15on</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>nl.martijndwars</groupId>
+            <artifactId>web-push</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>

--- a/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/VariantType.java
+++ b/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/VariantType.java
@@ -36,7 +36,12 @@ public enum VariantType {
     /**
      * The type identifier for our Windows WNS variants.
      */
-    WINDOWS_WNS("windows_wns");
+    WINDOWS_WNS("windows_wns"),
+
+    /**
+     * WebPush type identifier
+     */
+    WEB_PUSH("web_push");
 
     private final String typeName;
 

--- a/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/WebPushVariant.java
+++ b/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/WebPushVariant.java
@@ -1,0 +1,98 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright Red Hat, Inc., and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.aerogear.unifiedpush.api;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import nl.martijndwars.webpush.Utils;
+import org.jboss.aerogear.unifiedpush.utils.KeyUtils;
+
+import javax.validation.constraints.AssertTrue;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+
+/**
+ * The WebPush variant uses self-generated (and optionally provided) VAPID keys for push.
+ */
+public class WebPushVariant extends Variant {
+
+    private static final long serialVersionUID = -1873585264296190331L;
+
+
+    @NotNull
+    @Size(min = 1, max = 255, message = "Public Key must be max. 255 chars long")
+    private String publicKey;
+
+    /**
+     * TODO: Find a way to store this securely
+     */
+    @Size(max = 255, message = "Private Key must be max. 255 chars long")
+    private String privateKey;
+
+    /**
+     * This is a VAPID public key.  It must match the private key.
+     * See https://tools.ietf.org/html/draft-ietf-webpush-vapid-01
+     * @return
+     */
+    public String getPublicKey() {
+        return publicKey;
+    }
+
+    public void setPublicKey(String publicKey) {
+        this.publicKey = publicKey;
+    }
+
+    /**
+     * This is a VAPID private key.  It must match the public key.
+     * See https://tools.ietf.org/html/draft-ietf-webpush-vapid-01
+     * @return
+     */
+    public String getPrivateKey() {
+        return privateKey;
+    }
+
+    public void setPrivateKey(String privateKey) {
+        this.privateKey = privateKey;
+    }
+
+    @Override
+    public VariantType getType() {
+        return VariantType.WEB_PUSH;
+    }
+
+
+    /**
+     * Validates whether the certificate/passphrase pair
+     * is valid, and does not contain any bogus content.
+     *
+     * @return true if valid, otherwise false
+     */
+    @AssertTrue(message = "the provided private key does not match with the public key")
+    @JsonIgnore
+    public boolean isKeypairValid() {
+        try {
+            PrivateKey privateKeyObject = KeyUtils.loadPrivateKey(getPrivateKey());
+            PublicKey publicKeyObject = KeyUtils.loadPublicKey(getPublicKey());
+            return Utils.verifyKeyPair(privateKeyObject, publicKeyObject);
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+}

--- a/model/api/src/main/java/org/jboss/aerogear/unifiedpush/utils/KeyUtils.java
+++ b/model/api/src/main/java/org/jboss/aerogear/unifiedpush/utils/KeyUtils.java
@@ -1,0 +1,53 @@
+package org.jboss.aerogear.unifiedpush.utils;
+
+import nl.martijndwars.webpush.Base64Encoder;
+import org.bouncycastle.jce.ECNamedCurveTable;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.jce.spec.ECParameterSpec;
+import org.bouncycastle.jce.spec.ECPrivateKeySpec;
+import org.bouncycastle.jce.spec.ECPublicKeySpec;
+import org.bouncycastle.math.ec.ECCurve;
+import org.bouncycastle.math.ec.ECPoint;
+import org.bouncycastle.util.BigIntegers;
+
+import java.math.BigInteger;
+
+import java.security.*;
+import java.security.spec.InvalidKeySpecException;
+
+
+/**
+ * This class includes convenient wrappers for bouncy castle to perform key pair validation for WebPush VAPID keys.
+ *
+ * This is mostly based on nl.martijndwars.webpush.Utils, but uses an explicit java.security.provider
+ * instead of a lookup.
+ *
+ */
+public class KeyUtils {
+
+    private static final String CURVE = "prime256v1";
+    private static final String ALGORITHM = "ECDH";
+    private static final Provider PROVIDER = new BouncyCastleProvider();
+
+    public static PrivateKey loadPrivateKey(String privateKey) throws  NoSuchAlgorithmException, InvalidKeySpecException {
+        byte[] decodedPrivateKey = Base64Encoder.decode(privateKey);
+        BigInteger s = BigIntegers.fromUnsignedByteArray(decodedPrivateKey);
+        ECParameterSpec parameterSpec = ECNamedCurveTable.getParameterSpec(CURVE);
+        ECPrivateKeySpec privateKeySpec = new ECPrivateKeySpec(s, parameterSpec);
+        KeyFactory keyFactory = KeyFactory.getInstance(ALGORITHM, PROVIDER);
+
+        return keyFactory.generatePrivate(privateKeySpec);
+    }
+
+    public static PublicKey loadPublicKey(String publicKey) throws NoSuchAlgorithmException, InvalidKeySpecException {
+        byte[] decodedPublicKey = Base64Encoder.decode(publicKey);
+        KeyFactory keyFactory = KeyFactory.getInstance(ALGORITHM, PROVIDER);
+        ECParameterSpec parameterSpec = ECNamedCurveTable.getParameterSpec(CURVE);
+        ECCurve curve = parameterSpec.getCurve();
+        ECPoint point = curve.decodePoint(decodedPublicKey);
+        ECPublicKeySpec pubSpec = new ECPublicKeySpec(point, parameterSpec);
+
+        return keyFactory.generatePublic(pubSpec);
+
+    }
+}

--- a/model/jpa/src/main/resources/META-INF/orm.xml
+++ b/model/jpa/src/main/resources/META-INF/orm.xml
@@ -64,6 +64,18 @@ http://java.sun.com/xml/ns/persistence/orm_2_0.xsd"
             </basic>
         </attributes>
     </entity>
+    <entity class="WebPushVariant" access="FIELD">
+        <table name="webpush_variant"/>
+        <discriminator-value>webpush</discriminator-value>
+        <attributes>
+            <basic name="publicKey">
+                <column name="public_key" length="255" nullable="false"/>
+            </basic>
+            <basic name="privateKey">
+                <column name="private_key" length="255"/>
+            </basic>
+        </attributes>
+    </entity>
     <entity class="iOSVariant" access="FIELD">
         <table name="ios_variant"/>
         <discriminator-value>ios</discriminator-value>

--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,16 @@
         <version>${slfj4.version}</version>
         <scope>test</scope>
       </dependency>
+      <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bcprov-jdk15on</artifactId>
+        <version>1.62</version>
+      </dependency>
+      <dependency>
+        <groupId>nl.martijndwars</groupId>
+        <artifactId>web-push</artifactId>
+        <version>5.0.2</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
## Motivation

See here : 

https://issues.jboss.org/browse/AEROGEAR-9902

## What
This adds rest endpoints, variants, and entities for WebPush.  This is limited to CRUD operations on the variant; it does not include sending push notifications.


## Verification Steps
To create a web push variant you need to create a push application and generate a vapid key pair.

To create a push variant, feel free to use the web ui and take note of the application ID you make.

To create a vapid key, you can use this website https://tools.reactpwa.com/vapid

You can use this as a template for your curl command

```bash
curl --location --request POST "http://localhost:9999/rest/applications/$PUSH_APP_ID/webpush"   --header "Content-Type: application/json"   --data "{
    \"name\": \"WebPush\",
    \"variantID\": \"F85A9650-1FC1-4240-A6D6-D8E1052598D8\",
    \"secret\": \"E37A1C22-046A-4DC4-AFBD-B4A745F466D1\",
    \"type\": \"web_push\",
    \"publicKey\": \"$VAPID_PUBLIC_KEY\",
    \"privateKey\": \"$VAPID_PRIVATE_KEY\"
}"


```

Then check that your variant was created; you can use the ui or a rest command.

`curl  http://localhost:9999/rest/applications/$PUSH_APP_ID`


## Additional Notes

There is a graphical glitch in admin UI right now that shows a Android icon for the webpush variants.  We're not working on the admin ui for web push, but I would like to discuss how we want to fix this.

