### PR TITLE
fix: added Access-Control-Expose-Headers header to the corsfilter class

### DIFF
--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/filter/CORSFilter.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/filter/CORSFilter.java
@@ -25,5 +25,7 @@ public class CORSFilter implements ContainerResponseFilter {
         responseContext.getHeaders().add(
                 "Access-Control-Allow-Methods",
                 "GET, POST, PUT, DELETE, OPTIONS, HEAD");
+        responseContext.getHeaders().add(
+                "Access-Control-Expose-Headers", "*");
     }
 }


### PR DESCRIPTION
## Motivation
In the new AdminUI we need to be able to access the HEADERS to get:
1) The total number of applications
2) The total number of installations for each variants

We needed to expose the headers containing those values

## What
We added the `Access-Control-Expose-Headers: *` to the response headers in UPS.
We have not been able to namely expose the headers since the headers containing the number of installations for each variants are created on the fly and its name contains the variant id

 ## Why
The new UPS Admin UI can reside on different servers than the UPS itself, so CORS was blocking access to the headers

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 
