### PR TITLE
Forcing chameleon to use https during builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <!--
   JBoss, Home of Professional Open Source
   Copyright Red Hat, Inc., and individual contributors
@@ -31,7 +31,31 @@
 
   <name>AeroGear UnifiedPush Server</name>
   <url>http://aerogear.org/push</url>
-
+  <pluginRepositories>
+    <pluginRepository>
+      <id>central</id>
+      <name>Central Repository</name>
+      <url>https://repo.maven.apache.org/maven2</url>
+      <layout>default</layout>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <releases>
+        <updatePolicy>never</updatePolicy>
+      </releases>
+    </pluginRepository>
+  </pluginRepositories>
+  <repositories>
+    <repository>
+      <id>central</id>
+      <name>Central Repository</name>
+      <url>https://repo.maven.apache.org/maven2</url>
+      <layout>default</layout>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
   <scm>
     <connection>scm:git:git://github.com/aerogear/aerogear-unifiedpush-server.git</connection>
     <developerConnection>scm:git:git@github.com:aerogear/aerogear-unifiedpush-server.git
@@ -281,6 +305,7 @@
         <ups.ddl_value>update</ups.ddl_value>
       </properties>
     </profile>
+
 
     <profile>
       <id>code-coverage</id>


### PR DESCRIPTION
## Motivation
Maven has removed support for http based urls, some of our testing libraries are still using them; this overrides those libraries.

## What
added https overrides for maven central in the root pom.

## Why
This was done in the root pom instead of aerogear-parent because we would like to move away from aerogear-parent


## Verification Steps
Delete your local maven cache (~/.m2/repository) and build the project.  It should build without errors/test failures.

## Checklist:

- [ x ] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Additional Notes

If you get an error about docker, this means that the code has build succesfully and you can't build the docker image.  This technically means that the code has worked. 

