### PR TITLE
Aerogear 9897

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,14 @@ language: java
 
 sudo: required
 
-# required for oraclejdk9
-dist: trusty
+dist: bionic
 
 # required for oraclejdk9
 group: edge
 
 jdk:
-  - oraclejdk8
-  - oraclejdk9
+  - oraclejdk11
+  - oraclejdk12
 
 addons:
   sonarcloud:
@@ -20,7 +19,7 @@ addons:
 
 matrix:
   allow_failures:
-    - jdk: oraclejdk9
+    - jdk: oraclejdk12
 
 notifications:
   irc: "irc.freenode.org#aerogear"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,15 @@ language: java
 
 sudo: required
 
-dist: bionic
+# required for oraclejdk9
+dist: trusty
 
 # required for oraclejdk9
 group: edge
 
 jdk:
-  - oraclejdk11
-  - oraclejdk12
+  - oraclejdk8
+  - oraclejdk9
 
 addons:
   sonarcloud:
@@ -19,7 +20,7 @@ addons:
 
 matrix:
   allow_failures:
-    - jdk: oraclejdk12
+    - jdk: oraclejdk9
 
 notifications:
   irc: "irc.freenode.org#aerogear"

--- a/configuration/jms-setup-wildfly.cli
+++ b/configuration/jms-setup-wildfly.cli
@@ -19,6 +19,11 @@ try
   /subsystem=messaging-activemq/server=default/jms-queue=WNSTokenBatchQueue:add(entries=[queue/WNSTokenBatchQueue])
   /subsystem=messaging-activemq/server=default/address-setting=jms.queue.WNSTokenBatchQueue:add(address-full-policy=FAIL, max-size-bytes=40000)
 
+  /subsystem=messaging-activemq/server=default/jms-queue=WebPushMessageQueue:add(entries=[queue/WebPushMessageQueue])
+  /subsystem=messaging-activemq/server=default/address-setting=jms.queue.WebPushMessageQueue:add(redelivery-delay=1500, redelivery-multiplier=1.5, max-redelivery-delay=5000, max-delivery-attempts=-1)
+  /subsystem=messaging-activemq/server=default/jms-queue=WebTokenBatchQueue:add(entries=[queue/WebTokenBatchQueue])
+  /subsystem=messaging-activemq/server=default/address-setting=jms.queue.WebTokenBatchQueue:add(address-full-policy=FAIL, max-size-bytes=40000)
+
 
 
   /subsystem=messaging-activemq/server=default/jms-queue=MetricsQueue:add(entries=[queue/MetricsQueue])
@@ -66,7 +71,10 @@ catch
   /subsystem=messaging-activemq/server=default/jms-queue=WNSTokenBatchQueue:remove
   /subsystem=messaging-activemq/server=default/address-setting=jms.queue.WNSTokenBatchQueue:remove
 
-
+  /subsystem=messaging-activemq/server=default/jms-queue=WebPushMessageQueue:remove
+  /subsystem=messaging-activemq/server=default/address-setting=jms.queue.WebPushMessageQueue:remove
+  /subsystem=messaging-activemq/server=default/jms-queue=WebTokenBatchQueue:remove
+  /subsystem=messaging-activemq/server=default/address-setting=jms.queue.WebTokenBatchQueue:remove
 
   /subsystem=messaging-activemq/server=default/jms-queue=MetricsQueue:remove
   /subsystem=messaging-activemq/server=default/address-setting=jms.queue.MetricsQueue:remove
@@ -100,11 +108,14 @@ catch
   /subsystem=messaging-activemq/server=default/address-setting=jms.queue.GCMTokenBatchQueue:add(address-full-policy=FAIL, max-size-bytes=40000)
 
   /subsystem=messaging-activemq/server=default/jms-queue=WNSPushMessageQueue:add(entries=[queue/WNSPushMessageQueue])
-  /subsystem=messaging-activemq/server=default/address-setting=jms.queue.WNSPushMessageQueue:add(redelivery-delay=1500, redelivery-multiplier=1.5, max-redelivery-delay=5000, max-delivery-attempts=-1)
-  /subsystem=messaging-activemq/server=default/jms-queue=WNSTokenBatchQueue:add(entries=[queue/WNSTokenBatchQueue])
-  /subsystem=messaging-activemq/server=default/address-setting=jms.queue.WNSTokenBatchQueue:add(address-full-policy=FAIL, max-size-bytes=40000)
+    /subsystem=messaging-activemq/server=default/address-setting=jms.queue.WNSPushMessageQueue:add(redelivery-delay=1500, redelivery-multiplier=1.5, max-redelivery-delay=5000, max-delivery-attempts=-1)
+    /subsystem=messaging-activemq/server=default/jms-queue=WNSTokenBatchQueue:add(entries=[queue/WNSTokenBatchQueue])
+    /subsystem=messaging-activemq/server=default/address-setting=jms.queue.WNSTokenBatchQueue:add(address-full-policy=FAIL, max-size-bytes=40000)
 
-
+  /subsystem=messaging-activemq/server=default/jms-queue=WebPushMessageQueue:add(entries=[queue/WebPushMessageQueue])
+  /subsystem=messaging-activemq/server=default/address-setting=jms.queue.WebPushMessageQueue:add(redelivery-delay=1500, redelivery-multiplier=1.5, max-redelivery-delay=5000, max-delivery-attempts=-1)
+  /subsystem=messaging-activemq/server=default/jms-queue=WebTokenBatchQueue:add(entries=[queue/WebTokenBatchQueue])
+  /subsystem=messaging-activemq/server=default/address-setting=jms.queue.WebTokenBatchQueue:add(address-full-policy=FAIL, max-size-bytes=40000)
 
   /subsystem=messaging-activemq/server=default/jms-queue=MetricsQueue:add(entries=[queue/MetricsQueue])
   /subsystem=messaging-activemq/server=default/address-setting=jms.queue.MetricsQueue:add(max-delivery-attempts=-1)

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -15,8 +15,6 @@ services:
         POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
         POSTGRES_SERVICE_PORT: ${POSTGRES_SERVICE_PORT}
         POSTGRES_DATABASE: ${POSTGRES_DATABASE}
-        KEYCLOAK_SERVICE_HOST: ${KEYCLOAK_SERVICE_HOST}
-        KEYCLOAK_SERVICE_PORT: ${KEYCLOAK_SERVICE_PORT}
         ARTEMIS_USER: ${ARTEMIS_USER}
         ARTEMIS_PASSWORD: ${ARTEMIS_PASSWORD}
         ARTEMIS_SERVICE_HOST: ${ARTEMIS_SERVICE_HOST}
@@ -26,7 +24,6 @@ services:
     links:
       - unifiedpushDB:unifiedpush
       - artemis:artemis
-      - keycloakServer:keycloak
     ports:
       - 9999:8080
   unifiedpushDB:

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -26,7 +26,7 @@ services:
     links:
       - unifiedpushDB:unifiedpush
       - artemis:artemis
-    - keycloakServer:keycloak
+      - keycloakServer:keycloak
     ports:
       - 9999:8080
   unifiedpushDB:

--- a/jaxrs/src/test/java/org/jboss/aerogear/unifiedpush/rest/util/WebPushVariantTest.java
+++ b/jaxrs/src/test/java/org/jboss/aerogear/unifiedpush/rest/util/WebPushVariantTest.java
@@ -1,13 +1,13 @@
 /**
  * JBoss, Home of Professional Open Source
  * Copyright Red Hat, Inc., and individual contributors.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- * 	http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -45,6 +45,7 @@ public class WebPushVariantTest {
         //given
         WebPushVariant form = new WebPushVariant();
         form.setName("webPush");
+        form.setAlias("https://redhat.com");
         form.setPrivateKey("gibberishKey");
         form.setPublicKey("BIk8YK3iWC3BfMt3GLEghzY4v5GwaZsTWKxDKm-FZry3Nx2E_q-4VW3501DkQ5TX1Pe7c3yIsajUk9hQAo3sT-0");
         //when
@@ -62,6 +63,7 @@ public class WebPushVariantTest {
         //given
         WebPushVariant form = new WebPushVariant();
         form.setName("webPush");
+        form.setAlias("https://redhat.com");
         form.setPrivateKey("FTg6q0-BXP6m-i6cNpg8P6JKccCUwWaD4yuirotxqXo");
         form.setPublicKey("BIk8YK3iWC3BfMt3GLEghzY4v5GwaZsTWKxDKm-FZry3Nx2E_q-4VW3501DkQ5TX1Pe7c3yIsajUk9hQAo3sT-0");
         //when

--- a/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/WebPushVariant.java
+++ b/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/WebPushVariant.java
@@ -24,6 +24,7 @@ import org.jboss.aerogear.unifiedpush.utils.KeyUtils;
 import javax.validation.constraints.AssertTrue;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
+import java.net.MalformedURLException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 
@@ -34,7 +35,6 @@ public class WebPushVariant extends Variant {
 
     private static final long serialVersionUID = -1873585264296190331L;
 
-
     @NotNull
     @Size(min = 1, max = 255, message = "Public Key must be max. 255 chars long")
     private String publicKey;
@@ -42,8 +42,13 @@ public class WebPushVariant extends Variant {
     /**
      * TODO: Find a way to store this securely
      */
+    @NotNull
     @Size(max = 255, message = "Private Key must be max. 255 chars long")
     private String privateKey;
+
+    @NotNull
+    @Size(max = 255, message = "Alias Must be a max of 255 Chars")
+    private String alias;
 
     /**
      * This is a VAPID public key.  It must match the private key.
@@ -76,6 +81,13 @@ public class WebPushVariant extends Variant {
         return VariantType.WEB_PUSH;
     }
 
+    public String getAlias() {
+        return alias;
+    }
+
+    public void setAlias(String alias) {
+        this.alias = alias;
+    }
 
     /**
      * Validates whether the certificate/passphrase pair
@@ -91,6 +103,26 @@ public class WebPushVariant extends Variant {
             PublicKey publicKeyObject = KeyUtils.loadPublicKey(getPublicKey());
             return Utils.verifyKeyPair(privateKeyObject, publicKeyObject);
         } catch (Exception e) {
+            return false;
+        }
+    }
+
+    @AssertTrue(message = "Alias must be a url or mailto")
+    @JsonIgnore
+    public boolean isAlisURLorMailto() {
+        try {
+            if (alias == null || alias.isEmpty()) {
+                return false;
+            }
+            if (alias.toLowerCase().startsWith("mailto:")) {
+                return  alias.contains("@");
+            }
+            new java.net.URL(alias);
+            return true;
+        } catch (MalformedURLException e) {
+            //Bad practice to use an exception to check if a URL is valid, but I don't want to include a library for the purpose.
+            return false;
+        } catch (Exception e) {//We didn't expect this exception
             return false;
         }
     }

--- a/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/WebPushVariant.java
+++ b/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/WebPushVariant.java
@@ -109,7 +109,7 @@ public class WebPushVariant extends Variant {
 
     @AssertTrue(message = "Alias must be a url or mailto")
     @JsonIgnore
-    public boolean isAlisURLorMailto() {
+    public boolean isAliasURLorMailto() {
         try {
             if (alias == null || alias.isEmpty()) {
                 return false;

--- a/model/api/src/main/java/org/jboss/aerogear/unifiedpush/utils/KeyUtils.java
+++ b/model/api/src/main/java/org/jboss/aerogear/unifiedpush/utils/KeyUtils.java
@@ -11,7 +11,6 @@ import org.bouncycastle.math.ec.ECCurve;
 import org.bouncycastle.math.ec.ECPoint;
 import org.bouncycastle.util.BigIntegers;
 import org.jboss.aerogear.unifiedpush.api.WebPushRegistration;
-
 import java.math.BigInteger;
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;

--- a/model/api/src/main/java/org/jboss/aerogear/unifiedpush/utils/KeyUtils.java
+++ b/model/api/src/main/java/org/jboss/aerogear/unifiedpush/utils/KeyUtils.java
@@ -11,10 +11,10 @@ import org.bouncycastle.math.ec.ECCurve;
 import org.bouncycastle.math.ec.ECPoint;
 import org.bouncycastle.util.BigIntegers;
 import org.jboss.aerogear.unifiedpush.api.WebPushRegistration;
+
 import java.math.BigInteger;
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
-import java.security.NoSuchProviderException;
 import java.security.PrivateKey;
 import java.security.Provider;
 import java.security.PublicKey;
@@ -60,7 +60,7 @@ public class KeyUtils {
     /**
      * Returns the base64 encoded public key as a PublicKey object
      */
-    public static PublicKey getUserPublicKey(WebPushRegistration registration) throws NoSuchAlgorithmException, InvalidKeySpecException, NoSuchProviderException {
+    public static PublicKey getUserPublicKey(WebPushRegistration registration) throws NoSuchAlgorithmException, InvalidKeySpecException {
 
         KeyFactory kf = KeyFactory.getInstance("ECDH", PROVIDER);
         ECNamedCurveParameterSpec ecSpec = ECNamedCurveTable.getParameterSpec("secp256r1");

--- a/model/jpa/src/main/resources/META-INF/orm.xml
+++ b/model/jpa/src/main/resources/META-INF/orm.xml
@@ -72,7 +72,10 @@ http://java.sun.com/xml/ns/persistence/orm_2_0.xsd"
                 <column name="public_key" length="255" nullable="false"/>
             </basic>
             <basic name="privateKey">
-                <column name="private_key" length="255"/>
+                <column name="private_key" length="255" nullable="false"/>
+            </basic>
+            <basic name="alias">
+                <column name="alias" length="255" nullable="false"/>
             </basic>
         </attributes>
     </entity>

--- a/pom.xml
+++ b/pom.xml
@@ -218,8 +218,8 @@
         Options to override the compiler arguments directly on the compiler arument line to separate between what
         the IDE understands as the source level and what the Maven compiler actually use.
     -->
-    <maven.compiler.target>1.8</maven.compiler.target>
-    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
     <wildfly-maven-plugin.version>1.2.0.Final</wildfly-maven-plugin.version>
 
     <aerogear.bom.version>1.1.15</aerogear.bom.version>

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
       <dependency>
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcprov-jdk15on</artifactId>
-        <version>1.62</version>
+        <version>1.63</version>
       </dependency>
       <dependency>
         <groupId>nl.martijndwars</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -218,8 +218,8 @@
         Options to override the compiler arguments directly on the compiler arument line to separate between what
         the IDE understands as the source level and what the Maven compiler actually use.
     -->
-    <maven.compiler.target>11</maven.compiler.target>
-    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
     <wildfly-maven-plugin.version>1.2.0.Final</wildfly-maven-plugin.version>
 
     <aerogear.bom.version>1.1.15</aerogear.bom.version>

--- a/push-sender/pom.xml
+++ b/push-sender/pom.xml
@@ -23,8 +23,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>11</source>
-                    <target>11</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/push-sender/pom.xml
+++ b/push-sender/pom.xml
@@ -17,6 +17,18 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>10</source>
+                    <target>10</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
     <parent>
         <groupId>org.jboss.aerogear.unifiedpush</groupId>
         <artifactId>unifiedpush-parent</artifactId>
@@ -153,7 +165,12 @@
             <version>3.1.Final</version>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.mock-server</groupId>
+            <artifactId>mockserver-netty</artifactId>
+            <version>5.6.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/push-sender/pom.xml
+++ b/push-sender/pom.xml
@@ -23,8 +23,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>10</source>
-                    <target>10</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/push-sender/pom.xml
+++ b/push-sender/pom.xml
@@ -211,12 +211,12 @@
                 <dependency>
                     <groupId>org.bouncycastle</groupId>
                     <artifactId>bcprov-jdk15on</artifactId>
-                    <version>1.62</version>
+                    <version>1.63</version>
                 </dependency>
                 <dependency>
                     <groupId>org.bouncycastle</groupId>
                     <artifactId>bcpkix-jdk15on</artifactId>
-                    <version>1.62</version>
+                    <version>1.63</version>
                 </dependency>
                 <dependency>
                     <groupId>org.apache.derby</groupId>

--- a/push-sender/src/main/java/org/jboss/aerogear/unifiedpush/message/configuration/SenderConfigurationProvider.java
+++ b/push-sender/src/main/java/org/jboss/aerogear/unifiedpush/message/configuration/SenderConfigurationProvider.java
@@ -60,6 +60,11 @@ public class SenderConfigurationProvider {
         return loadConfigurationFor(VariantType.WINDOWS_WNS, new SenderConfiguration(10, 1000));
     }
 
+    @Produces @ApplicationScoped @SenderType(VariantType.WEB_PUSH)
+    public SenderConfiguration produceWebPushConfiguration() {
+        return loadConfigurationFor(VariantType.WEB_PUSH, new SenderConfiguration(10, 1000));
+    }
+
     private SenderConfiguration loadConfigurationFor(VariantType type, SenderConfiguration defaultConfiguration) {
         return validateAndSanitizeConfiguration(type, new SenderConfiguration(
                 getProperty(type, ConfigurationProperty.batchesToLoad, defaultConfiguration.batchesToLoad(), Integer.class),

--- a/push-sender/src/main/java/org/jboss/aerogear/unifiedpush/message/util/QueueUtils.java
+++ b/push-sender/src/main/java/org/jboss/aerogear/unifiedpush/message/util/QueueUtils.java
@@ -1,13 +1,13 @@
 /**
  * JBoss, Home of Professional Open Source
  * Copyright Red Hat, Inc., and individual contributors.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,18 +19,22 @@ package org.jboss.aerogear.unifiedpush.message.util;
 import org.jboss.aerogear.unifiedpush.api.VariantType;
 
 public class QueueUtils {
-    
+
     private static final String apnsTokenBatchQueue = "APNsTokenBatchQueue";
 
     private static final String gcmTokenBatchQueue = "GCMTokenBatchQueue";
 
     private static final String wnsTokenBatchQueue = "WNSTokenBatchQueue";
 
+    private static final String webTokenBatchQueue = "WebTokenBatchQueue";
+
     private static final String apnsPushBatchQueue = "APNsPushMessageQueue";
-        
+
     private static final String gcmPushBatchQueue = "GCMPushMessageQueue";
-    
+
     private static final String wnsPushBatchQueue = "WNSPushMessageQueue";
+
+    private static final String webPushBatchQueue = "WebPushMessageQueue";
 
     public static String selectTokenQueue(VariantType variantType) {
         switch (variantType) {
@@ -40,6 +44,8 @@ public class QueueUtils {
                 return apnsTokenBatchQueue;
             case WINDOWS_WNS:
                 return wnsTokenBatchQueue;
+            case WEB_PUSH:
+                return webTokenBatchQueue;
             default:
                 throw new IllegalStateException("Unknown variant type queue");
         }
@@ -53,6 +59,8 @@ public class QueueUtils {
                 return apnsPushBatchQueue;
             case WINDOWS_WNS:
                 return wnsPushBatchQueue;
+            case WEB_PUSH:
+                return webPushBatchQueue;
             default:
                 throw new IllegalStateException("Unknown variant type queue");
         }

--- a/push-sender/src/main/java/org/jboss/aerogear/unifiedpush/message/webpush/WebPushSender.java
+++ b/push-sender/src/main/java/org/jboss/aerogear/unifiedpush/message/webpush/WebPushSender.java
@@ -56,6 +56,21 @@ public class WebPushSender implements PushNotificationSender {
     @Inject
     private FlatPushMessageInformationDao flatPushMessageInformationDao;
 
+    /**
+     * Default for CDI
+     */
+    public WebPushSender() {
+    }
+
+    /**
+     * This is a constructor for injecting dependencies for testing.
+     * @param flatPushMessageInformationDao
+     */
+    public WebPushSender(FlatPushMessageInformationDao flatPushMessageInformationDao, NotificationDispatcher dispatcher, ClientInstallationService clientInstallationService) {
+        this.flatPushMessageInformationDao = flatPushMessageInformationDao;
+        this.dispatcher = dispatcher;
+        this.clientInstallationService = clientInstallationService;
+    }
 
     @Override
     public void sendPushMessage(final Variant variant, final Collection<String> tokens, final UnifiedPushMessage pushMessage, final String pushMessageInformationId, final NotificationSenderCallback senderCallback) {

--- a/push-sender/src/main/java/org/jboss/aerogear/unifiedpush/message/webpush/WebPushSender.java
+++ b/push-sender/src/main/java/org/jboss/aerogear/unifiedpush/message/webpush/WebPushSender.java
@@ -51,7 +51,7 @@ public class WebPushSender implements PushNotificationSender {
                 Notification notification = null;
                 try {
                     notification = new Notification(registration.getEndpoint(), getUserPublicKey(registration),
-                            registration.getAuthAsBytes(), pushMessage.getMessage().getAlert().getBytes());
+                            registration.getAuthAsBytes(), gson.toJson(pushMessage.getMessage()).getBytes());
                     webPushService.send(notification);
                 } catch (GeneralSecurityException | IOException | JoseException | ExecutionException | InterruptedException e) {
                     logger.error("Error sending web push message.", e);

--- a/push-sender/src/main/java/org/jboss/aerogear/unifiedpush/message/webpush/WebPushSender.java
+++ b/push-sender/src/main/java/org/jboss/aerogear/unifiedpush/message/webpush/WebPushSender.java
@@ -1,0 +1,4 @@
+package org.jboss.aerogear.unifiedpush.message.webpush;
+
+public class WebPushSender {
+}

--- a/push-sender/src/main/java/org/jboss/aerogear/unifiedpush/message/webpush/WebPushSender.java
+++ b/push-sender/src/main/java/org/jboss/aerogear/unifiedpush/message/webpush/WebPushSender.java
@@ -1,4 +1,69 @@
 package org.jboss.aerogear.unifiedpush.message.webpush;
 
-public class WebPushSender {
+import com.google.gson.Gson;
+import nl.martijndwars.webpush.Notification;
+import nl.martijndwars.webpush.PushService;
+import org.jboss.aerogear.unifiedpush.api.Variant;
+import org.jboss.aerogear.unifiedpush.api.VariantType;
+import org.jboss.aerogear.unifiedpush.api.WebPushRegistration;
+import org.jboss.aerogear.unifiedpush.api.WebPushVariant;
+import org.jboss.aerogear.unifiedpush.message.UnifiedPushMessage;
+import org.jboss.aerogear.unifiedpush.message.sender.NotificationSenderCallback;
+import org.jboss.aerogear.unifiedpush.message.sender.PushNotificationSender;
+import org.jboss.aerogear.unifiedpush.message.sender.SenderType;
+import org.jose4j.lang.JoseException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ejb.Stateless;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.Collection;
+import java.util.concurrent.ExecutionException;
+
+import static org.jboss.aerogear.unifiedpush.utils.KeyUtils.getUserPublicKey;
+import static org.jboss.aerogear.unifiedpush.utils.KeyUtils.loadPrivateKey;
+import static org.jboss.aerogear.unifiedpush.utils.KeyUtils.loadPublicKey;
+
+
+@Stateless
+@SenderType(VariantType.WEB_PUSH)
+public class WebPushSender implements PushNotificationSender {
+
+    private static final Logger logger = LoggerFactory.getLogger(WebPushSender.class);
+    private Gson gson = new Gson();
+
+
+    @Override
+    public void sendPushMessage(Variant variant, Collection<String> tokens, UnifiedPushMessage pushMessage, String pushMessageInformationId, NotificationSenderCallback senderCallback) {
+        WebPushVariant webPushVariant = (WebPushVariant) variant;
+        String privateKey = webPushVariant.getPrivateKey();
+        String publicKey = webPushVariant.getPublicKey();
+        String alias = webPushVariant.getAlias();
+        PushService webPushService = new PushService();
+        try {
+            webPushService.setPrivateKey(loadPrivateKey(privateKey));
+            webPushService.setPublicKey(loadPublicKey(publicKey));
+            webPushService.setSubject(alias);
+
+            tokens.forEach(token -> {
+                WebPushRegistration registration = gson.fromJson(token, WebPushRegistration.class);
+                Notification notification = null;
+                try {
+                    notification = new Notification(registration.getEndpoint(), getUserPublicKey(registration),
+                            registration.getAuthAsBytes(), pushMessage.getMessage().getAlert().getBytes());
+                    webPushService.send(notification);
+                } catch (GeneralSecurityException | IOException | JoseException | ExecutionException | InterruptedException e) {
+                    logger.error("Error sending web push message.", e);
+                    senderCallback.onError(e.getMessage());
+                }
+
+            });
+
+        } catch (GeneralSecurityException e) {
+            logger.error("Could not load VAPID keys.", e);
+            senderCallback.onError(e.getMessage());
+        }
+
+    }
 }

--- a/push-sender/src/main/java/org/jboss/aerogear/unifiedpush/message/webpush/WebPushSender.java
+++ b/push-sender/src/main/java/org/jboss/aerogear/unifiedpush/message/webpush/WebPushSender.java
@@ -3,24 +3,38 @@ package org.jboss.aerogear.unifiedpush.message.webpush;
 import com.google.gson.Gson;
 import nl.martijndwars.webpush.Notification;
 import nl.martijndwars.webpush.PushService;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.jboss.aerogear.unifiedpush.api.FlatPushMessageInformation;
 import org.jboss.aerogear.unifiedpush.api.Variant;
 import org.jboss.aerogear.unifiedpush.api.VariantType;
 import org.jboss.aerogear.unifiedpush.api.WebPushRegistration;
 import org.jboss.aerogear.unifiedpush.api.WebPushVariant;
+import org.jboss.aerogear.unifiedpush.dao.FlatPushMessageInformationDao;
+import org.jboss.aerogear.unifiedpush.message.NotificationDispatcher;
 import org.jboss.aerogear.unifiedpush.message.UnifiedPushMessage;
+import org.jboss.aerogear.unifiedpush.message.holder.MessageHolderWithTokens;
 import org.jboss.aerogear.unifiedpush.message.sender.NotificationSenderCallback;
 import org.jboss.aerogear.unifiedpush.message.sender.PushNotificationSender;
 import org.jboss.aerogear.unifiedpush.message.sender.SenderType;
+import org.jboss.aerogear.unifiedpush.service.ClientInstallationService;
 import org.jose4j.lang.JoseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.ejb.Stateless;
+import javax.inject.Inject;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
+import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
+import static org.apache.http.HttpStatus.SC_GONE;
+import static org.apache.http.HttpStatus.SC_NOT_FOUND;
+import static org.apache.http.HttpStatus.SC_REQUEST_TOO_LONG;
 import static org.jboss.aerogear.unifiedpush.utils.KeyUtils.getUserPublicKey;
 import static org.jboss.aerogear.unifiedpush.utils.KeyUtils.loadPrivateKey;
 import static org.jboss.aerogear.unifiedpush.utils.KeyUtils.loadPublicKey;
@@ -33,26 +47,74 @@ public class WebPushSender implements PushNotificationSender {
     private static final Logger logger = LoggerFactory.getLogger(WebPushSender.class);
     private Gson gson = new Gson();
 
+    @Inject
+    private ClientInstallationService clientInstallationService;
+
+    @Inject
+    private NotificationDispatcher dispatcher;
+
+    @Inject
+    private FlatPushMessageInformationDao flatPushMessageInformationDao;
+
 
     @Override
-    public void sendPushMessage(Variant variant, Collection<String> tokens, UnifiedPushMessage pushMessage, String pushMessageInformationId, NotificationSenderCallback senderCallback) {
-        WebPushVariant webPushVariant = (WebPushVariant) variant;
-        String privateKey = webPushVariant.getPrivateKey();
-        String publicKey = webPushVariant.getPublicKey();
-        String alias = webPushVariant.getAlias();
-        PushService webPushService = new PushService();
+    public void sendPushMessage(final Variant variant, final Collection<String> tokens, final UnifiedPushMessage pushMessage, final String pushMessageInformationId, final NotificationSenderCallback senderCallback) {
+        final WebPushVariant webPushVariant = (WebPushVariant) variant;
+        final String privateKey = webPushVariant.getPrivateKey();
+        final String publicKey = webPushVariant.getPublicKey();
+        final String alias = webPushVariant.getAlias();
+        final PushService webPushService = new PushService();
         try {
             webPushService.setPrivateKey(loadPrivateKey(privateKey));
             webPushService.setPublicKey(loadPublicKey(publicKey));
             webPushService.setSubject(alias);
 
+            // storage for all the invalid registration IDs:
+            final Set<String> inactiveTokens = new HashSet<>();
+
+            // storage for all the invalid registration IDs:
+            final Set<String> rescheduleTokens = new HashSet<>();
+
             tokens.forEach(token -> {
-                WebPushRegistration registration = gson.fromJson(token, WebPushRegistration.class);
-                Notification notification = null;
+                final WebPushRegistration registration = gson.fromJson(token, WebPushRegistration.class);
+
                 try {
-                    notification = new Notification(registration.getEndpoint(), getUserPublicKey(registration),
+                    final Notification notification = new Notification(registration.getEndpoint(), getUserPublicKey(registration),
                             registration.getAuthAsBytes(), gson.toJson(pushMessage.getMessage()).getBytes());
-                    webPushService.send(notification);
+
+                    final HttpResponse response = webPushService.send(notification);
+                    final int responseCode = response.getStatusLine().getStatusCode();
+                    final String responseReason = response.getStatusLine().getReasonPhrase();
+                    switch (response.getStatusLine().getStatusCode()) {
+                        case HttpStatus.SC_CREATED:
+                            break;
+                        case 429:
+                            //reschedule
+                            rescheduleTokens.add(token);
+                            break;
+                        case SC_NOT_FOUND:
+                            //not breaking here is intentional
+                        case SC_GONE:
+                            inactiveTokens.add(token);
+                            break;
+                        case SC_REQUEST_TOO_LONG:
+                            final String tooLongMessage = String.format("Request was too long. Message id %s", pushMessageInformationId);
+                            logger.error(tooLongMessage);
+                            senderCallback.onError(tooLongMessage);
+                            break;
+                        case SC_BAD_REQUEST:
+                            final String badRequestMessage = String.format("Bad request. Message id %s", pushMessageInformationId);
+                            logger.error(badRequestMessage);
+                            senderCallback.onError(badRequestMessage);
+                            break;
+                        default:
+                            final String unhandledMessage = String.format("Unknown message response. Was %d with http message %s. Message id %s", responseCode, responseReason, pushMessageInformationId);
+                            logger.error(unhandledMessage);
+                            senderCallback.onError(unhandledMessage);
+                            break;
+
+
+                    }
                 } catch (GeneralSecurityException | IOException | JoseException | ExecutionException | InterruptedException e) {
                     logger.error("Error sending web push message.", e);
                     senderCallback.onError(e.getMessage());
@@ -60,10 +122,39 @@ public class WebPushSender implements PushNotificationSender {
 
             });
 
+            senderCallback.onSuccess();
+
+            if (! inactiveTokens.isEmpty()) {
+                // trigger asynchronous deletion:
+                logger.info(String.format("Based on FCM response data and error codes, deleting %d invalid or duplicated Android installations", inactiveTokens.size()));
+                clientInstallationService.removeInstallationsForVariantByDeviceTokens(variant.getVariantID(), inactiveTokens);
+            }
+
+            if (! rescheduleTokens.isEmpty()) {
+                final FlatPushMessageInformation flatPushMessageInformation = removeErrors(flatPushMessageInformationDao.find(pushMessageInformationId));
+                MessageHolderWithTokens newMessage = new MessageHolderWithTokens(flatPushMessageInformation, pushMessage, variant, rescheduleTokens, 0);
+                newMessage.incrRetryCount();
+                dispatcher.sendMessagesToPushNetwork(newMessage);
+            }
+
         } catch (GeneralSecurityException e) {
             logger.error("Could not load VAPID keys.", e);
             senderCallback.onError(e.getMessage());
         }
 
+    }
+
+    private FlatPushMessageInformation removeErrors(FlatPushMessageInformation pushMessageInformation) {
+        FlatPushMessageInformation info = new FlatPushMessageInformation();
+        info.setAppOpenCounter(pushMessageInformation.getAppOpenCounter());
+        info.setClientIdentifier(pushMessageInformation.getClientIdentifier());
+        info.setFirstOpenDate(pushMessageInformation.getFirstOpenDate());
+        info.setId(pushMessageInformation.getId());
+        info.setIpAddress(pushMessageInformation.getIpAddress());
+        info.setLastOpenDate(pushMessageInformation.getLastOpenDate());
+        info.setPushApplicationId(pushMessageInformation.getPushApplicationId());
+        info.setRawJsonMessage(pushMessageInformation.getRawJsonMessage());
+        info.setSubmitDate(pushMessageInformation.getSubmitDate());
+        return info;
     }
 }

--- a/push-sender/src/test/java/org/jboss/aerogear/unifiedpush/message/sender/WebPushSenderTest.java
+++ b/push-sender/src/test/java/org/jboss/aerogear/unifiedpush/message/sender/WebPushSenderTest.java
@@ -28,6 +28,7 @@ import org.mockserver.model.HttpRequest;
 import org.mockserver.model.HttpResponse;
 
 import java.security.Security;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
@@ -126,12 +127,14 @@ public class WebPushSenderTest {
     @Test
     public void testMessageSent() throws InterruptedException {
         respondWith(HttpStatus.SC_CREATED);
-        final var succesRef = new AtomicBoolean(false);
-        final var errorMessageRef = new AtomicReference<>("");
-        final var latch = new CountDownLatch(1);
+        final AtomicBoolean succesRef = new AtomicBoolean(false);
+        final AtomicReference<String> errorMessageRef = new AtomicReference<>("");
+        final CountDownLatch latch = new CountDownLatch(1);
         NotificationSenderCallback callback = callback(succesRef, errorMessageRef, latch);
 
-        sender.sendPushMessage(pushVariant, List.of(TOKEN), MESSAGE, "42", callback);
+        List<String> tokenList = new ArrayList<>();
+        tokenList.add(TOKEN);
+        sender.sendPushMessage(pushVariant, tokenList, MESSAGE, "42", callback);
 
         latch.await(1, TimeUnit.SECONDS);
         assertEquals("", errorMessageRef.get());
@@ -141,12 +144,14 @@ public class WebPushSenderTest {
     @Test
     public void testReschedule() throws InterruptedException {
         respondWith(429);
-        final var succesRef = new AtomicBoolean(false);
-        final var errorMessageRef = new AtomicReference<>("");
-        final var latch = new CountDownLatch(1);
+        final AtomicBoolean succesRef = new AtomicBoolean(false);
+        final AtomicReference<String> errorMessageRef = new AtomicReference<>("");
+        final CountDownLatch latch = new CountDownLatch(1);
         NotificationSenderCallback callback = callback(succesRef, errorMessageRef, latch);
 
-        sender.sendPushMessage(pushVariant, List.of(TOKEN), MESSAGE, "42", callback);
+        List<String> tokenList = new ArrayList<>();
+        tokenList.add(TOKEN);
+        sender.sendPushMessage(pushVariant, tokenList, MESSAGE, "42", callback);
 
         latch.await(1, TimeUnit.SECONDS);
         assertEquals("", errorMessageRef.get());
@@ -158,12 +163,14 @@ public class WebPushSenderTest {
     @Test
     public void testGone() throws InterruptedException {
         respondWith(SC_GONE);
-        final var succesRef = new AtomicBoolean(false);
-        final var errorMessageRef = new AtomicReference<>("");
-        final var latch = new CountDownLatch(1);
+        final AtomicBoolean succesRef = new AtomicBoolean(false);
+        final AtomicReference<String> errorMessageRef = new AtomicReference<>("");
+        final CountDownLatch latch = new CountDownLatch(1);
         NotificationSenderCallback callback = callback(succesRef, errorMessageRef, latch);
 
-        sender.sendPushMessage(pushVariant, List.of(TOKEN), MESSAGE, "42", callback);
+        List<String> tokenList = new ArrayList<>();
+        tokenList.add(TOKEN);
+        sender.sendPushMessage(pushVariant, tokenList, MESSAGE, "42", callback);
 
         latch.await(1, TimeUnit.SECONDS);
         assertEquals("", errorMessageRef.get());
@@ -175,12 +182,14 @@ public class WebPushSenderTest {
     @Test
     public void testNotFound() throws InterruptedException {
         respondWith(SC_NOT_FOUND);
-        final var succesRef = new AtomicBoolean(false);
-        final var errorMessageRef = new AtomicReference<>("");
-        final var latch = new CountDownLatch(1);
+        final AtomicBoolean succesRef = new AtomicBoolean(false);
+        final AtomicReference<String> errorMessageRef = new AtomicReference<>("");
+        final CountDownLatch latch = new CountDownLatch(1);
         NotificationSenderCallback callback = callback(succesRef, errorMessageRef, latch);
 
-        sender.sendPushMessage(pushVariant, List.of(TOKEN), MESSAGE, "42", callback);
+        List<String> tokenList = new ArrayList<>();
+        tokenList.add(TOKEN);
+        sender.sendPushMessage(pushVariant, tokenList, MESSAGE, "42", callback);
 
         latch.await(1, TimeUnit.SECONDS);
         assertEquals("", errorMessageRef.get());
@@ -191,12 +200,14 @@ public class WebPushSenderTest {
     @Test
     public void testTooLong() throws InterruptedException {
         respondWith(SC_REQUEST_TOO_LONG);
-        final var succesRef = new AtomicBoolean(false);
-        final var errorMessageRef = new AtomicReference<>("");
-        final var latch = new CountDownLatch(1);
+        final AtomicBoolean succesRef = new AtomicBoolean(false);
+        final AtomicReference<String> errorMessageRef = new AtomicReference<>("");
+        final CountDownLatch latch = new CountDownLatch(1);
         NotificationSenderCallback callback = callback(succesRef, errorMessageRef, latch);
 
-        sender.sendPushMessage(pushVariant, List.of(TOKEN), MESSAGE, "42", callback);
+        List<String> tokenList = new ArrayList<>();
+        tokenList.add(TOKEN);
+        sender.sendPushMessage(pushVariant, tokenList, MESSAGE, "42", callback);
 
         latch.await(1, TimeUnit.SECONDS);
         assertEquals("Request was too long. Message id 42", errorMessageRef.get());
@@ -205,12 +216,14 @@ public class WebPushSenderTest {
     @Test
     public void testBadRequest() throws InterruptedException {
         respondWith(SC_BAD_REQUEST);
-        final var succesRef = new AtomicBoolean(false);
-        final var errorMessageRef = new AtomicReference<>("");
-        final var latch = new CountDownLatch(1);
+        final AtomicBoolean succesRef = new AtomicBoolean(false);
+        final AtomicReference<String> errorMessageRef = new AtomicReference<>("");
+        final CountDownLatch latch = new CountDownLatch(1);
         NotificationSenderCallback callback = callback(succesRef, errorMessageRef, latch);
 
-        sender.sendPushMessage(pushVariant, List.of(TOKEN), MESSAGE, "42", callback);
+        List<String> tokenList = new ArrayList<>();
+        tokenList.add(TOKEN);
+        sender.sendPushMessage(pushVariant, tokenList, MESSAGE, "42", callback);
 
         latch.await(1, TimeUnit.SECONDS);
         assertEquals("Bad request. Message id 42", errorMessageRef.get());

--- a/push-sender/src/test/java/org/jboss/aerogear/unifiedpush/message/sender/WebPushSenderTest.java
+++ b/push-sender/src/test/java/org/jboss/aerogear/unifiedpush/message/sender/WebPushSenderTest.java
@@ -1,0 +1,260 @@
+package org.jboss.aerogear.unifiedpush.message.sender;
+
+import org.apache.http.HttpStatus;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.jboss.aerogear.unifiedpush.api.FlatPushMessageInformation;
+import org.jboss.aerogear.unifiedpush.api.PushApplication;
+import org.jboss.aerogear.unifiedpush.api.WebPushVariant;
+import org.jboss.aerogear.unifiedpush.dao.FlatPushMessageInformationDao;
+import org.jboss.aerogear.unifiedpush.message.Message;
+import org.jboss.aerogear.unifiedpush.message.NotificationDispatcher;
+import org.jboss.aerogear.unifiedpush.message.UnifiedPushMessage;
+import org.jboss.aerogear.unifiedpush.message.webpush.WebPushSender;
+import org.jboss.aerogear.unifiedpush.message.windows.TileType;
+import org.jboss.aerogear.unifiedpush.message.windows.Type;
+import org.jboss.aerogear.unifiedpush.service.ClientInstallationService;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Matchers;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.mockserver.integration.ClientAndServer;
+import org.mockserver.model.HttpRequest;
+import org.mockserver.model.HttpResponse;
+
+import java.security.Security;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
+import static org.apache.http.HttpStatus.SC_GONE;
+import static org.apache.http.HttpStatus.SC_NOT_FOUND;
+import static org.apache.http.HttpStatus.SC_REQUEST_TOO_LONG;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockserver.integration.ClientAndServer.startClientAndServer;
+
+/**
+ * This class will test {@link org.jboss.aerogear.unifiedpush.message.webpush.WebPushSender } golden scenarios
+ * as well as error handling.
+ */
+
+@RunWith(MockitoJUnitRunner.class)
+public class WebPushSenderTest {
+
+    private static final String TOKEN = "{\"endpoint\":\"http://localhost:5309/send\",\"keys\":{\"p256dh\":\"BNrYBAc87+z7mFp8Jx8RoEZu/bYQVNJGd6ddAyuQnY9MnNpalbAbAYIHQ1T2kTU/mZCpbIs0NH4yYxAMsAuLCAI=\",\"auth\":\"vpD1pBCVtFi0usZumLYjYw==\"}}";
+    private static final UnifiedPushMessage MESSAGE;
+
+    private ClientAndServer mockServer;
+
+    @Mock
+    FlatPushMessageInformationDao flatPushMessageInformationDao;
+
+    @Mock
+    ClientInstallationService clientInstallationService;
+
+    @Mock
+    NotificationDispatcher dispatcher;
+
+    static {
+        //Create UPS MESSAGE
+        MESSAGE = new UnifiedPushMessage();
+
+        Message message = new Message();
+
+        message.setAlert("HELLO!");
+        message.getApns().setActionCategory("some value");
+        message.setSound("default");
+        message.setBadge(2);
+        message.getWindows().setPage("/MainPage.xaml");
+        message.getWindows().setType(Type.tile);
+        message.getWindows().setTileType(TileType.TileWideBlockAndText01);
+        message.getApns().setContentAvailable(true);
+        MESSAGE.setMessage(message);
+
+        //Add BC
+        Security.addProvider(new BouncyCastleProvider());
+    }
+
+    private WebPushSender sender;
+
+    private PushApplication pushApplication;
+    private WebPushVariant pushVariant;
+
+
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+        //Create push Application
+        pushApplication = new PushApplication();
+        pushApplication.setDescription("desc");
+        pushApplication.setDeveloper("Admin");
+        pushApplication.setName("MyPushApp");
+
+        pushVariant = new WebPushVariant();
+        pushVariant.setPrivateKey("FTg6q0-BXP6m-i6cNpg8P6JKccCUwWaD4yuirotxqXo");
+        pushVariant.setPublicKey("BIk8YK3iWC3BfMt3GLEghzY4v5GwaZsTWKxDKm-FZry3Nx2E_q-4VW3501DkQ5TX1Pe7c3yIsajUk9hQAo3sT-0");
+        pushVariant.setAlias("mailto:test@test.com");
+        pushVariant.setId("Id");
+        pushApplication.getVariants().add(pushVariant);
+
+        //setup flatPushDao
+        when(flatPushMessageInformationDao.find(Matchers.anyString())).thenReturn(new FlatPushMessageInformation());
+        sender = new WebPushSender(flatPushMessageInformationDao, dispatcher, clientInstallationService);
+    }
+
+    @After
+    public void tearDown() {
+        mockServer.stop();
+    }
+
+    @Test
+    public void testMessageSent() throws InterruptedException {
+        respondWith(HttpStatus.SC_CREATED);
+        final var succesRef = new AtomicBoolean(false);
+        final var errorMessageRef = new AtomicReference<>("");
+        final var latch = new CountDownLatch(1);
+        NotificationSenderCallback callback = callback(succesRef, errorMessageRef, latch);
+
+        sender.sendPushMessage(pushVariant, List.of(TOKEN), MESSAGE, "42", callback);
+
+        latch.await(1, TimeUnit.SECONDS);
+        assertEquals("", errorMessageRef.get());
+        assertTrue(succesRef.get());
+    }
+
+    @Test
+    public void testReschedule() throws InterruptedException {
+        respondWith(429);
+        final var succesRef = new AtomicBoolean(false);
+        final var errorMessageRef = new AtomicReference<>("");
+        final var latch = new CountDownLatch(1);
+        NotificationSenderCallback callback = callback(succesRef, errorMessageRef, latch);
+
+        sender.sendPushMessage(pushVariant, List.of(TOKEN), MESSAGE, "42", callback);
+
+        latch.await(1, TimeUnit.SECONDS);
+        assertEquals("", errorMessageRef.get());
+        assertTrue(succesRef.get());
+        verify(dispatcher, times(1)).sendMessagesToPushNetwork(anyObject());
+    }
+
+
+    @Test
+    public void testGone() throws InterruptedException {
+        respondWith(SC_GONE);
+        final var succesRef = new AtomicBoolean(false);
+        final var errorMessageRef = new AtomicReference<>("");
+        final var latch = new CountDownLatch(1);
+        NotificationSenderCallback callback = callback(succesRef, errorMessageRef, latch);
+
+        sender.sendPushMessage(pushVariant, List.of(TOKEN), MESSAGE, "42", callback);
+
+        latch.await(1, TimeUnit.SECONDS);
+        assertEquals("", errorMessageRef.get());
+        assertTrue(succesRef.get());
+        verify(clientInstallationService, times(1)).removeInstallationsForVariantByDeviceTokens(anyString(), Matchers.argThat(includes(TOKEN)));
+    }
+
+
+    @Test
+    public void testNotFound() throws InterruptedException {
+        respondWith(SC_NOT_FOUND);
+        final var succesRef = new AtomicBoolean(false);
+        final var errorMessageRef = new AtomicReference<>("");
+        final var latch = new CountDownLatch(1);
+        NotificationSenderCallback callback = callback(succesRef, errorMessageRef, latch);
+
+        sender.sendPushMessage(pushVariant, List.of(TOKEN), MESSAGE, "42", callback);
+
+        latch.await(1, TimeUnit.SECONDS);
+        assertEquals("", errorMessageRef.get());
+        assertTrue(succesRef.get());
+        verify(clientInstallationService, times(1)).removeInstallationsForVariantByDeviceTokens(anyString(), Matchers.argThat(includes(TOKEN)));
+    }
+
+    @Test
+    public void testTooLong() throws InterruptedException {
+        respondWith(SC_REQUEST_TOO_LONG);
+        final var succesRef = new AtomicBoolean(false);
+        final var errorMessageRef = new AtomicReference<>("");
+        final var latch = new CountDownLatch(1);
+        NotificationSenderCallback callback = callback(succesRef, errorMessageRef, latch);
+
+        sender.sendPushMessage(pushVariant, List.of(TOKEN), MESSAGE, "42", callback);
+
+        latch.await(1, TimeUnit.SECONDS);
+        assertEquals("Request was too long. Message id 42", errorMessageRef.get());
+    }
+
+    @Test
+    public void testBadRequest() throws InterruptedException {
+        respondWith(SC_BAD_REQUEST);
+        final var succesRef = new AtomicBoolean(false);
+        final var errorMessageRef = new AtomicReference<>("");
+        final var latch = new CountDownLatch(1);
+        NotificationSenderCallback callback = callback(succesRef, errorMessageRef, latch);
+
+        sender.sendPushMessage(pushVariant, List.of(TOKEN), MESSAGE, "42", callback);
+
+        latch.await(1, TimeUnit.SECONDS);
+        assertEquals("Bad request. Message id 42", errorMessageRef.get());
+    }
+
+
+    private BaseMatcher<Set<String>> includes(String token) {
+        return new BaseMatcher<Set<String>>() {
+            @Override
+            public boolean matches(Object item) {
+                return ((Set<String>)item).contains(TOKEN);
+            }
+
+            @Override
+            public void describeTo(Description description) {
+
+            }
+        };
+    }
+
+    private NotificationSenderCallback callback(AtomicBoolean succesRef, AtomicReference<String> errorMessageRef, CountDownLatch latch) {
+        return new NotificationSenderCallback() {
+            @Override
+            public void onSuccess() {
+                succesRef.set(true);
+                latch.countDown();
+            }
+
+            @Override
+            public void onError(String reason) {
+                errorMessageRef.set(reason);
+                latch.countDown();
+            }
+        };
+    }
+
+    private void respondWith(Integer responseCode) {
+        //Setup mock server
+        mockServer = startClientAndServer(5309);
+        mockServer.when(
+                HttpRequest.request().withPath("/send")
+        ).respond(
+                HttpResponse.response().withStatusCode( responseCode)
+        );
+    }
+}

--- a/push-sender/src/test/java/org/jboss/aerogear/unifiedpush/message/sender/WebPushSenderTest.java
+++ b/push-sender/src/test/java/org/jboss/aerogear/unifiedpush/message/sender/WebPushSenderTest.java
@@ -40,7 +40,6 @@ import static org.apache.http.HttpStatus.SC_GONE;
 import static org.apache.http.HttpStatus.SC_NOT_FOUND;
 import static org.apache.http.HttpStatus.SC_REQUEST_TOO_LONG;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;

--- a/push-sender/src/test/resources/META-INF/orm.xml
+++ b/push-sender/src/test/resources/META-INF/orm.xml
@@ -116,5 +116,19 @@ http://java.sun.com/xml/ns/persistence/orm_2_0.xsd"
             </basic>
         </attributes>
     </entity>
-
+    <entity class="WebPushVariant" access="FIELD">
+        <table name="webpush_variant"/>
+        <discriminator-value>webpush</discriminator-value>
+        <attributes>
+            <basic name="publicKey">
+                <column name="public_key" length="255" nullable="false"/>
+            </basic>
+            <basic name="privateKey">
+                <column name="private_key" length="255" nullable="false"/>
+            </basic>
+            <basic name="alias">
+                <column name="alias" length="255" nullable="false"/>
+            </basic>
+        </attributes>
+    </entity>
 </entity-mappings>

--- a/push-sender/src/test/resources/WEB-INF/jboss-ejb3.xml
+++ b/push-sender/src/test/resources/WEB-INF/jboss-ejb3.xml
@@ -83,6 +83,25 @@
                 </activation-config-property>
             </activation-config>
         </message-driven>
+        <message-driven>
+            <ejb-name>WebPushMessageConsumer</ejb-name>
+            <ejb-class>org.jboss.aerogear.unifiedpush.message.jms.MessageHolderWithVariantsConsumer</ejb-class>
+            <transaction-type>Container</transaction-type>
+            <activation-config>
+                <activation-config-property>
+                    <activation-config-property-name>destination</activation-config-property-name>
+                    <activation-config-property-value>queue/WebPushMessageQueue</activation-config-property-value>
+                </activation-config-property>
+                <activation-config-property>
+                    <activation-config-property-name>destinationType</activation-config-property-name>
+                    <activation-config-property-value>javax.jms.Queue</activation-config-property-value>
+                </activation-config-property>
+                <activation-config-property>
+                    <activation-config-property-name>acknowledgeMode</activation-config-property-name>
+                    <activation-config-property-value>Auto-acknowledge</activation-config-property-value>
+                </activation-config-property>
+            </activation-config>
+        </message-driven>
 
         <!-- Token Batch Queue MDBs -->
         <message-driven>
@@ -139,6 +158,29 @@
                 <activation-config-property>
                     <activation-config-property-name>destination</activation-config-property-name>
                     <activation-config-property-value>queue/WNSTokenBatchQueue</activation-config-property-value>
+                </activation-config-property>
+                <activation-config-property>
+                    <activation-config-property-name>destinationType</activation-config-property-name>
+                    <activation-config-property-value>javax.jms.Queue</activation-config-property-value>
+                </activation-config-property>
+                <activation-config-property>
+                    <activation-config-property-name>acknowledgeMode</activation-config-property-name>
+                    <activation-config-property-value>Auto-acknowledge</activation-config-property-value>
+                </activation-config-property>
+                <activation-config-property>
+                    <activation-config-property-name>maxSession</activation-config-property-name>
+                    <activation-config-property-value>15</activation-config-property-value>
+                </activation-config-property>
+            </activation-config>
+        </message-driven>
+        <message-driven>
+            <ejb-name>WebTokenBatchConsumer</ejb-name>
+            <ejb-class>org.jboss.aerogear.unifiedpush.message.jms.MessageHolderWithTokensConsumer</ejb-class>
+            <transaction-type>Container</transaction-type>
+            <activation-config>
+                <activation-config-property>
+                    <activation-config-property-name>destination</activation-config-property-name>
+                    <activation-config-property-value>queue/WwbTokenBatchQueue</activation-config-property-value>
                 </activation-config-property>
                 <activation-config-property>
                     <activation-config-property-name>destinationType</activation-config-property-name>

--- a/push-sender/src/test/resources/jms-cleanup-wildfly.cli
+++ b/push-sender/src/test/resources/jms-cleanup-wildfly.cli
@@ -20,6 +20,11 @@ batch
 /subsystem=messaging-activemq/server=default/jms-queue=WNSTokenBatchQueue:remove()
 /subsystem=messaging-activemq/server=default/address-setting=jms.queue.WNSTokenBatchQueue:remove()
 
+/subsystem=messaging-activemq/server=default/jms-queue=WebPushMessageQueue:remove()
+/subsystem=messaging-activemq/server=default/address-setting=jms.queue.WebPushMessageQueue:remove()
+/subsystem=messaging-activemq/server=default/jms-queue=WebTokenBatchQueue:remove()
+/subsystem=messaging-activemq/server=default/address-setting=jms.queue.WebTokenBatchQueue:remove()
+
 
 
 /subsystem=messaging-activemq/server=default/jms-queue=MetricsQueue:remove()

--- a/push-sender/src/test/resources/standalone-full.xml
+++ b/push-sender/src/test/resources/standalone-full.xml
@@ -436,6 +436,8 @@
                 <address-setting name="jms.queue.GCMTokenBatchQueue" max-size-bytes="40000" address-full-policy="FAIL"/>
                 <address-setting name="jms.queue.WNSPushMessageQueue" redelivery-delay="1500" redelivery-multiplier="1.5" max-delivery-attempts="-1" max-redelivery-delay="5000"/>
                 <address-setting name="jms.queue.WNSTokenBatchQueue" max-size-bytes="40000" address-full-policy="FAIL"/>
+                <address-setting name="jms.queue.WebPushMessageQueue" redelivery-delay="1500" redelivery-multiplier="1.5" max-delivery-attempts="-1" max-redelivery-delay="5000"/>
+                <address-setting name="jms.queue.WebTokenBatchQueue" max-size-bytes="40000" address-full-policy="FAIL"/>
                 <address-setting name="jms.queue.MetricsQueue" max-delivery-attempts="-1"/>
                 <address-setting name="jms.queue.TriggerMetricCollectionQueue" redelivery-delay="1000" max-delivery-attempts="-1"/>
                 <address-setting name="jms.queue.BatchLoadedQueue" max-delivery-attempts="-1"/>
@@ -463,6 +465,8 @@
                 <jms-queue name="GCMTokenBatchQueue" entries="queue/GCMTokenBatchQueue"/>
                 <jms-queue name="WNSPushMessageQueue" entries="queue/WNSPushMessageQueue"/>
                 <jms-queue name="WNSTokenBatchQueue" entries="queue/WNSTokenBatchQueue"/>
+                <jms-queue name="WebPushMessageQueue" entries="queue/WebPushMessageQueue"/>
+                <jms-queue name="WebTokenBatchQueue" entries="queue/WebTokenBatchQueue"/>
                 <jms-queue name="MetricsQueue" entries="queue/MetricsQueue"/>
                 <jms-queue name="TriggerMetricCollectionQueue" entries="queue/TriggerMetricCollectionQueue"/>
                 <jms-queue name="TriggerVariantMetricCollectionQueue" entries="queue/TriggerVariantMetricCollectionQueue"/>

--- a/servers/universal/pom.xml
+++ b/servers/universal/pom.xml
@@ -29,7 +29,7 @@
     <name>Configurable Container for UnifiedPush Server</name>
 
     <properties>
-        <base>jboss/wildfly:17.0.0.Final</base>
+        <base>jboss/wildfly:17.0.1.Final</base>
         <project.artifactId>${project.artifactId}</project.artifactId>
     </properties>
 

--- a/servers/universal/src/main/docker/config/create-queues-no-artemis.cli
+++ b/servers/universal/src/main/docker/config/create-queues-no-artemis.cli
@@ -15,6 +15,11 @@ embed-server --server-config=${server.config:standalone.xml}
 /subsystem=messaging-activemq/server=default/jms-queue=WNSTokenBatchQueue:add(entries=[queue/WNSTokenBatchQueue])
 /subsystem=messaging-activemq/server=default/address-setting=jms.queue.WNSTokenBatchQueue:add(address-full-policy=FAIL, max-size-bytes=40000)
 
+/subsystem=messaging-activemq/server=default/jms-queue=WebPushMessageQueue:add(entries=[queue/WebPushMessageQueue])
+/subsystem=messaging-activemq/server=default/address-setting=jms.queue.WebPushMessageQueue:add(redelivery-delay=1500, redelivery-multiplier=1.5, max-redelivery-delay=5000, max-delivery-attempts=-1)
+/subsystem=messaging-activemq/server=default/jms-queue=WebTokenBatchQueue:add(entries=[queue/WebTokenBatchQueue])
+/subsystem=messaging-activemq/server=default/address-setting=jms.queue.WebTokenBatchQueue:add(address-full-policy=FAIL, max-size-bytes=40000)
+
 
 
 /subsystem=messaging-activemq/server=default/jms-queue=MetricsQueue:add(entries=[queue/MetricsQueue])

--- a/servers/universal/src/main/docker/config/jboss-ejb3.xml.artemis
+++ b/servers/universal/src/main/docker/config/jboss-ejb3.xml.artemis
@@ -83,7 +83,25 @@
                 </activation-config-property>
             </activation-config>
         </message-driven>
-
+        <message-driven>
+            <ejb-name>WebPushMessageConsumer</ejb-name>
+            <ejb-class>org.jboss.aerogear.unifiedpush.message.jms.MessageHolderWithVariantsConsumer</ejb-class>
+            <transaction-type>Container</transaction-type>
+            <activation-config>
+                <activation-config-property>
+                    <activation-config-property-name>destination</activation-config-property-name>
+                    <activation-config-property-value>WebPushMessageQueue</activation-config-property-value>
+                </activation-config-property>
+                <activation-config-property>
+                    <activation-config-property-name>destinationType</activation-config-property-name>
+                    <activation-config-property-value>javax.jms.Queue</activation-config-property-value>
+                </activation-config-property>
+                <activation-config-property>
+                    <activation-config-property-name>acknowledgeMode</activation-config-property-name>
+                    <activation-config-property-value>Auto-acknowledge</activation-config-property-value>
+                </activation-config-property>
+            </activation-config>
+        </message-driven>
         <!-- Token Batch Queue MDBs -->
         <message-driven>
             <ejb-name>APNsTokenBatchConsumer</ejb-name>
@@ -155,6 +173,29 @@
             </activation-config>
         </message-driven>
         <message-driven>
+                    <ejb-name>WebTokenBatchConsumer</ejb-name>
+                    <ejb-class>org.jboss.aerogear.unifiedpush.message.jms.MessageHolderWithTokensConsumer</ejb-class>
+                    <transaction-type>Container</transaction-type>
+                    <activation-config>
+                        <activation-config-property>
+                            <activation-config-property-name>destination</activation-config-property-name>
+                            <activation-config-property-value>queue/WebTokenBatchQueue</activation-config-property-value>
+                        </activation-config-property>
+                        <activation-config-property>
+                            <activation-config-property-name>destinationType</activation-config-property-name>
+                            <activation-config-property-value>javax.jms.Queue</activation-config-property-value>
+                        </activation-config-property>
+                        <activation-config-property>
+                            <activation-config-property-name>acknowledgeMode</activation-config-property-name>
+                            <activation-config-property-value>Auto-acknowledge</activation-config-property-value>
+                        </activation-config-property>
+                        <activation-config-property>
+                            <activation-config-property-name>maxSession</activation-config-property-name>
+                            <activation-config-property-value>15</activation-config-property-value>
+                        </activation-config-property>
+                    </activation-config>
+                </message-driven>
+        <message-driven>
             <ejb-name>APNSClientConsumer</ejb-name>
             <ejb-class>org.jboss.aerogear.unifiedpush.message.jms.APNSClientConsumer</ejb-class>
             <transaction-type>Container</transaction-type>
@@ -188,6 +229,10 @@
             <r:resource-adapter-name>remote-artemis-xa</r:resource-adapter-name>
         </r:resource-adapter-binding>
         <r:resource-adapter-binding>
+            <ejb-name>WebPushMessageConsumer</ejb-name>
+            <r:resource-adapter-name>remote-artemis-xa</r:resource-adapter-name>
+        </r:resource-adapter-binding>
+        <r:resource-adapter-binding>
             <ejb-name>APNsPushMessageConsumer</ejb-name>
             <r:resource-adapter-name>remote-artemis-xa</r:resource-adapter-name>
         </r:resource-adapter-binding>
@@ -197,6 +242,10 @@
         </r:resource-adapter-binding>
         <r:resource-adapter-binding>
             <ejb-name>WNSTokenBatchConsumer</ejb-name>
+            <r:resource-adapter-name>remote-artemis-xa</r:resource-adapter-name>
+        </r:resource-adapter-binding>
+        <r:resource-adapter-binding>
+            <ejb-name>WebTokenBatchConsumer</ejb-name>
             <r:resource-adapter-name>remote-artemis-xa</r:resource-adapter-name>
         </r:resource-adapter-binding>
         <r:resource-adapter-binding>

--- a/servers/universal/src/main/docker/config/jboss-ejb3.xml.noartemis
+++ b/servers/universal/src/main/docker/config/jboss-ejb3.xml.noartemis
@@ -65,25 +65,44 @@
             </activation-config>
         </message-driven>
         <message-driven>
-            <ejb-name>WNSPushMessageConsumer</ejb-name>
-            <ejb-class>org.jboss.aerogear.unifiedpush.message.jms.MessageHolderWithVariantsConsumer</ejb-class>
-            <transaction-type>Container</transaction-type>
-            <activation-config>
-                <activation-config-property>
-                    <activation-config-property-name>destination</activation-config-property-name>
-                    <activation-config-property-value>queue/WNSPushMessageQueue</activation-config-property-value>
-                </activation-config-property>
-                <activation-config-property>
-                    <activation-config-property-name>destinationType</activation-config-property-name>
-                    <activation-config-property-value>javax.jms.Queue</activation-config-property-value>
-                </activation-config-property>
-                <activation-config-property>
-                    <activation-config-property-name>acknowledgeMode</activation-config-property-name>
-                    <activation-config-property-value>Auto-acknowledge</activation-config-property-value>
-                </activation-config-property>
-            </activation-config>
-        </message-driven>
-        
+                    <ejb-name>WNSPushMessageConsumer</ejb-name>
+                    <ejb-class>org.jboss.aerogear.unifiedpush.message.jms.MessageHolderWithVariantsConsumer</ejb-class>
+                    <transaction-type>Container</transaction-type>
+                    <activation-config>
+                        <activation-config-property>
+                            <activation-config-property-name>destination</activation-config-property-name>
+                            <activation-config-property-value>queue/WNSPushMessageQueue</activation-config-property-value>
+                        </activation-config-property>
+                        <activation-config-property>
+                            <activation-config-property-name>destinationType</activation-config-property-name>
+                            <activation-config-property-value>javax.jms.Queue</activation-config-property-value>
+                        </activation-config-property>
+                        <activation-config-property>
+                            <activation-config-property-name>acknowledgeMode</activation-config-property-name>
+                            <activation-config-property-value>Auto-acknowledge</activation-config-property-value>
+                        </activation-config-property>
+                    </activation-config>
+                </message-driven>
+                <message-driven>
+                            <ejb-name>WebPushMessageConsumer</ejb-name>
+                            <ejb-class>org.jboss.aerogear.unifiedpush.message.jms.MessageHolderWithVariantsConsumer</ejb-class>
+                            <transaction-type>Container</transaction-type>
+                            <activation-config>
+                                <activation-config-property>
+                                    <activation-config-property-name>destination</activation-config-property-name>
+                                    <activation-config-property-value>queue/WebPushMessageQueue</activation-config-property-value>
+                                </activation-config-property>
+                                <activation-config-property>
+                                    <activation-config-property-name>destinationType</activation-config-property-name>
+                                    <activation-config-property-value>javax.jms.Queue</activation-config-property-value>
+                                </activation-config-property>
+                                <activation-config-property>
+                                    <activation-config-property-name>acknowledgeMode</activation-config-property-name>
+                                    <activation-config-property-value>Auto-acknowledge</activation-config-property-value>
+                                </activation-config-property>
+                            </activation-config>
+                        </message-driven>
+
         <!-- Token Batch Queue MDBs -->
         <message-driven>
             <ejb-name>APNsTokenBatchConsumer</ejb-name>
@@ -132,28 +151,51 @@
             </activation-config>
         </message-driven>
         <message-driven>
-            <ejb-name>WNSTokenBatchConsumer</ejb-name>
-            <ejb-class>org.jboss.aerogear.unifiedpush.message.jms.MessageHolderWithTokensConsumer</ejb-class>
-            <transaction-type>Container</transaction-type>
-            <activation-config>
-                <activation-config-property>
-                    <activation-config-property-name>destination</activation-config-property-name>
-                    <activation-config-property-value>queue/WNSTokenBatchQueue</activation-config-property-value>
-                </activation-config-property>
-                <activation-config-property>
-                    <activation-config-property-name>destinationType</activation-config-property-name>
-                    <activation-config-property-value>javax.jms.Queue</activation-config-property-value>
-                </activation-config-property>
-                <activation-config-property>
-                    <activation-config-property-name>acknowledgeMode</activation-config-property-name>
-                    <activation-config-property-value>Auto-acknowledge</activation-config-property-value>
-                </activation-config-property>
-                <activation-config-property>
-                    <activation-config-property-name>maxSession</activation-config-property-name>
-                    <activation-config-property-value>15</activation-config-property-value>
-                </activation-config-property>
-            </activation-config>
-        </message-driven>
+                    <ejb-name>WNSTokenBatchConsumer</ejb-name>
+                    <ejb-class>org.jboss.aerogear.unifiedpush.message.jms.MessageHolderWithTokensConsumer</ejb-class>
+                    <transaction-type>Container</transaction-type>
+                    <activation-config>
+                        <activation-config-property>
+                            <activation-config-property-name>destination</activation-config-property-name>
+                            <activation-config-property-value>queue/WNSTokenBatchQueue</activation-config-property-value>
+                        </activation-config-property>
+                        <activation-config-property>
+                            <activation-config-property-name>destinationType</activation-config-property-name>
+                            <activation-config-property-value>javax.jms.Queue</activation-config-property-value>
+                        </activation-config-property>
+                        <activation-config-property>
+                            <activation-config-property-name>acknowledgeMode</activation-config-property-name>
+                            <activation-config-property-value>Auto-acknowledge</activation-config-property-value>
+                        </activation-config-property>
+                        <activation-config-property>
+                            <activation-config-property-name>maxSession</activation-config-property-name>
+                            <activation-config-property-value>15</activation-config-property-value>
+                        </activation-config-property>
+                    </activation-config>
+                </message-driven>
+                <message-driven>
+                            <ejb-name>WebTokenBatchConsumer</ejb-name>
+                            <ejb-class>org.jboss.aerogear.unifiedpush.message.jms.MessageHolderWithTokensConsumer</ejb-class>
+                            <transaction-type>Container</transaction-type>
+                            <activation-config>
+                                <activation-config-property>
+                                    <activation-config-property-name>destination</activation-config-property-name>
+                                    <activation-config-property-value>queue/WebTokenBatchQueue</activation-config-property-value>
+                                </activation-config-property>
+                                <activation-config-property>
+                                    <activation-config-property-name>destinationType</activation-config-property-name>
+                                    <activation-config-property-value>javax.jms.Queue</activation-config-property-value>
+                                </activation-config-property>
+                                <activation-config-property>
+                                    <activation-config-property-name>acknowledgeMode</activation-config-property-name>
+                                    <activation-config-property-value>Auto-acknowledge</activation-config-property-value>
+                                </activation-config-property>
+                                <activation-config-property>
+                                    <activation-config-property-name>maxSession</activation-config-property-name>
+                                    <activation-config-property-value>15</activation-config-property-value>
+                                </activation-config-property>
+                            </activation-config>
+                        </message-driven>
         <message-driven>
             <ejb-name>APNSClientConsumer</ejb-name>
             <ejb-class>org.jboss.aerogear.unifiedpush.message.jms.APNSClientConsumer</ejb-class>

--- a/servers/universal/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/servers/universal/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -3,6 +3,7 @@
         <dependencies>
             <module name="org.jboss.resteasy.resteasy-jackson2-provider"  services="import" />
             <module name="org.jboss.xnio"/>
+            <module name="org.bouncycastle" />
         </dependencies>
     </deployment>
 </jboss-deployment-structure>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -94,12 +94,12 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk15on</artifactId>
-            <version>1.62</version>
+            <version>1.63</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk15on</artifactId>
-            <version>1.62</version>
+            <version>1.63</version>
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-9897 

This is it, the PR that let's you send notifications to browsers.  Right now there's still a lot of work left to do.

## How
This adds 2 new queues in all of the right places, adds handling for web push variants to the messaging system, and actually sends messages.  It is missing a few things; most notably lifecycle management for messages.

## Verification Steps
 * Setup UPS with a web push variant (see recent previous PRs)
 * Register a client with UPS (please use the js-sdk PR here : https://github.com/aerogear/aerogear-js-sdk/pull/431)
 * Send a message
 * Ensure message is fetched

## Progress

- [x] Messages send
- [x] Errors handled


## Notes
I removed the "check extra properties" progress task.  This is probably better handled in a different PR as the notification generated by the JS SDK needs to support those as well and we need to figure out what properties we want to support and what they look like.
 

