### PR TITLE
Disabling endpoints by env var and system prop

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -113,6 +113,7 @@ The Unified Push Server can be configured with either System Properties (passed 
 | `ARTEMIS_PORT` |  PORT For AMQP Server.
 | `ARTEMIS_PASSWORD` |  Password for AMQP server.
 | `ARTEMIS_USERNAME` |  Username for AMQP server.
+| `UPS_DISABLED` | a comma separated list of variants to be disabled per their variant type.  See `org.jboss.aerogear.unifiedpush.rest.annotations.DisabledByEnvironment` for more details
 |===
 
 == Releasing the UnifiedPush Server

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.jboss.aerogear.unifiedpush</groupId>
         <artifactId>unifiedpush-parent</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.5.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>unifiedpush-dist</artifactId>

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/annotations/DisabledByEnvironment.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/annotations/DisabledByEnvironment.java
@@ -1,0 +1,50 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright Red Hat, Inc., and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.aerogear.unifiedpush.rest.annotations;
+
+import javax.enterprise.util.Nonbinding;
+import javax.ws.rs.NameBinding;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This endpoint may be disabled by an environment variable, UPS_DISABLED.
+ * This variable takes a comma separated list of endpoints to disable.
+ * 
+ * This is used by the variant endpoints to disable certain REST endpoints per 
+ * environment.
+ * 
+ * To disable web push you would use 
+ * <code>
+ * export UPS_DISABLED=web_push,webpush
+ * </code>
+ *
+ * To disable everything you would use 
+ * <code>
+ * export UPS_DISABLED=web_push,webpush,android,ios,ios_token,iostoken
+ * </code>
+ * 
+ */
+@NameBinding
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE})
+public @interface DisabledByEnvironment {
+    @Nonbinding String[] value() default "";
+}

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/filter/DisabledVariantEndpointFilter.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/filter/DisabledVariantEndpointFilter.java
@@ -1,0 +1,91 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright Red Hat, Inc., and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.aerogear.unifiedpush.rest.filter;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.servlet.ServletException;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.Provider;
+
+import org.jboss.aerogear.unifiedpush.rest.annotations.DisabledByEnvironment;
+import org.jboss.aerogear.unifiedpush.system.ConfigurationUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This filter will return a 404 if the requested path matches a
+ * DisabledByEnvironment annotation
+ */
+@Provider
+@DisabledByEnvironment
+public class DisabledVariantEndpointFilter implements ContainerRequestFilter {
+
+    private static final Logger log = LoggerFactory.getLogger(DisabledVariantEndpointFilter.class.getName());
+
+    private Set<String> globallyDisabledEndpoints = new HashSet<>();
+
+    public DisabledVariantEndpointFilter() throws ServletException {
+        String environmentString = ConfigurationUtils.tryGetGlobalProperty("UPS_DISABLED", "");
+
+        String[] disabledEndpoints = (environmentString.split(","));
+
+        Arrays.stream(disabledEndpoints).filter(env -> !env.isBlank()).forEach(globallyDisabledEndpoints::add);
+
+        log.info(String.format("The following variant endpoints are disabled " + environmentString));
+
+    }
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+
+        List<Object> resources = requestContext.getUriInfo().getMatchedResources();
+
+        for (Object resource : resources) {
+            DisabledByEnvironment annotation = getAnnotation(resource.getClass());
+            
+            if (annotation != null) {
+                for (String value : annotation.value()) {
+                    if (globallyDisabledEndpoints.contains(value)) {
+                        requestContext.abortWith(Response.status(404).build());
+                        return;
+                    }
+
+                }
+            }
+        };
+        
+    }
+
+    public static DisabledByEnvironment getAnnotation(Class<?> clazz) {
+        while (clazz != null) {
+            if (clazz.isAnnotationPresent(DisabledByEnvironment.class)) {
+                return clazz.getAnnotation(DisabledByEnvironment.class);
+            }
+            clazz = clazz.getSuperclass();
+        }
+
+        return null;
+    }
+
+}

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/AndroidVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/AndroidVariantEndpoint.java
@@ -19,7 +19,7 @@ package org.jboss.aerogear.unifiedpush.rest.registry.applications;
 import org.jboss.aerogear.unifiedpush.api.AndroidVariant;
 import org.jboss.aerogear.unifiedpush.api.PushApplication;
 import org.jboss.aerogear.unifiedpush.service.impl.SearchManager;
-
+import org.jboss.aerogear.unifiedpush.rest.annotations.DisabledByEnvironment;
 import javax.validation.ConstraintViolationException;
 import javax.validation.Validator;
 import javax.ws.rs.*;
@@ -31,6 +31,7 @@ import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriInfo;
 
 @Path("/applications/{pushAppID}/android")
+@DisabledByEnvironment("android")
 public class AndroidVariantEndpoint extends AbstractVariantEndpoint<AndroidVariant> {
 
     // required for RESTEasy
@@ -97,8 +98,7 @@ public class AndroidVariantEndpoint extends AbstractVariantEndpoint<AndroidVaria
      * @return                  list of {@link AndroidVariant}s
      */
     @GET
-    @Produces(MediaType.APPLICATION_JSON)
-    public Response listAllAndroidVariationsForPushApp(@PathParam("pushAppID") String pushApplicationID) {
+    @Produces(MediaType.APPLICATION_JSON)    public Response listAllAndroidVariationsForPushApp(@PathParam("pushAppID") String pushApplicationID) {
         final PushApplication application = getSearch().findByPushApplicationIDForDeveloper(pushApplicationID);
         return Response.ok(getVariants(application)).build();
     }

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/WebPushVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/WebPushVariantEndpoint.java
@@ -18,6 +18,7 @@ package org.jboss.aerogear.unifiedpush.rest.registry.applications;
 
 import org.jboss.aerogear.unifiedpush.api.PushApplication;
 import org.jboss.aerogear.unifiedpush.api.WebPushVariant;
+import org.jboss.aerogear.unifiedpush.rest.annotations.DisabledByEnvironment;
 import org.jboss.aerogear.unifiedpush.service.impl.SearchManager;
 
 import javax.validation.ConstraintViolationException;
@@ -28,7 +29,8 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
-@Path("/applications/{pushAppID}/webpush")
+@Path("/applications/{pushAppID}/{ignore:webpush|web_push}")
+@DisabledByEnvironment({"webpush","web_push"})
 public class WebPushVariantEndpoint extends AbstractVariantEndpoint<WebPushVariant> {
 
     public WebPushVariantEndpoint() {

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/iOSTokenVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/iOSTokenVariantEndpoint.java
@@ -19,6 +19,7 @@ package org.jboss.aerogear.unifiedpush.rest.registry.applications;
 import org.jboss.aerogear.unifiedpush.api.PushApplication;
 import org.jboss.aerogear.unifiedpush.api.iOSTokenVariant;
 import org.jboss.aerogear.unifiedpush.message.jms.APNSClientProducer;
+import org.jboss.aerogear.unifiedpush.rest.annotations.DisabledByEnvironment;
 import org.jboss.aerogear.unifiedpush.rest.annotations.PATCH;
 import org.jboss.aerogear.unifiedpush.service.impl.SearchManager;
 
@@ -39,7 +40,8 @@ import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriInfo;
 
-@Path("/applications/{pushAppID}/ios_token")
+@Path("/applications/{pushAppID}/{ignore:iostoken|ios_token}")
+@DisabledByEnvironment({"ios_token","iostoken"})
 public class iOSTokenVariantEndpoint extends AbstractVariantEndpoint<iOSTokenVariant> {
 
     @Inject

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/iOSVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/iOSVariantEndpoint.java
@@ -19,6 +19,7 @@ package org.jboss.aerogear.unifiedpush.rest.registry.applications;
 import org.jboss.aerogear.unifiedpush.api.PushApplication;
 import org.jboss.aerogear.unifiedpush.api.iOSVariant;
 import org.jboss.aerogear.unifiedpush.message.jms.APNSClientProducer;
+import org.jboss.aerogear.unifiedpush.rest.annotations.DisabledByEnvironment;
 import org.jboss.aerogear.unifiedpush.rest.annotations.PATCH;
 import org.jboss.aerogear.unifiedpush.rest.util.iOSApplicationUploadForm;
 import org.jboss.aerogear.unifiedpush.service.impl.SearchManager;
@@ -36,6 +37,7 @@ import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriInfo;
 
 @Path("/applications/{pushAppID}/ios")
+@DisabledByEnvironment("ios")
 public class iOSVariantEndpoint extends AbstractVariantEndpoint<iOSVariant> {
 
     @Inject

--- a/jaxrs/src/test/java/org/jboss/aerogear/unifiedpush/rest/annotations/DisabledByEnvironmentTest.java
+++ b/jaxrs/src/test/java/org/jboss/aerogear/unifiedpush/rest/annotations/DisabledByEnvironmentTest.java
@@ -1,0 +1,115 @@
+package org.jboss.aerogear.unifiedpush.rest.annotations;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.Response;
+
+import org.jboss.aerogear.unifiedpush.rest.filter.DisabledVariantEndpointFilter;
+import org.jboss.aerogear.unifiedpush.rest.registry.applications.AndroidVariantEndpoint;
+import org.jboss.aerogear.unifiedpush.rest.registry.applications.WebPushVariantEndpoint;
+import org.jboss.aerogear.unifiedpush.rest.registry.applications.iOSTokenVariantEndpoint;
+import org.jboss.aerogear.unifiedpush.rest.registry.applications.iOSVariantEndpoint;
+import org.jboss.resteasy.spi.ResteasyUriInfo;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Matchers;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DisabledByEnvironmentTest {
+
+    private DisabledVariantEndpointFilter filter;
+
+    @Before
+    public void setup() throws ServletException {
+        System.setProperty("UPS_DISABLED", "ios,android,webpush,web_push,iostoken,ios_token");
+        filter = new DisabledVariantEndpointFilter();
+    }
+
+
+    @Test
+    public void doNotAbortIfNotInVariable() throws IOException, ServletException {
+        System.setProperty("UPS_DISABLED", "");
+        DisabledVariantEndpointFilter localFilter = new DisabledVariantEndpointFilter();
+        ResteasyUriInfo uriInfo = new ResteasyUriInfo("http://example.org/rest/applications/fake-push-id/android", "",
+                "");
+        uriInfo.pushCurrentResource(new AndroidVariantEndpoint());
+        ContainerRequestContext context = mock(ContainerRequestContext.class);
+        when(context.getUriInfo()).thenReturn(uriInfo);
+        doThrow(new RuntimeException("This should not be aborted.")).when(context).abortWith(Matchers.any());
+        
+        try {
+            localFilter.filter(context);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+    }
+
+    @Test
+    public void androidEnvDisablesAndroid() throws IOException {
+        ResteasyUriInfo uriInfo = new ResteasyUriInfo("http://example.org/rest/applications/fake-push-id/android", "",
+                "");
+        uriInfo.pushCurrentResource(new AndroidVariantEndpoint());
+        runTest(uriInfo);
+    }
+
+    @Test
+    public void iosTokenEnvDisablesiOSToken() {
+        ResteasyUriInfo uriInfo = new ResteasyUriInfo("http://example.org/rest/applications/fake-push-id/ios_token", "",
+                "");
+        uriInfo.pushCurrentResource(new iOSTokenVariantEndpoint());
+        runTest(uriInfo);
+
+        uriInfo = new ResteasyUriInfo("http://example.org/rest/applications/fake-push-id/iostoken", "", "");
+        uriInfo.pushCurrentResource(new iOSTokenVariantEndpoint());
+        runTest(uriInfo);
+
+    }
+
+    private void runTest(ResteasyUriInfo uriInfo) {
+        ContainerRequestContext context = mock(ContainerRequestContext.class);
+        when(context.getUriInfo()).thenReturn(uriInfo);
+        ArgumentCaptor<Response> argument = ArgumentCaptor.forClass(Response.class);
+
+        try {
+            filter.filter(context);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        verify(context).abortWith(argument.capture());
+
+        assertEquals(404, argument.getValue().getStatus());
+    }
+
+    @Test
+    public void iosEnvDisablesIOS() {
+        ResteasyUriInfo uriInfo = new ResteasyUriInfo("http://example.org/rest/applications/fake-push-id/ios", "", "");
+        uriInfo.pushCurrentResource(new iOSVariantEndpoint());
+        runTest(uriInfo);
+    }
+
+    @Test
+    public void webPushEnvDisablesWebPush() {
+        ResteasyUriInfo uriInfo = new ResteasyUriInfo("http://example.org/rest/applications/fake-push-id/webpush", "",
+                "");
+        uriInfo.pushCurrentResource(new WebPushVariantEndpoint());
+        runTest(uriInfo);
+
+        uriInfo = new ResteasyUriInfo("http://example.org/rest/applications/fake-push-id/web_push", "", "");
+        uriInfo.pushCurrentResource(new WebPushVariantEndpoint());
+        runTest(uriInfo);
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -226,7 +226,7 @@
     <wildfly-maven-plugin.version>1.2.0.Final</wildfly-maven-plugin.version>
 
     <aerogear.bom.version>1.1.15</aerogear.bom.version>
-    <admin-ui.version>2.2.1</admin-ui.version>
+    <admin-ui.version>2.2.3</admin-ui.version>
 
     <!-- Override versions of AeroGear BOMs-->
     <junit.version>4.12</junit.version>


### PR DESCRIPTION
## Motivation
See https://issues.jboss.org/browse/AEROGEAR-10100

## How

A Jax-RS filter and annotation were created.  The annotation defines when a variant endpoint should not be called, and the filter checks that call against the configuration to see if the call is allowed.

If the call is not allowed, a 404 error is returned.

## Verification Steps
 
1. Run the container with `docker run --rm -p 8080:8080 -it -e UPS_DISABLED=android quay.io/secondsun/unifiedpush-configurable-container:2.5.1-SNAPSHOT`
2. Attempt to create an Android variant (you can use nonsense data)
3. Verify that this fails with a 404 message in admin-ui
4. Attempt to create a webpush variant (must use valid data https://tools.reactpwa.com/vapid can provide it)
5. This should be created successfully

## Checklist:

- [ x ] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

## Additional Notes

UI updates will be in a separate PR. 

