### PR TITLE
initial docs config

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -114,6 +114,7 @@ The Unified Push Server can be configured with either System Properties (passed 
 | `ARTEMIS_PASSWORD` |  Password for AMQP server.
 | `ARTEMIS_USERNAME` |  Username for AMQP server.
 | `UPS_DISABLED` | a comma separated list of variants to be disabled per their variant type.  See `org.jboss.aerogear.unifiedpush.rest.annotations.DisabledByEnvironment` for more details
+| `DOCS_PATH` |  File system path for documentation links json file. See [docs-links](./jaxrs/src/main/resources/doc-links.json) as an example
 |===
 
 == Releasing the UnifiedPush Server

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/config/DocLinks.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/config/DocLinks.java
@@ -1,0 +1,81 @@
+package org.jboss.aerogear.unifiedpush.rest.config;
+
+import com.google.gson.Gson;
+import org.jboss.aerogear.unifiedpush.system.ConfigurationUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.*;
+import java.util.Map;
+
+public final class DocLinks {
+    private final static String DEFAULT_LINKS = "/doc-links.json";
+    private static DocLinks INSTANCE = null;
+
+    private static final Logger logger = LoggerFactory.getLogger(DocLinks.class);
+
+    private DocLinks() {
+    }
+
+    private static class StreamUtils {
+        public static String streamToString(InputStream in) throws IOException {
+            ByteArrayOutputStream bout = new ByteArrayOutputStream();
+            BufferedInputStream bin = new BufferedInputStream(in);
+
+            int count;
+            byte[] buff = new byte[512];
+
+            do {
+                count = bin.read(buff);
+                if (count > 0) {
+                    bout.write(buff, 0, count);
+                }
+            } while(count > 0);
+
+            return new String(bout.toByteArray());
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, String> getDocsLinks(InputStream jsonStream) throws IOException {
+        String json = StreamUtils.streamToString(jsonStream);
+        Gson gson = new Gson();
+        return gson.fromJson(json, Map.class);
+    }
+
+    public Map<String, String> getDocsLinks() {
+        final Map<String, String> links;
+
+        // Load the default links
+        try(InputStream defaultDocLink = getClass().getClassLoader().getResourceAsStream(DEFAULT_LINKS)) {
+            links = getDocsLinks(defaultDocLink);
+        } catch (Exception e) {
+            throw new IllegalStateException("Error parsing default doc links", e);
+        }
+
+        // Load custom links
+        final String customLinksFilePath = ConfigurationUtils.tryGetGlobalProperty("DOCS_PATH");
+
+        if (customLinksFilePath != null) {
+            try(InputStream customDocLinks = new FileInputStream(customLinksFilePath)) {
+                links.putAll(getDocsLinks(customDocLinks));
+            } catch (Exception e) {
+                logger.error("An error has occurred parsing the custom doc link file at '" + customLinksFilePath + "': " + e.getMessage(), e);
+            }
+        }
+
+        return links;
+    }
+
+    public static DocLinks getInstance() {
+        if (INSTANCE == null) {
+            synchronized (DocLinks.class) {
+                if (INSTANCE == null) {
+                    INSTANCE = new DocLinks();
+                }
+            }
+        }
+
+        return INSTANCE;
+    }
+}

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/config/UIConfigEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/config/UIConfigEndpoint.java
@@ -1,0 +1,69 @@
+package org.jboss.aerogear.unifiedpush.rest.config;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import com.google.gson.Gson;
+
+import org.jboss.aerogear.unifiedpush.system.ConfigurationUtils;
+
+/**
+ * Provides the following ui options * Documentation Links * Disabled Services
+ */
+@Path("/ui/config")
+public class UIConfigEndpoint {
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Map<String, Object> uiConfig() throws Exception {
+
+        String disabled = ConfigurationUtils.tryGetGlobalProperty("UPS_DISABLED");
+        String docsPath = ConfigurationUtils.tryGetGlobalProperty("DOCS_PATH", "/doc-links.json");
+        Map<String, String> docLinks = getDocsLinks(docsPath);
+        Map<String, Object> toReturn = new HashMap<>();
+
+        toReturn.put("UPS_DISABLED", disabled);
+        toReturn.put("DOCS_LINKS", docLinks);
+
+        return toReturn;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, String> getDocsLinks(String docsPath) throws Exception {
+        InputStream stream;
+
+        stream = getClass().getClassLoader().getResourceAsStream(docsPath);
+        if (stream == null) {
+            File file = new File(docsPath);
+            stream = new FileInputStream(file);
+        }
+
+        String json = readAsSting(stream);
+        Gson gson = new Gson();
+        return gson.fromJson(json, Map.class);
+    }
+
+    private String readAsSting(InputStream stream) throws Exception {
+        StringBuilder builder = new StringBuilder();
+        try {
+
+            int data = stream.read();
+            while (data != -1) {
+                builder.append((char) data);
+                data = stream.read();
+            }
+        } finally {
+            stream.close();
+        }
+        return builder.toString();
+    }
+
+}

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/config/UIConfigEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/config/UIConfigEndpoint.java
@@ -1,8 +1,5 @@
 package org.jboss.aerogear.unifiedpush.rest.config;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -10,8 +7,6 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-
-import com.google.gson.Gson;
 
 import org.jboss.aerogear.unifiedpush.system.ConfigurationUtils;
 
@@ -38,32 +33,6 @@ public class UIConfigEndpoint {
 
     @SuppressWarnings("unchecked")
     private Map<String, String> getDocsLinks(String docsPath) throws Exception {
-        InputStream stream;
-
-        stream = getClass().getClassLoader().getResourceAsStream(docsPath);
-        if (stream == null) {
-            File file = new File(docsPath);
-            stream = new FileInputStream(file);
-        }
-
-        String json = readAsSting(stream);
-        Gson gson = new Gson();
-        return gson.fromJson(json, Map.class);
+        return DocLinks.getInstance().getDocsLinks();
     }
-
-    private String readAsSting(InputStream stream) throws Exception {
-        StringBuilder builder = new StringBuilder();
-        try {
-
-            int data = stream.read();
-            while (data != -1) {
-                builder.append((char) data);
-                data = stream.read();
-            }
-        } finally {
-            stream.close();
-        }
-        return builder.toString();
-    }
-
 }

--- a/jaxrs/src/main/resources/doc-links.json
+++ b/jaxrs/src/main/resources/doc-links.json
@@ -1,0 +1,22 @@
+{
+    "create-app": "https://aerogear.org/docs/unifiedpush/ups_userguide/index/#_create_and_manage_pushapplication",
+    "add-variant": "https://aerogear.org/docs/unifiedpush/ups_userguide/index/#_create_and_manage_variants",
+    "step-by-step-android": "https://aerogear.org/docs/unifiedpush/aerogear-push-android/guides/",
+    "step-by-step-ios": "https://aerogear.org/docs/unifiedpush/aerogear-push-ios/guides/",
+    "register-device-android": "https://aerogear.org/docs/unifiedpush/aerogear-push-android/guides/#_registration_with_the_unifiedpush_server",
+    "register-device-ios": "https://aerogear.org/docs/unifiedpush/aerogear-push-ios/guides/#_setting_up_the_ios_variant_id",
+    "build-and-deploy-android": "https://aerogear.org/docs/unifiedpush/aerogear-push-android/guides/#_handling_notification",
+    "build-and-deploy-ios": "https://aerogear.org/docs/unifiedpush/aerogear-push-ios/guides/#_test_the_app_on_your_device",
+    "sender-api": "https://aerogear.org/docs/specs/#push",
+    "sender-api-java": "https://aerogear.org/docs/specs/aerogear-unifiedpush-java-client/",
+    "sender-api-nodejs": "https://www.npmjs.com/package/unifiedpush-node-sender",
+    "sender-api-rest": "https://aerogear.org/docs/specs/aerogear-unifiedpush-rest/index.html",
+    "sender-downloads-java": "https://aerogear.org/getstarted/downloads/#push",
+    "sender-downloads-nodejs": "https://aerogear.org/getstarted/downloads/#push",
+    "sender-step-by-step-java": "https://aerogear.org/docs/unifiedpush/GetStartedwithJavaSender/",
+    "docs-push-getting-started": "https://aerogear.org/getstarted/guides/#push",
+    "docs-push-ios": "http://aerogear.org/docs/unifiedpush/aerogear-push-ios/",
+    "docs-push-cordova": "http://aerogear.org/docs/guides/aerogear-cordova/AerogearCordovaPush/",
+    "docs-push-android": "http://aerogear.org/docs/unifiedpush/aerogear-push-android/",
+    "docs-push-chrome": "http://aerogear.org/docs/unifiedpush/aerogear-push-chrome/"
+  }

--- a/pom.xml
+++ b/pom.xml
@@ -226,7 +226,7 @@
     <wildfly-maven-plugin.version>1.2.0.Final</wildfly-maven-plugin.version>
 
     <aerogear.bom.version>1.1.15</aerogear.bom.version>
-    <admin-ui.version>2.2.4-SNAPSHOT</admin-ui.version>
+    <admin-ui.version>2.2.4</admin-ui.version>
 
     <!-- Override versions of AeroGear BOMs-->
     <junit.version>4.12</junit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -226,7 +226,7 @@
     <wildfly-maven-plugin.version>1.2.0.Final</wildfly-maven-plugin.version>
 
     <aerogear.bom.version>1.1.15</aerogear.bom.version>
-    <admin-ui.version>2.2.3</admin-ui.version>
+    <admin-ui.version>2.2.4-SNAPSHOT</admin-ui.version>
 
     <!-- Override versions of AeroGear BOMs-->
     <junit.version>4.12</junit.version>


### PR DESCRIPTION
## Motivation
See AEROGEAR-10101

This PR creates UI config points and exposes a json configuration for the UI to consume.  

## What
* Two environment variables have been added, DOCS_PATH which is a path to the doc-links.json file and UPS_DISABLED which is a comma separated list of variants to not allow.
* A default doc-links.json is embedded into the source code so that default values are provided for doc links. If any key misses from the provided `doc-links.json`, the default one is used.

## Verification Steps
Add the steps required to check this change. Following an example.
 
1. `mvn clean install`
2. configure a doc-links.json file (there is a default file in the PR)
3. Set the environment variable to point to the path of your file
4. Run UPS
5. Navigate to http://localhost:8080/rest/ui/config and confirm the JSON matches your values

If you are having trouble, I would suggest copying the doc-links.json file to your tmp directory and editing that.  THen you can mount your tmp directory in a docker container and load that file using the environment variable.

Ex
```
docker run --rm -p 8080:8080 -it  -v /tmp:/tmp -e DOCS_PATH=/tmp/doc-links.json -e UPS_DISABLED=ios,android,web_push aerogear/unifiedpush-configurable-container:2.5.1-SNAPSHOT
```
