### PR TITLE
Fixed minor logging issue in NotificationDispatcher

### DIFF
--- a/push-sender/src/main/java/org/jboss/aerogear/unifiedpush/message/NotificationDispatcher.java
+++ b/push-sender/src/main/java/org/jboss/aerogear/unifiedpush/message/NotificationDispatcher.java
@@ -74,7 +74,7 @@ public class NotificationDispatcher {
         final UnifiedPushMessage unifiedPushMessage = msg.getUnifiedPushMessage();
         final Collection<String> deviceTokens = msg.getDeviceTokens();
 
-        logger.info("Received UnifiedPushMessage from JMS queue, will now trigger the Push Notification delivery for the %s variant ({})", variant.getType().getTypeName(), variant.getVariantID());
+        logger.info("Received UnifiedPushMessage from JMS queue, will now trigger the Push Notification delivery for the {} variant ({})", variant.getType().getTypeName(), variant.getVariantID());
         String deduplicationId = String.format("%s-%s-%d", msg.getPushMessageInformation().getId(), msg.getSerialId(), msg.getRetryCount());
         logger.debug("Receiving message " + deduplicationId);
 


### PR DESCRIPTION
## Motivation
Noticed a minor log format issue in our aerogear logs

## What
Detected a minor log format issue in our aerogear logs. Example:
2019-09-25 08:40:38,373 INFO  [NotificationDispatcher] (Thread-42640 (ActiveMQ-client-global-threads)) Received UnifiedPushMessage from JMS queue, will now trigger the Push Notification delivery for the %s variant (android)
This is due to a log format issue in the org.jboss.aerogear.unifiedpush.message.NotificationDispatcher class (l. 77)

## Why
See above

## How
Replace %s with log4j's {} formatting token. 

## Verification Steps
Send push message and look at the logs
 
## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 
