### PR TITLE
Aerogear 9903

### DIFF
--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -15,8 +15,6 @@ services:
         POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
         POSTGRES_SERVICE_PORT: ${POSTGRES_SERVICE_PORT}
         POSTGRES_DATABASE: ${POSTGRES_DATABASE}
-        KEYCLOAK_SERVICE_HOST: ${KEYCLOAK_SERVICE_HOST}
-        KEYCLOAK_SERVICE_PORT: ${KEYCLOAK_SERVICE_PORT}
         ARTEMIS_USER: ${ARTEMIS_USER}
         ARTEMIS_PASSWORD: ${ARTEMIS_PASSWORD}
         ARTEMIS_SERVICE_HOST: ${ARTEMIS_SERVICE_HOST}
@@ -26,7 +24,6 @@ services:
     links:
       - unifiedpushDB:unifiedpush
       - artemis:artemis
-      - keycloakServer:keycloak
     ports:
       - 9999:8080
   unifiedpushDB:

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -15,6 +15,8 @@ services:
         POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
         POSTGRES_SERVICE_PORT: ${POSTGRES_SERVICE_PORT}
         POSTGRES_DATABASE: ${POSTGRES_DATABASE}
+        KEYCLOAK_SERVICE_HOST: ${KEYCLOAK_SERVICE_HOST}
+        KEYCLOAK_SERVICE_PORT: ${KEYCLOAK_SERVICE_PORT}
         ARTEMIS_USER: ${ARTEMIS_USER}
         ARTEMIS_PASSWORD: ${ARTEMIS_PASSWORD}
         ARTEMIS_SERVICE_HOST: ${ARTEMIS_SERVICE_HOST}
@@ -24,6 +26,7 @@ services:
     links:
       - unifiedpushDB:unifiedpush
       - artemis:artemis
+    - keycloakServer:keycloak
     ports:
       - 9999:8080
   unifiedpushDB:

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/installations/InstallationRegistrationEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/installations/InstallationRegistrationEndpoint.java
@@ -79,7 +79,6 @@ public class InstallationRegistrationEndpoint extends AbstractBaseEndpoint {
     public Response crossOriginForInstallations(
             @Context HttpHeaders headers,
             @PathParam("token") String token) {
-
         return appendPreflightResponseHeaders(headers, Response.ok()).build();
     }
 
@@ -99,7 +98,6 @@ public class InstallationRegistrationEndpoint extends AbstractBaseEndpoint {
      */
     @OPTIONS
     public Response crossOriginForInstallations(@Context HttpHeaders headers) {
-
         return appendPreflightResponseHeaders(headers, Response.ok()).build();
     }
 

--- a/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/WebPushRegistration.java
+++ b/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/WebPushRegistration.java
@@ -1,0 +1,85 @@
+package org.jboss.aerogear.unifiedpush.api;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import java.util.Base64;
+
+/**
+ * This is a deserialized webpush token.
+ */
+public class WebPushRegistration {
+    private String endpoint ="";
+    private PushKey keys = new PushKey();
+
+    @JsonIgnore
+    public byte[] getAuthAsBytes() {
+        return Base64.getDecoder().decode(keys.getAuth());
+    }
+
+    @JsonIgnore
+    public byte[] getKeyAsBytes() {
+        return Base64.getDecoder().decode(keys.getP256dh());
+    }
+
+    /**
+     * @param endpoint the endpoint to set
+     */
+    public void setEndpoint(String endpoint) {
+        this.endpoint = endpoint;
+    }
+
+    /**
+     * @param keys the keys to set
+     */
+    public void setKeys(PushKey keys) {
+        this.keys = keys;
+    }
+
+    /**
+     * @return the endpoint
+     */
+    public String getEndpoint() {
+        return endpoint;
+    }
+    /**
+     * @return the keys
+     */
+    public PushKey getKeys() {
+        return keys;
+    }
+
+    public static class PushKey {
+        private String p256dh = "";
+        private String auth = "";
+
+        /**
+         * @return the auth
+         */
+        public String getAuth() {
+            return auth;
+        }
+
+        /**
+         * @return the p256dh
+         */
+        public String getP256dh() {
+            return p256dh;
+        }
+
+        /**
+         * @param auth the auth to set
+         */
+        public void setAuth(String auth) {
+            this.auth = auth;
+        }
+
+        /**
+         * @param p256dh the p256dh to set
+         */
+        public void setP256dh(String p256dh) {
+            this.p256dh = p256dh;
+        }
+
+    }
+
+}

--- a/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/validation/DeviceTokenValidator.java
+++ b/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/validation/DeviceTokenValidator.java
@@ -16,8 +16,10 @@
  */
 package org.jboss.aerogear.unifiedpush.api.validation;
 
-import org.jboss.aerogear.unifiedpush.api.VariantType;
+import com.google.gson.Gson;
 import org.jboss.aerogear.unifiedpush.api.Installation;
+import org.jboss.aerogear.unifiedpush.api.VariantType;
+import org.jboss.aerogear.unifiedpush.api.WebPushRegistration;
 
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
@@ -75,7 +77,21 @@ public class DeviceTokenValidator implements ConstraintValidator<DeviceTokenChec
                 return ANDROID_DEVICE_TOKEN.matcher(deviceToken).matches();
             case WINDOWS_WNS:
                 return WINDOWS_DEVICE_TOKEN.matcher(deviceToken).matches();
+            case WEB_PUSH:
+                return isWebPushRegistration(deviceToken);
         }
         return false;
+    }
+
+    private static boolean isWebPushRegistration(String deviceToken) {
+        try {
+            Gson gson = new Gson();
+            WebPushRegistration registration = gson.fromJson(deviceToken, WebPushRegistration.class);
+            return !registration.getEndpoint().isEmpty()
+                    && !registration.getKeys().getAuth().isEmpty()
+                    && !registration.getKeys().getP256dh().isEmpty();
+        } catch (Exception ignore) {
+            return false;
+        }
     }
 }

--- a/model/api/src/main/java/org/jboss/aerogear/unifiedpush/utils/KeyUtils.java
+++ b/model/api/src/main/java/org/jboss/aerogear/unifiedpush/utils/KeyUtils.java
@@ -48,8 +48,7 @@ public class KeyUtils {
     public static PublicKey loadPublicKey(String publicKey) throws NoSuchAlgorithmException, InvalidKeySpecException {
         byte[] decodedPublicKey = Base64Encoder.decode(publicKey);
         KeyFactory keyFactory = KeyFactory.getInstance(ALGORITHM, PROVIDER);
-        ECParameterSpec parameterSpec;
-        parameterSpec = ECNamedCurveTable.getParameterSpec(CURVE);
+        ECParameterSpec parameterSpec = ECNamedCurveTable.getParameterSpec(CURVE);
         ECCurve curve = parameterSpec.getCurve();
         ECPoint point = curve.decodePoint(decodedPublicKey);
         ECPublicKeySpec pubSpec = new ECPublicKeySpec(point, parameterSpec);

--- a/model/api/src/main/java/org/jboss/aerogear/unifiedpush/utils/KeyUtils.java
+++ b/model/api/src/main/java/org/jboss/aerogear/unifiedpush/utils/KeyUtils.java
@@ -3,15 +3,22 @@ package org.jboss.aerogear.unifiedpush.utils;
 import nl.martijndwars.webpush.Base64Encoder;
 import org.bouncycastle.jce.ECNamedCurveTable;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.jce.spec.ECNamedCurveParameterSpec;
 import org.bouncycastle.jce.spec.ECParameterSpec;
 import org.bouncycastle.jce.spec.ECPrivateKeySpec;
 import org.bouncycastle.jce.spec.ECPublicKeySpec;
 import org.bouncycastle.math.ec.ECCurve;
 import org.bouncycastle.math.ec.ECPoint;
 import org.bouncycastle.util.BigIntegers;
+import org.jboss.aerogear.unifiedpush.api.WebPushRegistration;
 
 import java.math.BigInteger;
-import java.security.*;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.PrivateKey;
+import java.security.Provider;
+import java.security.PublicKey;
 import java.security.spec.InvalidKeySpecException;
 
 
@@ -28,7 +35,7 @@ public class KeyUtils {
     private static final String ALGORITHM = "ECDH";
     private static final Provider PROVIDER = new BouncyCastleProvider();
 
-    public static PrivateKey loadPrivateKey(String privateKey) throws  NoSuchAlgorithmException, InvalidKeySpecException {
+    public static PrivateKey loadPrivateKey(String privateKey) throws NoSuchAlgorithmException, InvalidKeySpecException {
         byte[] decodedPrivateKey = Base64Encoder.decode(privateKey);
         BigInteger s = BigIntegers.fromUnsignedByteArray(decodedPrivateKey);
         ECParameterSpec parameterSpec = ECNamedCurveTable.getParameterSpec(CURVE);
@@ -41,7 +48,8 @@ public class KeyUtils {
     public static PublicKey loadPublicKey(String publicKey) throws NoSuchAlgorithmException, InvalidKeySpecException {
         byte[] decodedPublicKey = Base64Encoder.decode(publicKey);
         KeyFactory keyFactory = KeyFactory.getInstance(ALGORITHM, PROVIDER);
-        ECParameterSpec parameterSpec = ECNamedCurveTable.getParameterSpec(CURVE);
+        ECParameterSpec parameterSpec;
+        parameterSpec = ECNamedCurveTable.getParameterSpec(CURVE);
         ECCurve curve = parameterSpec.getCurve();
         ECPoint point = curve.decodePoint(decodedPublicKey);
         ECPublicKeySpec pubSpec = new ECPublicKeySpec(point, parameterSpec);
@@ -49,4 +57,20 @@ public class KeyUtils {
         return keyFactory.generatePublic(pubSpec);
 
     }
+
+
+    /**
+     * Returns the base64 encoded public key as a PublicKey object
+     */
+    public static PublicKey getUserPublicKey(WebPushRegistration registration) throws NoSuchAlgorithmException, InvalidKeySpecException, NoSuchProviderException {
+
+        KeyFactory kf = KeyFactory.getInstance("ECDH", PROVIDER);
+        ECNamedCurveParameterSpec ecSpec = ECNamedCurveTable.getParameterSpec("secp256r1");
+        ECPoint point = ecSpec.getCurve().decodePoint(registration.getKeyAsBytes());
+        ECPublicKeySpec pubSpec = new ECPublicKeySpec(point, ecSpec);
+
+        return kf.generatePublic(pubSpec);
+    }
+
+
 }

--- a/model/api/src/main/java/org/jboss/aerogear/unifiedpush/utils/KeyUtils.java
+++ b/model/api/src/main/java/org/jboss/aerogear/unifiedpush/utils/KeyUtils.java
@@ -11,7 +11,6 @@ import org.bouncycastle.math.ec.ECPoint;
 import org.bouncycastle.util.BigIntegers;
 
 import java.math.BigInteger;
-
 import java.security.*;
 import java.security.spec.InvalidKeySpecException;
 

--- a/model/api/src/test/java/org/jboss/aerogear/unifiedpush/api/validation/DeviceTokenValidatorTest.java
+++ b/model/api/src/test/java/org/jboss/aerogear/unifiedpush/api/validation/DeviceTokenValidatorTest.java
@@ -16,7 +16,9 @@
  */
 package org.jboss.aerogear.unifiedpush.api.validation;
 
+import com.google.gson.Gson;
 import org.jboss.aerogear.unifiedpush.api.VariantType;
+import org.jboss.aerogear.unifiedpush.api.WebPushRegistration;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -39,5 +41,44 @@ public class DeviceTokenValidatorTest {
     public void testInvalidToken() {
         final VariantType andVariantType = VariantType.ANDROID;
         assertThat(DeviceTokenValidator.isValidDeviceTokenForVariant("some-bogus:token", andVariantType)).isFalse();
+    }
+
+    @Test
+    public void testInvalidWebPush() {
+
+        final Gson gson = new Gson();
+
+        final VariantType webPushType = VariantType.WEB_PUSH;
+        assertThat(DeviceTokenValidator.isValidDeviceTokenForVariant("some-bogus:token", webPushType)).isFalse();
+
+        WebPushRegistration registration = new WebPushRegistration();
+        String registrationJson = gson.toJson(registration);
+        assertThat(DeviceTokenValidator.isValidDeviceTokenForVariant(registrationJson, webPushType)).isFalse();
+
+        registration.setEndpoint("https://some nonsense");
+        registrationJson = gson.toJson(registration);
+        assertThat(DeviceTokenValidator.isValidDeviceTokenForVariant(registrationJson, webPushType)).isFalse();
+
+    }
+
+    /**
+     * This just tests that the endpoint and keyfields are set, it does not veryify anything.
+     */
+    @Test
+    public void testValidWebPush() {
+
+        final Gson gson = new Gson();
+
+        final VariantType webPushType = VariantType.WEB_PUSH;
+
+        WebPushRegistration registration = new WebPushRegistration();
+        registration.setEndpoint("https://some nonsense");
+        registration.getKeys().setAuth("authTokens");
+        registration.getKeys().setP256dh("devicePublicKey");
+        String registrationJson = gson.toJson(registration);
+        assertThat(DeviceTokenValidator.isValidDeviceTokenForVariant(registrationJson, webPushType)).isTrue();
+
+
+
     }
 }


### PR DESCRIPTION
## Motivation
See AEROGEAR_9903, WebPush clients can now create installations in UPS.

## How
We have added the ability for the installation endpoint to receive installations where the device token is a json representation of the web push subscription object generated by the client.

## Verification Steps
This is actually hard and confusing because we don't have a js sdk implemented yet.  I will work with @danielpassos  to create a script that can be run.  