### PR TITLE
Using Base64 encoding of webpush tokens

### DIFF
--- a/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/validation/DeviceTokenValidator.java
+++ b/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/validation/DeviceTokenValidator.java
@@ -23,6 +23,7 @@ import org.jboss.aerogear.unifiedpush.api.WebPushRegistration;
 
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
+import java.util.Base64;
 import java.util.regex.Pattern;
 
 /**
@@ -85,8 +86,9 @@ public class DeviceTokenValidator implements ConstraintValidator<DeviceTokenChec
 
     private static boolean isWebPushRegistration(String deviceToken) {
         try {
+            String jsonToken = new String(Base64.getDecoder().decode(deviceToken));
             Gson gson = new Gson();
-            WebPushRegistration registration = gson.fromJson(deviceToken, WebPushRegistration.class);
+            WebPushRegistration registration = gson.fromJson(jsonToken, WebPushRegistration.class);
             return !registration.getEndpoint().isEmpty()
                     && !registration.getKeys().getAuth().isEmpty()
                     && !registration.getKeys().getP256dh().isEmpty();

--- a/model/api/src/test/java/org/jboss/aerogear/unifiedpush/api/validation/DeviceTokenValidatorTest.java
+++ b/model/api/src/test/java/org/jboss/aerogear/unifiedpush/api/validation/DeviceTokenValidatorTest.java
@@ -21,6 +21,8 @@ import org.jboss.aerogear.unifiedpush.api.VariantType;
 import org.jboss.aerogear.unifiedpush.api.WebPushRegistration;
 import org.junit.Test;
 
+import java.util.Base64;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class DeviceTokenValidatorTest {
@@ -52,7 +54,7 @@ public class DeviceTokenValidatorTest {
         assertThat(DeviceTokenValidator.isValidDeviceTokenForVariant("some-bogus:token", webPushType)).isFalse();
 
         WebPushRegistration registration = new WebPushRegistration();
-        String registrationJson = gson.toJson(registration);
+        String registrationJson = Base64.getEncoder().encodeToString(gson.toJson(registration).getBytes());
         assertThat(DeviceTokenValidator.isValidDeviceTokenForVariant(registrationJson, webPushType)).isFalse();
 
         registration.setEndpoint("https://some nonsense");
@@ -75,7 +77,7 @@ public class DeviceTokenValidatorTest {
         registration.setEndpoint("https://some nonsense");
         registration.getKeys().setAuth("authTokens");
         registration.getKeys().setP256dh("devicePublicKey");
-        String registrationJson = gson.toJson(registration);
+        String registrationJson = Base64.getEncoder().encodeToString(gson.toJson(registration).getBytes());
         assertThat(DeviceTokenValidator.isValidDeviceTokenForVariant(registrationJson, webPushType)).isTrue();
 
 

--- a/push-sender/src/main/java/org/jboss/aerogear/unifiedpush/message/webpush/WebPushSender.java
+++ b/push-sender/src/main/java/org/jboss/aerogear/unifiedpush/message/webpush/WebPushSender.java
@@ -26,6 +26,7 @@ import javax.ejb.Stateless;
 import javax.inject.Inject;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
+import java.util.Base64;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
@@ -91,7 +92,8 @@ public class WebPushSender implements PushNotificationSender {
             final Set<String> rescheduleTokens = new HashSet<>();
 
             tokens.forEach(token -> {
-                final WebPushRegistration registration = gson.fromJson(token, WebPushRegistration.class);
+                String tokenAsJson = new String(Base64.getDecoder().decode(token));
+                final WebPushRegistration registration = gson.fromJson(tokenAsJson, WebPushRegistration.class);
 
                 try {
                     final Notification notification = new Notification(registration.getEndpoint(), getUserPublicKey(registration),

--- a/push-sender/src/test/java/org/jboss/aerogear/unifiedpush/message/sender/WebPushSenderTest.java
+++ b/push-sender/src/test/java/org/jboss/aerogear/unifiedpush/message/sender/WebPushSenderTest.java
@@ -29,6 +29,7 @@ import org.mockserver.model.HttpResponse;
 
 import java.security.Security;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
@@ -57,7 +58,7 @@ import static org.mockserver.integration.ClientAndServer.startClientAndServer;
 @RunWith(MockitoJUnitRunner.class)
 public class WebPushSenderTest {
 
-    private static final String TOKEN = "{\"endpoint\":\"http://localhost:5309/send\",\"keys\":{\"p256dh\":\"BNrYBAc87+z7mFp8Jx8RoEZu/bYQVNJGd6ddAyuQnY9MnNpalbAbAYIHQ1T2kTU/mZCpbIs0NH4yYxAMsAuLCAI=\",\"auth\":\"vpD1pBCVtFi0usZumLYjYw==\"}}";
+    private static final String TOKEN = Base64.getEncoder().encodeToString("{\"endpoint\":\"http://localhost:5309/send\",\"keys\":{\"p256dh\":\"BNrYBAc87+z7mFp8Jx8RoEZu/bYQVNJGd6ddAyuQnY9MnNpalbAbAYIHQ1T2kTU/mZCpbIs0NH4yYxAMsAuLCAI=\",\"auth\":\"vpD1pBCVtFi0usZumLYjYw==\"}}".getBytes());
     private static final UnifiedPushMessage MESSAGE;
 
     private ClientAndServer mockServer;
@@ -239,7 +240,7 @@ public class WebPushSenderTest {
 
             @Override
             public void describeTo(Description description) {
-
+                description.appendText("Expected to include" + TOKEN);
             }
         };
     }


### PR DESCRIPTION
## Motivation
Because tokens are used as restul identifiers, we decided to encode webpush tokens as base64 strings instead of using the raw json.  This makes them safe for URLs, if a bit long.

## What
WebPush tokens are passed and stored as base64 encoded strings.


## Verification Steps
Add the steps required to check this change. Following an example.
 
This is a standard webpush smoke test.
