### PR TITLE
fix!: replacing error string in responses with json objects

### DIFF
--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '2.1'
 
 services:
   unifiedpushserver:
-    image: quay.io/aerogear/unifiedpush-configurable-container:master
+    image: aerogear/unifiedpush-configurable-container:2.5.1-SNAPSHOT
     volumes:
        - ./helper:/ups-helper:z
     entrypoint: "/ups-helper/exportKeycloakHost.sh"

--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -133,6 +133,14 @@
                     </tags>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>11</source>
+                    <target>11</target>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/AbstractBaseEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/AbstractBaseEndpoint.java
@@ -17,6 +17,7 @@
 
 package org.jboss.aerogear.unifiedpush.rest;
 
+import org.jboss.aerogear.unifiedpush.rest.util.error.ErrorBuilder;
 import org.jboss.aerogear.unifiedpush.service.PushSearchService;
 import org.jboss.aerogear.unifiedpush.service.impl.SearchManager;
 import org.slf4j.Logger;
@@ -88,7 +89,7 @@ public abstract class AbstractBaseEndpoint {
                 .collect(Collectors.toMap(v -> v.getPropertyPath().toString(), ConstraintViolation::getMessage));
 
         return Response.status(Response.Status.BAD_REQUEST)
-                .entity(responseObj);
+                .entity(ErrorBuilder.forValidation().setMap(responseObj).build());
     }
 
     /**

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/metrics/PushMetricsEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/metrics/PushMetricsEndpoint.java
@@ -19,6 +19,7 @@ package org.jboss.aerogear.unifiedpush.rest.metrics;
 import org.jboss.aerogear.unifiedpush.api.FlatPushMessageInformation;
 import org.jboss.aerogear.unifiedpush.dao.PageResult;
 import org.jboss.aerogear.unifiedpush.dto.MessageMetrics;
+import org.jboss.aerogear.unifiedpush.rest.util.error.UnifiedPushError;
 import org.jboss.aerogear.unifiedpush.service.metrics.PushMessageMetricsService;
 
 import javax.inject.Inject;
@@ -73,7 +74,7 @@ public class PushMetricsEndpoint {
         }
 
         if (id == null) {
-            return Response.status(Response.Status.NOT_FOUND).entity("Could not find requested information").build();
+            return Response.status(Response.Status.NOT_FOUND).entity(new UnifiedPushError("Could not find requested information")).build();
         }
 
         PageResult<FlatPushMessageInformation, MessageMetrics> pageResult =

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/AbstractVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/AbstractVariantEndpoint.java
@@ -64,7 +64,7 @@ public abstract class AbstractVariantEndpoint<T extends Variant> extends Abstrac
      * @param variantId id of {@link Variant}
      * @return {@link Variant} with new secret
      * @statuscode 200 The secret of Variant reset successfully
-     * @statuscode 400 The requested Variant resource exists but it is not of the given type
+     * @statuscode 404 The requested Variant resource exists but it is not of the given type
      * @statuscode 404 The requested Variant resource does not exist
      */
     @PUT
@@ -87,7 +87,7 @@ public abstract class AbstractVariantEndpoint<T extends Variant> extends Abstrac
         }
 
         if (!type.isInstance(variant)) {
-            return Response.status(Response.Status.BAD_REQUEST).entity(ErrorBuilder.forVariants().wrongType().build()).build();
+            return Response.status(Response.Status.NOT_FOUND).entity(ErrorBuilder.forVariants().notFound().build()).build();
         }
 
         logger.trace("Resetting secret for: {}", variant.getName());
@@ -106,7 +106,7 @@ public abstract class AbstractVariantEndpoint<T extends Variant> extends Abstrac
      *
      * @param variantId id of {@link Variant}
      * @return requested {@link Variant}
-     * @statuscode 400 The requested Variant resource exists but it is not of the given type
+     * @statuscode 404 The requested Variant resource exists but it is not of the given type
      * @statuscode 404 The requested Variant resource does not exist
      */
     @GET
@@ -129,7 +129,7 @@ public abstract class AbstractVariantEndpoint<T extends Variant> extends Abstrac
         }
 
         if (!type.isInstance(variant)) {
-            return Response.status(Response.Status.BAD_REQUEST).entity(ErrorBuilder.forVariants().wrongType().build()).build();
+            return Response.status(Response.Status.NOT_FOUND).entity(ErrorBuilder.forVariants().notFound().build()).build();
         }
 
         return Response.ok(variant).build();
@@ -141,7 +141,7 @@ public abstract class AbstractVariantEndpoint<T extends Variant> extends Abstrac
      * @param variantId id of {@link Variant}
      * @return no content or 404
      * @statuscode 204 The Variant successfully deleted
-     * @statuscode 400 The requested Variant resource exists but it is not of the given type
+     * @statuscode 404 The requested Variant resource exists but it is not of the given type
      * @statuscode 404 The requested Variant resource does not exist
      */
     @DELETE
@@ -162,7 +162,7 @@ public abstract class AbstractVariantEndpoint<T extends Variant> extends Abstrac
         }
 
         if (!type.isInstance(variant)) {
-            return Response.status(Response.Status.BAD_REQUEST).entity(ErrorBuilder.forVariants().wrongType().build()).build();
+            return Response.status(Response.Status.NOT_FOUND).entity(ErrorBuilder.forVariants().notFound().build()).build();
         }
 
         logger.trace("Deleting: {}", variant.getClass().getSimpleName());

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/AbstractVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/AbstractVariantEndpoint.java
@@ -1,13 +1,13 @@
 /**
  * JBoss, Home of Professional Open Source
  * Copyright Red Hat, Inc., and individual contributors.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -53,7 +53,7 @@ public abstract class AbstractVariantEndpoint<T extends Variant> extends Abstrac
     }
 
     // required for tests
-    AbstractVariantEndpoint(Validator validator, SearchManager searchManager, Class<T> type ) {
+    AbstractVariantEndpoint(Validator validator, SearchManager searchManager, Class<T> type) {
         super(validator, searchManager);
         this.type = type;
     }
@@ -62,8 +62,7 @@ public abstract class AbstractVariantEndpoint<T extends Variant> extends Abstrac
      * Secret Reset
      *
      * @param variantId id of {@link Variant}
-     * @return          {@link Variant} with new secret
-     *
+     * @return {@link Variant} with new secret
      * @statuscode 200 The secret of Variant reset successfully
      * @statuscode 400 The requested Variant resource exists but it is not of the given type
      * @statuscode 404 The requested Variant resource does not exist
@@ -72,7 +71,14 @@ public abstract class AbstractVariantEndpoint<T extends Variant> extends Abstrac
     @Path("/{variantId}/reset")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    public Response resetSecret(@PathParam("variantId") String variantId) {
+    public Response resetSecret(@PathParam("pushAppID") String pushApplicationID,
+                                @PathParam("variantId") String variantId) {
+        // find the root push app
+        PushApplication pushApp = getSearch().findByPushApplicationIDForDeveloper(pushApplicationID);
+
+        if (pushApp == null) {
+            return Response.status(Response.Status.NOT_FOUND).entity(ErrorBuilder.forPushApplications().notFound().build()).build();
+        }
 
         Variant variant = variantService.findByVariantID(variantId);
 
@@ -99,15 +105,22 @@ public abstract class AbstractVariantEndpoint<T extends Variant> extends Abstrac
      * Get Variant
      *
      * @param variantId id of {@link Variant}
-     * @return          requested {@link Variant}
-     *
+     * @return requested {@link Variant}
      * @statuscode 400 The requested Variant resource exists but it is not of the given type
      * @statuscode 404 The requested Variant resource does not exist
      */
     @GET
     @Path("/{variantId}")
     @Produces(MediaType.APPLICATION_JSON)
-    public Response findVariantById(@PathParam("variantId") String variantId) {
+    public Response findVariantById(@PathParam("pushAppID") String pushApplicationID,
+                                    @PathParam("variantId") String variantId) {
+
+        // find the root push app
+        PushApplication pushApp = getSearch().findByPushApplicationIDForDeveloper(pushApplicationID);
+
+        if (pushApp == null) {
+            return Response.status(Response.Status.NOT_FOUND).entity(ErrorBuilder.forPushApplications().notFound().build()).build();
+        }
 
         Variant variant = variantService.findByVariantID(variantId);
 
@@ -126,16 +139,21 @@ public abstract class AbstractVariantEndpoint<T extends Variant> extends Abstrac
      * Delete Variant
      *
      * @param variantId id of {@link Variant}
-     *
      * @return no content or 404
-     *
      * @statuscode 204 The Variant successfully deleted
      * @statuscode 400 The requested Variant resource exists but it is not of the given type
      * @statuscode 404 The requested Variant resource does not exist
      */
     @DELETE
     @Path("/{variantId}")
-    public Response deleteVariant(@PathParam("variantId") String variantId) {
+    public Response deleteVariant(@PathParam("pushAppID") String pushApplicationID,
+                                  @PathParam("variantId") String variantId) {
+        // find the root push app
+        PushApplication pushApp = getSearch().findByPushApplicationIDForDeveloper(pushApplicationID);
+
+        if (pushApp == null) {
+            return Response.status(Response.Status.NOT_FOUND).entity(ErrorBuilder.forPushApplications().notFound().build()).build();
+        }
 
         Variant variant = variantService.findByVariantID(variantId);
 

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/AbstractVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/AbstractVariantEndpoint.java
@@ -19,6 +19,7 @@ package org.jboss.aerogear.unifiedpush.rest.registry.applications;
 import org.jboss.aerogear.unifiedpush.api.PushApplication;
 import org.jboss.aerogear.unifiedpush.api.Variant;
 import org.jboss.aerogear.unifiedpush.rest.AbstractBaseEndpoint;
+import org.jboss.aerogear.unifiedpush.rest.util.error.UnifiedPushError;
 import org.jboss.aerogear.unifiedpush.service.GenericVariantService;
 import org.jboss.aerogear.unifiedpush.service.PushApplicationService;
 import org.jboss.aerogear.unifiedpush.service.impl.SearchManager;
@@ -76,11 +77,11 @@ public abstract class AbstractVariantEndpoint<T extends Variant> extends Abstrac
         Variant variant = variantService.findByVariantID(variantId);
 
         if (variant == null) {
-            return Response.status(Response.Status.NOT_FOUND).entity("Could not find requested Variant").build();
+            return Response.status(Response.Status.NOT_FOUND).entity(new UnifiedPushError("Could not find requested Variant")).build();
         }
 
         if (!type.isInstance(variant)) {
-            return Response.status(Response.Status.BAD_REQUEST).entity("Requested Variant is of another type/platform").build();
+            return Response.status(Response.Status.BAD_REQUEST).entity(new UnifiedPushError("Requested Variant is of another type/platform")).build();
         }
 
         logger.trace("Resetting secret for: {}", variant.getName());
@@ -111,11 +112,11 @@ public abstract class AbstractVariantEndpoint<T extends Variant> extends Abstrac
         Variant variant = variantService.findByVariantID(variantId);
 
         if (variant == null) {
-            return Response.status(Response.Status.NOT_FOUND).entity("Could not find requested Variant").build();
+            return Response.status(Response.Status.NOT_FOUND).entity(new UnifiedPushError("Could not find requested Variant")).build();
         }
 
         if (!type.isInstance(variant)) {
-            return Response.status(Response.Status.BAD_REQUEST).entity("Requested Variant is of another type/platform").build();
+            return Response.status(Response.Status.BAD_REQUEST).entity(new UnifiedPushError("Requested Variant is of another type/platform")).build();
         }
 
         return Response.ok(variant).build();
@@ -139,11 +140,11 @@ public abstract class AbstractVariantEndpoint<T extends Variant> extends Abstrac
         Variant variant = variantService.findByVariantID(variantId);
 
         if (variant == null) {
-            return Response.status(Response.Status.NOT_FOUND).entity("Could not find requested Variant").build();
+            return Response.status(Response.Status.NOT_FOUND).entity(new UnifiedPushError("Could not find requested Variant")).build();
         }
 
         if (!type.isInstance(variant)) {
-            return Response.status(Response.Status.BAD_REQUEST).entity("Requested Variant is of another type/platform").build();
+            return Response.status(Response.Status.BAD_REQUEST).entity(new UnifiedPushError("Requested Variant is of another type/platform")).build();
         }
 
         logger.trace("Deleting: {}", variant.getClass().getSimpleName());

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/AndroidVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/AndroidVariantEndpoint.java
@@ -1,13 +1,13 @@
 /**
  * JBoss, Home of Professional Open Source
  * Copyright Red Hat, Inc., and individual contributors.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- * 	http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,9 +18,10 @@ package org.jboss.aerogear.unifiedpush.rest.registry.applications;
 
 import org.jboss.aerogear.unifiedpush.api.AndroidVariant;
 import org.jboss.aerogear.unifiedpush.api.PushApplication;
+import org.jboss.aerogear.unifiedpush.rest.annotations.DisabledByEnvironment;
 import org.jboss.aerogear.unifiedpush.rest.util.error.ErrorBuilder;
 import org.jboss.aerogear.unifiedpush.service.impl.SearchManager;
-import org.jboss.aerogear.unifiedpush.rest.annotations.DisabledByEnvironment;
+
 import javax.validation.ConstraintViolationException;
 import javax.validation.Validator;
 import javax.ws.rs.*;
@@ -51,7 +52,7 @@ public class AndroidVariantEndpoint extends AbstractVariantEndpoint<AndroidVaria
      * @param androidVariant    new {@link AndroidVariant}
      * @param pushApplicationID id of {@link PushApplication}
      * @param uriInfo           the uri
-     * @return                  created {@link AndroidVariant}
+     * @return created {@link AndroidVariant}
      *
      * @statuscode 201 The Android Variant created successfully
      * @statuscode 400 The format of the client request was incorrect
@@ -96,10 +97,11 @@ public class AndroidVariantEndpoint extends AbstractVariantEndpoint<AndroidVaria
      * List Android Variants for Push Application
      *
      * @param pushApplicationID id of {@link PushApplication}
-     * @return                  list of {@link AndroidVariant}s
+     * @return list of {@link AndroidVariant}s
      */
     @GET
-    @Produces(MediaType.APPLICATION_JSON)    public Response listAllAndroidVariationsForPushApp(@PathParam("pushAppID") String pushApplicationID) {
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response listAllAndroidVariationsForPushApp(@PathParam("pushAppID") String pushApplicationID) {
         final PushApplication application = getSearch().findByPushApplicationIDForDeveloper(pushApplicationID);
 
         if (application == null) {
@@ -116,7 +118,7 @@ public class AndroidVariantEndpoint extends AbstractVariantEndpoint<AndroidVaria
      * @param androidID                 id of {@link AndroidVariant}
      * @param updatedAndroidApplication new info of {@link AndroidVariant}
      *
-     * @return                  updated {@link AndroidVariant}
+     * @return updated {@link AndroidVariant}
      *
      * @statuscode 200 The Android Variant updated successfully
      * @statuscode 400 The format of the client request was incorrect
@@ -137,10 +139,14 @@ public class AndroidVariantEndpoint extends AbstractVariantEndpoint<AndroidVaria
             return Response.status(Response.Status.NOT_FOUND).entity(ErrorBuilder.forPushApplications().notFound().build()).build();
         }
 
-        AndroidVariant androidVariant = (AndroidVariant) variantService.findByVariantID(androidID);
-        if (androidVariant != null) {
+        // some validation
+        var variant = variantService.findByVariantID(androidID);
 
-            // some validation
+        if (variant != null) {
+            if (!(variant instanceof AndroidVariant)) {
+                return Response.status(Response.Status.NOT_FOUND).entity(ErrorBuilder.forVariants().notFound().build()).build();
+            }
+            AndroidVariant androidVariant = (AndroidVariant) variant;
             try {
                 updatedAndroidApplication.merge(androidVariant);
                 validateModelClass(androidVariant);

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/AndroidVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/AndroidVariantEndpoint.java
@@ -101,13 +101,18 @@ public class AndroidVariantEndpoint extends AbstractVariantEndpoint<AndroidVaria
     @GET
     @Produces(MediaType.APPLICATION_JSON)    public Response listAllAndroidVariationsForPushApp(@PathParam("pushAppID") String pushApplicationID) {
         final PushApplication application = getSearch().findByPushApplicationIDForDeveloper(pushApplicationID);
+
+        if (application == null) {
+            return Response.status(Response.Status.NOT_FOUND).entity(ErrorBuilder.forPushApplications().notFound().build()).build();
+        }
+
         return Response.ok(getVariants(application)).build();
     }
 
     /**
      * Update Android Variant
      *
-     * @param id                        id of {@link PushApplication}
+     * @param pushApplicationId         id of {@link PushApplication}
      * @param androidID                 id of {@link AndroidVariant}
      * @param updatedAndroidApplication new info of {@link AndroidVariant}
      *
@@ -122,9 +127,15 @@ public class AndroidVariantEndpoint extends AbstractVariantEndpoint<AndroidVaria
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     public Response updateAndroidVariant(
-            @PathParam("pushAppID") String id,
+            @PathParam("pushAppID") String pushApplicationId,
             @PathParam("androidID") String androidID,
             AndroidVariant updatedAndroidApplication) {
+
+        final PushApplication application = getSearch().findByPushApplicationIDForDeveloper(pushApplicationId);
+
+        if (application == null) {
+            return Response.status(Response.Status.NOT_FOUND).entity(ErrorBuilder.forPushApplications().notFound().build()).build();
+        }
 
         AndroidVariant androidVariant = (AndroidVariant) variantService.findByVariantID(androidID);
         if (androidVariant != null) {

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/AndroidVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/AndroidVariantEndpoint.java
@@ -142,7 +142,8 @@ public class AndroidVariantEndpoint extends AbstractVariantEndpoint<AndroidVaria
 
             // some validation
             try {
-                validateModelClass(updatedAndroidApplication);
+                updatedAndroidApplication.merge(androidVariant);
+                validateModelClass(androidVariant);
             } catch (ConstraintViolationException cve) {
                 logger.info("Unable to update Android Variant '{}'", androidVariant.getVariantID());
                 logger.debug("Details: {}", cve);
@@ -153,11 +154,7 @@ public class AndroidVariantEndpoint extends AbstractVariantEndpoint<AndroidVaria
                 return builder.build();
             }
 
-            // apply updated data:
-            androidVariant.setGoogleKey(updatedAndroidApplication.getGoogleKey());
-            androidVariant.setProjectNumber(updatedAndroidApplication.getProjectNumber());
-            androidVariant.setName(updatedAndroidApplication.getName());
-            androidVariant.setDescription(updatedAndroidApplication.getDescription());
+
             logger.trace("Updating Android Variant '{}'", androidID);
             variantService.updateVariant(androidVariant);
             return Response.ok(androidVariant).build();

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/AndroidVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/AndroidVariantEndpoint.java
@@ -18,6 +18,7 @@ package org.jboss.aerogear.unifiedpush.rest.registry.applications;
 
 import org.jboss.aerogear.unifiedpush.api.AndroidVariant;
 import org.jboss.aerogear.unifiedpush.api.PushApplication;
+import org.jboss.aerogear.unifiedpush.rest.util.error.UnifiedPushError;
 import org.jboss.aerogear.unifiedpush.service.impl.SearchManager;
 import org.jboss.aerogear.unifiedpush.rest.annotations.DisabledByEnvironment;
 import javax.validation.ConstraintViolationException;
@@ -68,7 +69,7 @@ public class AndroidVariantEndpoint extends AbstractVariantEndpoint<AndroidVaria
         PushApplication pushApp = getSearch().findByPushApplicationIDForDeveloper(pushApplicationID);
 
         if (pushApp == null) {
-            return Response.status(Status.NOT_FOUND).entity("Could not find requested PushApplicationEntity").build();
+            return Response.status(Status.NOT_FOUND).entity(new UnifiedPushError("Could not find requested PushApplicationEntity")).build();
         }
 
         // some validation
@@ -151,7 +152,7 @@ public class AndroidVariantEndpoint extends AbstractVariantEndpoint<AndroidVaria
             return Response.ok(androidVariant).build();
         }
 
-        return Response.status(Status.NOT_FOUND).entity("Could not find requested Variant").build();
+        return Response.status(Status.NOT_FOUND).entity(new UnifiedPushError("Could not find requested Variant")).build();
     }
 
 }

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/InstallationManagementEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/InstallationManagementEndpoint.java
@@ -19,6 +19,7 @@ package org.jboss.aerogear.unifiedpush.rest.registry.applications;
 import org.jboss.aerogear.unifiedpush.api.Installation;
 import org.jboss.aerogear.unifiedpush.dao.PageResult;
 import org.jboss.aerogear.unifiedpush.dto.Count;
+import org.jboss.aerogear.unifiedpush.rest.util.error.UnifiedPushError;
 import org.jboss.aerogear.unifiedpush.service.ClientInstallationService;
 import org.jboss.aerogear.unifiedpush.service.impl.SearchManager;
 import org.jboss.resteasy.spi.Link;
@@ -81,7 +82,7 @@ public class InstallationManagementEndpoint {
 
         //Find the variant using the variantID
         if (!searchManager.getSearchService().existsVariantIDForDeveloper(variantId)) {
-            return Response.status(Response.Status.NOT_FOUND).entity("Could not find requested Variant").build();
+            return Response.status(Response.Status.NOT_FOUND).entity(new UnifiedPushError("Could not find requested Variant")).build();
         }
 
         //Find the installations using the variantID
@@ -135,7 +136,7 @@ public class InstallationManagementEndpoint {
         Installation installation = clientInstallationService.findById(installationId);
 
         if (installation == null) {
-            return Response.status(Response.Status.NOT_FOUND).entity("Could not find requested Installation").build();
+            return Response.status(Response.Status.NOT_FOUND).entity(new UnifiedPushError("Could not find requested Installation")).build();
         }
 
         return Response.ok(installation).build();
@@ -161,7 +162,7 @@ public class InstallationManagementEndpoint {
         Installation installation = clientInstallationService.findById(installationId);
 
         if (installation == null) {
-            return Response.status(Response.Status.NOT_FOUND).entity("Could not find requested Installation").build();
+            return Response.status(Response.Status.NOT_FOUND).entity(new UnifiedPushError("Could not find requested Installation")).build();
         }
 
         clientInstallationService.updateInstallation(installation, entity);
@@ -188,7 +189,7 @@ public class InstallationManagementEndpoint {
         Installation installation = clientInstallationService.findById(installationId);
 
         if (installation == null) {
-            return Response.status(Response.Status.NOT_FOUND).entity("Could not find requested Installation").build();
+            return Response.status(Response.Status.NOT_FOUND).entity(new UnifiedPushError("Could not find requested Installation")).build();
         }
 
         // remove it

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/PushApplicationEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/PushApplicationEndpoint.java
@@ -22,6 +22,7 @@ import org.jboss.aerogear.unifiedpush.dao.InstallationDao;
 import org.jboss.aerogear.unifiedpush.dao.PageResult;
 import org.jboss.aerogear.unifiedpush.dto.Count;
 import org.jboss.aerogear.unifiedpush.rest.AbstractBaseEndpoint;
+import org.jboss.aerogear.unifiedpush.rest.util.error.UnifiedPushError;
 import org.jboss.aerogear.unifiedpush.service.PushApplicationService;
 import org.jboss.aerogear.unifiedpush.service.impl.SearchManager;
 import org.jboss.aerogear.unifiedpush.service.metrics.PushMessageMetricsService;
@@ -188,7 +189,7 @@ public class PushApplicationEndpoint extends AbstractBaseEndpoint {
             return response.build();
         }
 
-        return Response.status(Status.NOT_FOUND).entity("Could not find requested PushApplicationEntity").build();
+        return Response.status(Status.NOT_FOUND).entity(new UnifiedPushError("Could not find requested PushApplicationEntity")).build();
     }
 
     private void putActivityIntoResponseHeaders(PushApplication app, ResponseBuilder response) {
@@ -247,7 +248,7 @@ public class PushApplicationEndpoint extends AbstractBaseEndpoint {
             return Response.noContent().build();
         }
 
-        return Response.status(Status.NOT_FOUND).entity("Could not find requested PushApplicationEntity").build();
+        return Response.status(Status.NOT_FOUND).entity(new UnifiedPushError("Could not find requested PushApplicationEntity")).build();
     }
 
     /**
@@ -278,7 +279,7 @@ public class PushApplicationEndpoint extends AbstractBaseEndpoint {
             return Response.ok(pushApp).build();
         }
 
-        return Response.status(Status.NOT_FOUND).entity("Could not find requested PushApplicationEntity").build();
+        return Response.status(Status.NOT_FOUND).entity(new UnifiedPushError("Could not find requested PushApplicationEntity")).build();
     }
 
     /**
@@ -302,7 +303,7 @@ public class PushApplicationEndpoint extends AbstractBaseEndpoint {
             pushAppService.removePushApplication(pushApp);
             return Response.noContent().build();
         }
-        return Response.status(Status.NOT_FOUND).entity("Could not find requested PushApplicationEntity").build();
+        return Response.status(Status.NOT_FOUND).entity(new UnifiedPushError("Could not find requested PushApplicationEntity")).build();
     }
 
     /**

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/WebPushVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/WebPushVariantEndpoint.java
@@ -101,6 +101,11 @@ public class WebPushVariantEndpoint extends AbstractVariantEndpoint<WebPushVaria
     @Produces(MediaType.APPLICATION_JSON)
     public Response listAllWebPushVariationsForPushApp(@PathParam("pushAppID") String pushApplicationID) {
         final PushApplication application = getSearch().findByPushApplicationIDForDeveloper(pushApplicationID);
+
+        if (application == null) {
+            return Response.status(Response.Status.NOT_FOUND).entity(ErrorBuilder.forPushApplications().notFound().build()).build();
+        }
+
         return Response.ok(getVariants(application)).build();
     }
 
@@ -108,8 +113,15 @@ public class WebPushVariantEndpoint extends AbstractVariantEndpoint<WebPushVaria
     @Path("/{webPushID}")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    public Response updateWebPushVariant(@PathParam("pushAppID") String id,
+    public Response updateWebPushVariant(@PathParam("pushAppID") String pushApplicationID,
                                          @PathParam("webPushID") String webPushID, WebPushVariant updatedVariant) {
+
+        final PushApplication application = getSearch().findByPushApplicationIDForDeveloper(pushApplicationID);
+
+        if (application == null) {
+            return Response.status(Response.Status.NOT_FOUND).entity(ErrorBuilder.forPushApplications().notFound().build()).build();
+        }
+
         WebPushVariant webPushVariant = (WebPushVariant) variantService.findByVariantID(webPushID);
         if (webPushVariant != null) {
 

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/WebPushVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/WebPushVariantEndpoint.java
@@ -122,9 +122,13 @@ public class WebPushVariantEndpoint extends AbstractVariantEndpoint<WebPushVaria
             return Response.status(Response.Status.NOT_FOUND).entity(ErrorBuilder.forPushApplications().notFound().build()).build();
         }
 
-        WebPushVariant webPushVariant = (WebPushVariant) variantService.findByVariantID(webPushID);
-        if (webPushVariant != null) {
+        var variant = variantService.findByVariantID(webPushID);
 
+        if (variant != null) {
+            if (!(variant instanceof WebPushVariant)) {
+                return Response.status(Response.Status.NOT_FOUND).entity(ErrorBuilder.forVariants().notFound().build()).build();
+            }
+            WebPushVariant webPushVariant = (WebPushVariant) variant;
             // some validation
             try {
                 updatedVariant.merge(webPushVariant);

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/WebPushVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/WebPushVariantEndpoint.java
@@ -127,7 +127,8 @@ public class WebPushVariantEndpoint extends AbstractVariantEndpoint<WebPushVaria
 
             // some validation
             try {
-                validateModelClass(updatedVariant);
+                updatedVariant.merge(webPushVariant);
+                validateModelClass(webPushVariant);
             } catch (ConstraintViolationException cve) {
                 logger.info("Unable to update WebPush Variant '{}'", webPushVariant.getVariantID());
                 logger.debug("Details: {}", cve);
@@ -138,11 +139,6 @@ public class WebPushVariantEndpoint extends AbstractVariantEndpoint<WebPushVaria
                 return builder.build();
             }
 
-            // apply updated data:
-            webPushVariant.setPublicKey(updatedVariant.getPublicKey());
-            webPushVariant.setPrivateKey(updatedVariant.getPrivateKey());
-            webPushVariant.setName(updatedVariant.getName());
-            webPushVariant.setDescription(updatedVariant.getDescription());
             logger.trace("Updating WebPush Variant '{}'", webPushID);
             variantService.updateVariant(webPushVariant);
             return Response.ok(webPushVariant).build();

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/WebPushVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/WebPushVariantEndpoint.java
@@ -19,6 +19,7 @@ package org.jboss.aerogear.unifiedpush.rest.registry.applications;
 import org.jboss.aerogear.unifiedpush.api.PushApplication;
 import org.jboss.aerogear.unifiedpush.api.WebPushVariant;
 import org.jboss.aerogear.unifiedpush.rest.annotations.DisabledByEnvironment;
+import org.jboss.aerogear.unifiedpush.rest.util.error.UnifiedPushError;
 import org.jboss.aerogear.unifiedpush.service.impl.SearchManager;
 
 import javax.validation.ConstraintViolationException;
@@ -66,7 +67,7 @@ public class WebPushVariantEndpoint extends AbstractVariantEndpoint<WebPushVaria
         PushApplication pushApp = getSearch().findByPushApplicationIDForDeveloper(pushApplicationID);
 
         if (pushApp == null) {
-            return Response.status(Response.Status.NOT_FOUND).entity("Could not find requested PushApplicationEntity").build();
+            return Response.status(Response.Status.NOT_FOUND).entity(new UnifiedPushError("Could not find requested PushApplicationEntity")).build();
         }
 
         // some validation
@@ -135,6 +136,6 @@ public class WebPushVariantEndpoint extends AbstractVariantEndpoint<WebPushVaria
             return Response.ok(webPushVariant).build();
         }
 
-        return Response.status(Response.Status.NOT_FOUND).entity("Could not find requested Variant").build();
+        return Response.status(Response.Status.NOT_FOUND).entity(new UnifiedPushError("Could not find requested Variant")).build();
     }
 }

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/iOSTokenVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/iOSTokenVariantEndpoint.java
@@ -27,13 +27,7 @@ import org.jboss.aerogear.unifiedpush.service.impl.SearchManager;
 import javax.inject.Inject;
 import javax.validation.ConstraintViolationException;
 import javax.validation.Validator;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
+import javax.ws.rs.*;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -61,11 +55,10 @@ public class iOSTokenVariantEndpoint extends AbstractVariantEndpoint<iOSTokenVar
     /**
      * Add iOS Variant
      *
-     * @param iOSVariant         new iOS Token Variant
+     * @param iOSVariant        new iOS Token Variant
      * @param pushApplicationID id of {@link PushApplication}
      * @param uriInfo           uri
      * @return created {@link iOSTokenVariant}
-     *
      * @statuscode 201 The iOS Variant created successfully
      * @statuscode 400 The format of the client request was incorrect
      * @statuscode 404 The requested PushApplication resource does not exist
@@ -109,7 +102,6 @@ public class iOSTokenVariantEndpoint extends AbstractVariantEndpoint<iOSTokenVar
      * List iOS Variants for Push Application
      *
      * @param pushApplicationID id of {@link PushApplication}
-     * @return updated {@link iOSTokenVariant}
      * @return list of {@link iOSTokenVariant}s
      */
     @GET
@@ -131,7 +123,6 @@ public class iOSTokenVariantEndpoint extends AbstractVariantEndpoint<iOSTokenVar
      * @param iOSID             id of {@link iOSTokenVariant}
      * @param updatediOSVariant updated version of {@link iOSTokenVariant}
      * @return updated {@link iOSTokenVariant}
-     *
      * @statuscode 204 The iOS Variant updated successfully
      * @statuscode 404 The requested Variant resource does not exist
      */
@@ -178,12 +169,10 @@ public class iOSTokenVariantEndpoint extends AbstractVariantEndpoint<iOSTokenVar
     /**
      * Update iOS Variant
      *
-     * @param pushApplicationId     id of {@link PushApplication}
-     * @param iOSID                 id of {@link iOSTokenVariant}
-     * @param updatediOSVariant    new info of {@link iOSTokenVariant}
-     *
+     * @param pushApplicationId id of {@link PushApplication}
+     * @param iOSID             id of {@link iOSTokenVariant}
+     * @param updatediOSVariant new info of {@link iOSTokenVariant}
      * @return updated {@link iOSTokenVariant}
-     *
      * @statuscode 200 The iOS Variant updated successfully
      * @statuscode 400 The format of the client request was incorrect
      * @statuscode 404 The requested iOS Variant resource does not exist
@@ -204,9 +193,13 @@ public class iOSTokenVariantEndpoint extends AbstractVariantEndpoint<iOSTokenVar
         }
 
 
-        iOSTokenVariant iOSTokenVariant = (iOSTokenVariant) variantService.findByVariantID(iOSID);
-        if (iOSTokenVariant != null) {
+        var variant = variantService.findByVariantID(iOSID);
 
+        if (variant != null) {
+            if (!(variant instanceof iOSTokenVariant)) {
+                return Response.status(Response.Status.NOT_FOUND).entity(ErrorBuilder.forVariants().notFound().build()).build();
+            }
+            iOSTokenVariant iOSTokenVariant = (iOSTokenVariant) variant;
             // merge the values and validate the new model
             try {
                 updatediOSVariant.merge(iOSTokenVariant);

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/iOSTokenVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/iOSTokenVariantEndpoint.java
@@ -1,13 +1,13 @@
 /**
  * JBoss, Home of Professional Open Source
  * Copyright Red Hat, Inc., and individual contributors.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- * 	http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -42,7 +42,7 @@ import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriInfo;
 
 @Path("/applications/{pushAppID}/{ignore:iostoken|ios_token}")
-@DisabledByEnvironment({"ios_token","iostoken"})
+@DisabledByEnvironment({"ios_token", "iostoken"})
 public class iOSTokenVariantEndpoint extends AbstractVariantEndpoint<iOSTokenVariant> {
 
     @Inject
@@ -64,7 +64,7 @@ public class iOSTokenVariantEndpoint extends AbstractVariantEndpoint<iOSTokenVar
      * @param iOSVariant         new iOS Token Variant
      * @param pushApplicationID id of {@link PushApplication}
      * @param uriInfo           uri
-     * @return                  created {@link iOSTokenVariant}
+     * @return created {@link iOSTokenVariant}
      *
      * @statuscode 201 The iOS Variant created successfully
      * @statuscode 400 The format of the client request was incorrect
@@ -109,8 +109,8 @@ public class iOSTokenVariantEndpoint extends AbstractVariantEndpoint<iOSTokenVar
      * List iOS Variants for Push Application
      *
      * @param pushApplicationID id of {@link PushApplication}
-     * @return                  updated {@link iOSTokenVariant}
-     * @return                  list of {@link iOSTokenVariant}s
+     * @return updated {@link iOSTokenVariant}
+     * @return list of {@link iOSTokenVariant}s
      */
     @GET
     @Produces(MediaType.APPLICATION_JSON)
@@ -130,7 +130,7 @@ public class iOSTokenVariantEndpoint extends AbstractVariantEndpoint<iOSTokenVar
      * @param pushApplicationId id of {@link PushApplication}
      * @param iOSID             id of {@link iOSTokenVariant}
      * @param updatediOSVariant updated version of {@link iOSTokenVariant}
-     * @return                  updated {@link iOSTokenVariant}
+     * @return updated {@link iOSTokenVariant}
      *
      * @statuscode 204 The iOS Variant updated successfully
      * @statuscode 404 The requested Variant resource does not exist
@@ -150,18 +150,22 @@ public class iOSTokenVariantEndpoint extends AbstractVariantEndpoint<iOSTokenVar
             return Response.status(Response.Status.NOT_FOUND).entity(ErrorBuilder.forPushApplications().notFound().build()).build();
         }
 
-        iOSTokenVariant iOSTokenVariant = (iOSTokenVariant)variantService.findByVariantID(iOSID);
+        iOSTokenVariant iOSTokenVariant = (iOSTokenVariant) variantService.findByVariantID(iOSID);
 
         if (iOSTokenVariant != null) {
 
             // apply update:
-            iOSTokenVariant.setName(updatediOSVariant.getName());
-            iOSTokenVariant.setDescription(updatediOSVariant.getDescription());
-            iOSTokenVariant.setProduction(updatediOSVariant.isProduction());
-            iOSTokenVariant.setKeyId(updatediOSVariant.getKeyId());
-            iOSTokenVariant.setBundleId(updatediOSVariant.getBundleId());
-            iOSTokenVariant.setTeamId(updatediOSVariant.getTeamId());
-            iOSTokenVariant.setPrivateKey(updatediOSVariant.getPrivateKey());
+
+            // merge the values and validate the new model
+            try {
+                updatediOSVariant.merge(iOSTokenVariant);
+                validateModelClass(iOSTokenVariant);
+            } catch (ConstraintViolationException cve) {
+                // Build and return the 400 (Bad Request) response
+                ResponseBuilder builder = createBadRequestResponse(cve.getConstraintViolations());
+                return builder.build();
+            }
+
 
             logger.trace("Updating text details on iOS Variant '{}'", iOSID);
 
@@ -178,7 +182,7 @@ public class iOSTokenVariantEndpoint extends AbstractVariantEndpoint<iOSTokenVar
      * @param iOSID                 id of {@link iOSTokenVariant}
      * @param updatediOSVariant    new info of {@link iOSTokenVariant}
      *
-     * @return                  updated {@link iOSTokenVariant}
+     * @return updated {@link iOSTokenVariant}
      *
      * @statuscode 200 The iOS Variant updated successfully
      * @statuscode 400 The format of the client request was incorrect
@@ -200,26 +204,18 @@ public class iOSTokenVariantEndpoint extends AbstractVariantEndpoint<iOSTokenVar
         }
 
 
-        iOSTokenVariant iOSTokenVariant = (iOSTokenVariant)variantService.findByVariantID(iOSID);
+        iOSTokenVariant iOSTokenVariant = (iOSTokenVariant) variantService.findByVariantID(iOSID);
         if (iOSTokenVariant != null) {
 
-            // some model validation on the uploaded form
+            // merge the values and validate the new model
             try {
-                validateModelClass(updatediOSVariant);
+                updatediOSVariant.merge(iOSTokenVariant);
+                validateModelClass(iOSTokenVariant);
             } catch (ConstraintViolationException cve) {
                 // Build and return the 400 (Bad Request) response
                 ResponseBuilder builder = createBadRequestResponse(cve.getConstraintViolations());
                 return builder.build();
             }
-
-            // apply update:
-            iOSTokenVariant.setName(updatediOSVariant.getName());
-            iOSTokenVariant.setDescription(updatediOSVariant.getDescription());
-            iOSTokenVariant.setProduction(updatediOSVariant.isProduction());
-            iOSTokenVariant.setKeyId(updatediOSVariant.getKeyId());
-            iOSTokenVariant.setTeamId(updatediOSVariant.getTeamId());
-            iOSTokenVariant.setBundleId(updatediOSVariant.getBundleId());
-            iOSTokenVariant.setPrivateKey(updatediOSVariant.getPrivateKey());
 
             // update performed, we now need to invalidate existing connection w/ APNs:
             logger.trace("Updating iOS Variant '{}'", iOSTokenVariant.getVariantID());

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/iOSTokenVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/iOSTokenVariantEndpoint.java
@@ -116,6 +116,11 @@ public class iOSTokenVariantEndpoint extends AbstractVariantEndpoint<iOSTokenVar
     @Produces(MediaType.APPLICATION_JSON)
     public Response listAlliOSVariantsForPushApp(@PathParam("pushAppID") String pushApplicationID) {
         final PushApplication application = getSearch().findByPushApplicationIDForDeveloper(pushApplicationID);
+
+        if (application == null) {
+            return Response.status(Response.Status.NOT_FOUND).entity(ErrorBuilder.forPushApplications().notFound().build()).build();
+        }
+
         return Response.ok(getVariants(application)).build();
     }
 
@@ -138,6 +143,12 @@ public class iOSTokenVariantEndpoint extends AbstractVariantEndpoint<iOSTokenVar
             @PathParam("pushAppID") String pushApplicationId,
             @PathParam("iOSID") String iOSID,
             iOSTokenVariant updatediOSVariant) {
+
+        final PushApplication application = getSearch().findByPushApplicationIDForDeveloper(pushApplicationId);
+
+        if (application == null) {
+            return Response.status(Response.Status.NOT_FOUND).entity(ErrorBuilder.forPushApplications().notFound().build()).build();
+        }
 
         iOSTokenVariant iOSTokenVariant = (iOSTokenVariant)variantService.findByVariantID(iOSID);
 
@@ -181,6 +192,13 @@ public class iOSTokenVariantEndpoint extends AbstractVariantEndpoint<iOSTokenVar
             iOSTokenVariant updatediOSVariant,
             @PathParam("pushAppID") String pushApplicationId,
             @PathParam("iOSID") String iOSID) {
+
+        final PushApplication application = getSearch().findByPushApplicationIDForDeveloper(pushApplicationId);
+
+        if (application == null) {
+            return Response.status(Response.Status.NOT_FOUND).entity(ErrorBuilder.forPushApplications().notFound().build()).build();
+        }
+
 
         iOSTokenVariant iOSTokenVariant = (iOSTokenVariant)variantService.findByVariantID(iOSID);
         if (iOSTokenVariant != null) {

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/iOSTokenVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/iOSTokenVariantEndpoint.java
@@ -21,6 +21,7 @@ import org.jboss.aerogear.unifiedpush.api.iOSTokenVariant;
 import org.jboss.aerogear.unifiedpush.message.jms.APNSClientProducer;
 import org.jboss.aerogear.unifiedpush.rest.annotations.DisabledByEnvironment;
 import org.jboss.aerogear.unifiedpush.rest.annotations.PATCH;
+import org.jboss.aerogear.unifiedpush.rest.util.error.UnifiedPushError;
 import org.jboss.aerogear.unifiedpush.service.impl.SearchManager;
 
 import javax.inject.Inject;
@@ -80,7 +81,7 @@ public class iOSTokenVariantEndpoint extends AbstractVariantEndpoint<iOSTokenVar
         PushApplication pushApp = getSearch().findByPushApplicationIDForDeveloper(pushApplicationID);
 
         if (pushApp == null) {
-            return Response.status(Status.NOT_FOUND).entity("Could not find requested PushApplicationEntity").build();
+            return Response.status(Status.NOT_FOUND).entity(new UnifiedPushError("Could not find requested PushApplicationEntity")).build();
         }
 
         // some model validation on the entity:
@@ -156,7 +157,7 @@ public class iOSTokenVariantEndpoint extends AbstractVariantEndpoint<iOSTokenVar
             variantService.updateVariant(iOSTokenVariant);
             return Response.noContent().build();
         }
-        return Response.status(Status.NOT_FOUND).entity("Could not find requested Variant").build();
+        return Response.status(Status.NOT_FOUND).entity(new UnifiedPushError("Could not find requested Variant")).build();
     }
 
     /**
@@ -209,6 +210,6 @@ public class iOSTokenVariantEndpoint extends AbstractVariantEndpoint<iOSTokenVar
 
             return Response.ok(iOSTokenVariant).build();
         }
-        return Response.status(Status.NOT_FOUND).entity("Could not find requested Variant").build();
+        return Response.status(Status.NOT_FOUND).entity(new UnifiedPushError("Could not find requested Variant")).build();
     }
 }

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/iOSVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/iOSVariantEndpoint.java
@@ -133,6 +133,10 @@ public class iOSVariantEndpoint extends AbstractVariantEndpoint<iOSVariant> {
     @Produces(MediaType.APPLICATION_JSON)
     public Response listAlliOSVariantsForPushApp(@PathParam("pushAppID") String pushApplicationID) {
         final PushApplication application = getSearch().findByPushApplicationIDForDeveloper(pushApplicationID);
+
+        if (application == null) {
+            return Response.status(Response.Status.NOT_FOUND).entity(ErrorBuilder.forPushApplications().notFound().build()).build();
+        }
         return Response.ok(getVariants(application)).build();
     }
 
@@ -155,6 +159,12 @@ public class iOSVariantEndpoint extends AbstractVariantEndpoint<iOSVariant> {
             @PathParam("pushAppID") String pushApplicationId,
             @PathParam("iOSID") String iOSID,
             iOSVariant updatediOSVariant) {
+
+        final PushApplication application = getSearch().findByPushApplicationIDForDeveloper(pushApplicationId);
+
+        if (application == null) {
+            return Response.status(Response.Status.NOT_FOUND).entity(ErrorBuilder.forPushApplications().notFound().build()).build();
+        }
 
         iOSVariant iOSVariant = (iOSVariant)variantService.findByVariantID(iOSID);
 
@@ -193,6 +203,12 @@ public class iOSVariantEndpoint extends AbstractVariantEndpoint<iOSVariant> {
             @MultipartForm iOSApplicationUploadForm updatedForm,
             @PathParam("pushAppID") String pushApplicationId,
             @PathParam("iOSID") String iOSID) {
+
+        final PushApplication application = getSearch().findByPushApplicationIDForDeveloper(pushApplicationId);
+
+        if (application == null) {
+            return Response.status(Response.Status.NOT_FOUND).entity(ErrorBuilder.forPushApplications().notFound().build()).build();
+        }
 
         iOSVariant iOSVariant = (iOSVariant)variantService.findByVariantID(iOSID);
         if (iOSVariant != null) {

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/iOSVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/iOSVariantEndpoint.java
@@ -1,13 +1,13 @@
 /**
  * JBoss, Home of Professional Open Source
  * Copyright Red Hat, Inc., and individual contributors.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- * 	http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -60,17 +60,40 @@ public class iOSVariantEndpoint extends AbstractVariantEndpoint<iOSVariant> {
      * @param form              new iOS Variant
      * @param pushApplicationID id of {@link PushApplication}
      * @param uriInfo           uri
-     * @return                  created {@link iOSVariant}
+     * @return created {@link iOSVariant}
+     * @deprecated please use the JSON endpoint with a base64 encoded certificate instead
      *
      * @statuscode 201 The iOS Variant created successfully
      * @statuscode 400 The format of the client request was incorrect
      * @statuscode 404 The requested PushApplication resource does not exist
      */
     @POST
+    @Deprecated
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Produces(MediaType.APPLICATION_JSON)
-    public Response registeriOSVariant(
+    public Response registeriOSVariantMultipart(
             @MultipartForm iOSApplicationUploadForm form,
+            @PathParam("pushAppID") String pushApplicationID,
+            @Context UriInfo uriInfo) {
+        return registeriOSVariant(form, pushApplicationID, uriInfo);
+    }
+
+    /**
+     * Add iOS Variant
+     *
+     * @param form              new iOS Variant
+     * @param pushApplicationID id of {@link PushApplication}
+     * @param uriInfo           uri
+     * @return created {@link iOSVariant}
+     * @statuscode 201 The iOS Variant created successfully
+     * @statuscode 400 The format of the client request was incorrect
+     * @statuscode 404 The requested PushApplication resource does not exist
+     */
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response registeriOSVariant(
+            iOSApplicationUploadForm form,
             @PathParam("pushAppID") String pushApplicationID,
             @Context UriInfo uriInfo) {
         // find the root push app
@@ -126,8 +149,7 @@ public class iOSVariantEndpoint extends AbstractVariantEndpoint<iOSVariant> {
      * List iOS Variants for Push Application
      *
      * @param pushApplicationID id of {@link PushApplication}
-     * @return                  updated {@link iOSVariant}
-     * @return                  list of {@link iOSVariant}s
+     * @return list of {@link iOSVariant}s
      */
     @GET
     @Produces(MediaType.APPLICATION_JSON)
@@ -146,8 +168,7 @@ public class iOSVariantEndpoint extends AbstractVariantEndpoint<iOSVariant> {
      * @param pushApplicationId id of {@link PushApplication}
      * @param iOSID             id of {@link iOSVariant}
      * @param updatediOSVariant updated version of {@link iOSVariant}
-     * @return                  updated {@link iOSVariant}
-     *
+     * @return updated {@link iOSVariant}
      * @statuscode 204 The iOS Variant updated successfully
      * @statuscode 404 The requested Variant resource does not exist
      */
@@ -166,7 +187,7 @@ public class iOSVariantEndpoint extends AbstractVariantEndpoint<iOSVariant> {
             return Response.status(Response.Status.NOT_FOUND).entity(ErrorBuilder.forPushApplications().notFound().build()).build();
         }
 
-        iOSVariant iOSVariant = (iOSVariant)variantService.findByVariantID(iOSID);
+        iOSVariant iOSVariant = (iOSVariant) variantService.findByVariantID(iOSID);
 
         if (iOSVariant != null) {
 
@@ -185,22 +206,44 @@ public class iOSVariantEndpoint extends AbstractVariantEndpoint<iOSVariant> {
     /**
      * Update iOS Variant
      *
-     * @param pushApplicationId     id of {@link PushApplication}
-     * @param iOSID                 id of {@link iOSVariant}
-     * @param updatedForm           new info of {@link iOSVariant}
+     * @param pushApplicationId id of {@link PushApplication}
+     * @param iOSID             id of {@link iOSVariant}
+     * @param updatedForm       new info of {@link iOSVariant}
+     * @return updated {@link iOSVariant}
+     * @statuscode 200 The iOS Variant updated successfully
+     * @statuscode 400 The format of the client request was incorrect
+     * @statuscode 404 The requested iOS Variant resource does not exist
+     * @deprecated Please use JSON with a base64 encoded certificate
+     */
+    @PUT
+    @Path("/{iOSID}")
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Deprecated
+    public Response updateiOSVariantMultipart(
+            @MultipartForm iOSApplicationUploadForm updatedForm,
+            @PathParam("pushAppID") String pushApplicationId,
+            @PathParam("iOSID") String iOSID) {
+        return updateiOSVariant(updatedForm, pushApplicationId, iOSID);
+    }
+
+    /**
+     * Update iOS Variant
      *
-     * @return                  updated {@link iOSVariant}
-     *
+     * @param pushApplicationId id of {@link PushApplication}
+     * @param iOSID             id of {@link iOSVariant}
+     * @param updatedForm       new info of {@link iOSVariant}
+     * @return updated {@link iOSVariant}
      * @statuscode 200 The iOS Variant updated successfully
      * @statuscode 400 The format of the client request was incorrect
      * @statuscode 404 The requested iOS Variant resource does not exist
      */
     @PUT
     @Path("/{iOSID}")
-    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     public Response updateiOSVariant(
-            @MultipartForm iOSApplicationUploadForm updatedForm,
+            iOSApplicationUploadForm updatedForm,
             @PathParam("pushAppID") String pushApplicationId,
             @PathParam("iOSID") String iOSID) {
 
@@ -210,24 +253,21 @@ public class iOSVariantEndpoint extends AbstractVariantEndpoint<iOSVariant> {
             return Response.status(Response.Status.NOT_FOUND).entity(ErrorBuilder.forPushApplications().notFound().build()).build();
         }
 
-        iOSVariant iOSVariant = (iOSVariant)variantService.findByVariantID(iOSID);
+        iOSVariant iOSVariant = (iOSVariant) variantService.findByVariantID(iOSID);
         if (iOSVariant != null) {
 
             // some model validation on the uploaded form
             try {
-                validateModelClass(updatedForm);
+
+                // apply update:
+                updatedForm.apply(iOSVariant);
             } catch (ConstraintViolationException cve) {
                 // Build and return the 400 (Bad Request) response
                 ResponseBuilder builder = createBadRequestResponse(cve.getConstraintViolations());
                 return builder.build();
             }
 
-            // apply update:
-            iOSVariant.setName(updatedForm.getName());
-            iOSVariant.setDescription(updatedForm.getDescription());
-            iOSVariant.setPassphrase(updatedForm.getPassphrase());
-            iOSVariant.setCertificate(updatedForm.getCertificate());
-            iOSVariant.setProduction(updatedForm.getProduction());
+
 
             // some model validation on the entity:
             try {

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/iOSVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/iOSVariantEndpoint.java
@@ -61,11 +61,10 @@ public class iOSVariantEndpoint extends AbstractVariantEndpoint<iOSVariant> {
      * @param pushApplicationID id of {@link PushApplication}
      * @param uriInfo           uri
      * @return created {@link iOSVariant}
-     * @deprecated please use the JSON endpoint with a base64 encoded certificate instead
-     *
      * @statuscode 201 The iOS Variant created successfully
      * @statuscode 400 The format of the client request was incorrect
      * @statuscode 404 The requested PushApplication resource does not exist
+     * @deprecated please use the JSON endpoint with a base64 encoded certificate instead
      */
     @POST
     @Deprecated
@@ -253,9 +252,14 @@ public class iOSVariantEndpoint extends AbstractVariantEndpoint<iOSVariant> {
             return Response.status(Response.Status.NOT_FOUND).entity(ErrorBuilder.forPushApplications().notFound().build()).build();
         }
 
-        iOSVariant iOSVariant = (iOSVariant) variantService.findByVariantID(iOSID);
-        if (iOSVariant != null) {
 
+        var variant = variantService.findByVariantID(iOSID);
+
+        if (variant != null) {
+            if (!(variant instanceof iOSVariant)) {
+                return Response.status(Response.Status.NOT_FOUND).entity(ErrorBuilder.forVariants().notFound().build()).build();
+            }
+            iOSVariant iOSVariant = (iOSVariant) variant;
             // some model validation on the uploaded form
             try {
 
@@ -266,7 +270,6 @@ public class iOSVariantEndpoint extends AbstractVariantEndpoint<iOSVariant> {
                 ResponseBuilder builder = createBadRequestResponse(cve.getConstraintViolations());
                 return builder.build();
             }
-
 
 
             // some model validation on the entity:

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/iOSVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/iOSVariantEndpoint.java
@@ -21,6 +21,7 @@ import org.jboss.aerogear.unifiedpush.api.iOSVariant;
 import org.jboss.aerogear.unifiedpush.message.jms.APNSClientProducer;
 import org.jboss.aerogear.unifiedpush.rest.annotations.DisabledByEnvironment;
 import org.jboss.aerogear.unifiedpush.rest.annotations.PATCH;
+import org.jboss.aerogear.unifiedpush.rest.util.error.UnifiedPushError;
 import org.jboss.aerogear.unifiedpush.rest.util.iOSApplicationUploadForm;
 import org.jboss.aerogear.unifiedpush.service.impl.SearchManager;
 import org.jboss.resteasy.annotations.providers.multipart.MultipartForm;
@@ -76,7 +77,7 @@ public class iOSVariantEndpoint extends AbstractVariantEndpoint<iOSVariant> {
         PushApplication pushApp = getSearch().findByPushApplicationIDForDeveloper(pushApplicationID);
 
         if (pushApp == null) {
-            return Response.status(Status.NOT_FOUND).entity("Could not find requested PushApplicationEntity").build();
+            return Response.status(Status.NOT_FOUND).entity(new UnifiedPushError("Could not find requested PushApplicationEntity")).build();
         }
 
         // some model validation on the uploaded form
@@ -168,7 +169,7 @@ public class iOSVariantEndpoint extends AbstractVariantEndpoint<iOSVariant> {
             variantService.updateVariant(iOSVariant);
             return Response.noContent().build();
         }
-        return Response.status(Status.NOT_FOUND).entity("Could not find requested Variant").build();
+        return Response.status(Status.NOT_FOUND).entity(new UnifiedPushError("Could not find requested Variant")).build();
     }
 
     /**
@@ -232,6 +233,6 @@ public class iOSVariantEndpoint extends AbstractVariantEndpoint<iOSVariant> {
 
             return Response.ok(iOSVariant).build();
         }
-        return Response.status(Status.NOT_FOUND).entity("Could not find requested Variant").build();
+        return Response.status(Status.NOT_FOUND).entity(new UnifiedPushError("Could not find requested Variant")).build();
     }
 }

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/installations/InstallationRegistrationEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/installations/InstallationRegistrationEndpoint.java
@@ -24,6 +24,7 @@ import org.jboss.aerogear.unifiedpush.api.validation.DeviceTokenValidator;
 import org.jboss.aerogear.unifiedpush.auth.HttpBasicHelper;
 import org.jboss.aerogear.unifiedpush.rest.AbstractBaseEndpoint;
 import org.jboss.aerogear.unifiedpush.rest.EmptyJSON;
+import org.jboss.aerogear.unifiedpush.rest.util.error.UnifiedPushError;
 import org.jboss.aerogear.unifiedpush.service.ClientInstallationService;
 import org.jboss.aerogear.unifiedpush.service.GenericVariantService;
 import org.jboss.aerogear.unifiedpush.service.metrics.PrometheusExporter;
@@ -370,7 +371,7 @@ public class InstallationRegistrationEndpoint extends AbstractBaseEndpoint {
         return appendAllowOriginHeader(
                 Response.status(Status.UNAUTHORIZED)
                         .header("WWW-Authenticate", "Basic realm=\"AeroGear UnifiedPush Server\"")
-                        .entity("Unauthorized Request"),
+                        .entity(new UnifiedPushError("Unauthorized Request")),
                 request);
     }
 

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/sender/PushNotificationSenderEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/sender/PushNotificationSenderEndpoint.java
@@ -22,6 +22,7 @@ import org.jboss.aerogear.unifiedpush.message.InternalUnifiedPushMessage;
 import org.jboss.aerogear.unifiedpush.message.NotificationRouter;
 import org.jboss.aerogear.unifiedpush.rest.EmptyJSON;
 import org.jboss.aerogear.unifiedpush.rest.util.HttpRequestUtil;
+import org.jboss.aerogear.unifiedpush.rest.util.error.UnifiedPushError;
 import org.jboss.aerogear.unifiedpush.service.PushApplicationService;
 import org.jboss.aerogear.unifiedpush.service.metrics.PrometheusExporter;
 import org.slf4j.Logger;
@@ -94,7 +95,7 @@ public class PushNotificationSenderEndpoint {
         if (pushApplication == null) {
             return Response.status(Status.UNAUTHORIZED)
                     .header("WWW-Authenticate", "Basic realm=\"AeroGear UnifiedPush Server\"")
-                    .entity("Unauthorized Request")
+                    .entity(new UnifiedPushError("Unauthorized Request"))
                     .build();
         }
 

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/util/HealthCheck.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/util/HealthCheck.java
@@ -1,13 +1,13 @@
 /**
  * JBoss, Home of Professional Open Source
  * Copyright Red Hat, Inc., and individual contributors.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- * 	http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/util/HealthCheck.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/util/HealthCheck.java
@@ -17,6 +17,7 @@
 package org.jboss.aerogear.unifiedpush.rest.util;
 
 import org.jboss.aerogear.unifiedpush.message.HealthNetworkService;
+import org.jboss.aerogear.unifiedpush.rest.util.error.UnifiedPushError;
 import org.jboss.aerogear.unifiedpush.service.HealthDBService;
 import org.jboss.aerogear.unifiedpush.service.impl.health.HealthDetails;
 import org.jboss.aerogear.unifiedpush.service.impl.health.HealthStatus;
@@ -102,7 +103,7 @@ public class HealthCheck {
         try (final InputStream manifestStream = context.getResourceAsStream("/META-INF/MANIFEST.MF")) {
             return Response.ok(new Manifest(manifestStream).getMainAttributes()).build();
         } catch (Exception e) {
-            return Response.status(Response.Status.NOT_FOUND).entity("Could not find version information").build();
+            return Response.status(Response.Status.NOT_FOUND).entity(new UnifiedPushError("Could not find version information")).build();
         }
     }
 }

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/util/error/ErrorBuilder.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/util/error/ErrorBuilder.java
@@ -1,5 +1,7 @@
 package org.jboss.aerogear.unifiedpush.rest.util.error;
 
+import java.util.Map;
+
 public abstract class ErrorBuilder {
     private ErrorBuilder() {
     }
@@ -26,6 +28,14 @@ public abstract class ErrorBuilder {
 
     public static MetricsErrorBuilder forMetrics() {
         return new MetricsErrorBuilder();
+    }
+
+    public static ServerErrorBuilder forServer() {
+        return new ServerErrorBuilder();
+    }
+
+    public static ValidationErrorBuilder forValidation() {
+        return new ValidationErrorBuilder();
     }
 
 
@@ -112,6 +122,23 @@ public abstract class ErrorBuilder {
 
         public HealthCheckErrorBuilder noVersion() {
             return this.setError(new UnifiedPushError("Could not find version information"));
+        }
+    }
+
+    public static class ServerErrorBuilder extends  AbstractErrorBuilder<ServerErrorBuilder> {
+        public ServerErrorBuilder generalException(Exception e) {
+            return this.setError(new UnifiedPushError(e.getMessage()));
+        }
+    }
+
+    public static class ValidationErrorBuilder extends AbstractErrorBuilder<ValidationErrorBuilder> {
+
+        public ValidationErrorBuilder  setMap(Map<String, String> failingFields) {
+
+            var error = new UnifiedPushError("Validation Failure");
+            failingFields.entrySet().forEach(entry -> error.addDetail(entry.getKey(), entry.getValue()));
+
+            return this.setError(error);
         }
     }
 }

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/util/error/JsonProcessingExceptionMapper.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/util/error/JsonProcessingExceptionMapper.java
@@ -1,0 +1,19 @@
+package org.jboss.aerogear.unifiedpush.rest.util.error;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+public class JsonProcessingExceptionMapper implements ExceptionMapper<JsonProcessingException> {
+
+    public JsonProcessingExceptionMapper() {
+    }
+
+    @Override
+    public Response toResponse(JsonProcessingException exception) {
+        return Response.serverError().entity(ErrorBuilder.forServer().generalException(exception).build()).build();
+    }
+}

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/util/error/JsonProcessingExceptionMapper.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/util/error/JsonProcessingExceptionMapper.java
@@ -1,6 +1,8 @@
 package org.jboss.aerogear.unifiedpush.rest.util.error;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
@@ -9,11 +11,15 @@ import javax.ws.rs.ext.Provider;
 @Provider
 public class JsonProcessingExceptionMapper implements ExceptionMapper<JsonProcessingException> {
 
+    private static final Logger LOG = LoggerFactory.getLogger(JsonProcessingExceptionMapper.class);
+
     public JsonProcessingExceptionMapper() {
+        LOG.debug("Starting up");
     }
 
     @Override
     public Response toResponse(JsonProcessingException exception) {
+        LOG.debug("Caught exception " + exception.getMessage());
         return Response.serverError().entity(ErrorBuilder.forServer().generalException(exception).build()).build();
     }
 }

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/util/error/UnifiedPushError.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/util/error/UnifiedPushError.java
@@ -1,12 +1,20 @@
 package org.jboss.aerogear.unifiedpush.rest.util.error;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import javax.validation.constraints.NotNull;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
 public class UnifiedPushError {
+    @NotNull
     private final String message;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private final Map<String, String> details = new HashMap<>();
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private Throwable rootException;
 
     UnifiedPushError(String message) {

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/util/error/UnifiedPushError.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/util/error/UnifiedPushError.java
@@ -1,0 +1,13 @@
+package org.jboss.aerogear.unifiedpush.rest.util.error;
+
+public class UnifiedPushError {
+    private final String message;
+
+    public UnifiedPushError(String message) {
+        this.message = message;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/util/error/UnrecognizedPropertyExceptionHandler.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/util/error/UnrecognizedPropertyExceptionHandler.java
@@ -1,0 +1,17 @@
+package org.jboss.aerogear.unifiedpush.rest.util.error;
+
+import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+public class UnrecognizedPropertyExceptionHandler implements ExceptionMapper<UnrecognizedPropertyException> {
+    public UnrecognizedPropertyExceptionHandler() {
+    }
+
+    public Response toResponse(UnrecognizedPropertyException exception) {
+        return Response.serverError().entity(ErrorBuilder.forServer().generalException(exception).build()).build();
+    }
+}

--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/util/iOSApplicationUploadForm.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/util/iOSApplicationUploadForm.java
@@ -157,4 +157,28 @@ public class iOSApplicationUploadForm {
             return false;
         }
     }
+
+    /**
+     * This method will apply non null fields to the iOSVariant.
+     * @param iOSVariant an iOS Variant to have its fields replaced
+     */
+    public void apply(iOSVariant iOSVariant) {
+        if (name != null && !name.isBlank()) {
+            iOSVariant.setName(name);
+        }
+
+        if (description != null && !description.isBlank()) {
+            iOSVariant.setDescription(description);
+        }
+        if (passphrase != null && !passphrase.isBlank()) {
+            iOSVariant.setPassphrase(passphrase);
+        }
+        if (certificate != null && certificate.length != 0) {
+            iOSVariant.setCertificate(certificate);
+        }
+        if (production != null) {
+            iOSVariant.setProduction(production);
+        }
+
+    }
 }

--- a/jaxrs/src/test/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/AndroidVariantEndpointTest.java
+++ b/jaxrs/src/test/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/AndroidVariantEndpointTest.java
@@ -134,10 +134,12 @@ public class AndroidVariantEndpointTest {
     public void shouldUpdateAndroidVariantSuccessfully() {
         final AndroidVariant originalVariant = new AndroidVariant();
         final AndroidVariant updatedVariant = new AndroidVariant();
+        final PushApplication pushApp = new PushApplication();
 
         originalVariant.setGoogleKey("Original Google Key");
         updatedVariant.setGoogleKey("Updated Google Key");
 
+        when(searchService.findByPushApplicationIDForDeveloper("push-app-id")).thenReturn(pushApp);
         when(variantService.findByVariantID("variant-id")).thenReturn(originalVariant);
         when(validator.validate(updatedVariant)).thenReturn(Collections.EMPTY_SET);
 

--- a/jaxrs/src/test/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/AndroidVariantEndpointTest.java
+++ b/jaxrs/src/test/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/AndroidVariantEndpointTest.java
@@ -165,11 +165,11 @@ public class AndroidVariantEndpointTest {
     }
 
     @Test
-    public void shouldReturn400WhenFindVariantByIdFindsVariantOfAnotherPlatform() {
+    public void shouldReturn404WhenFindVariantByIdFindsVariantOfAnotherPlatform() {
         when(variantService.findByVariantID("123")).thenReturn(new iOSVariant());
 
         final Response response = this.endpoint.findVariantById(GOOD_APP_ID,"123");
-        assertEquals(response.getStatus(), 400);
+        assertEquals(response.getStatus(), 404);
     }
 
     @Test
@@ -213,7 +213,7 @@ public class AndroidVariantEndpointTest {
         when(variantService.findByVariantID("123")).thenReturn(new iOSVariant());
 
         final Response response = this.endpoint.deleteVariant(GOOD_APP_ID,"123");
-        assertEquals(response.getStatus(), 400);
+        assertEquals(response.getStatus(), 404);
     }
 
     @Test
@@ -236,11 +236,11 @@ public class AndroidVariantEndpointTest {
     }
 
     @Test
-    public void shouldReturn400WhenResetSecretFindsVariantOfAnotherPlatform() {
+    public void shouldReturn404WhenResetSecretFindsVariantOfAnotherPlatform() {
         when(variantService.findByVariantID("123")).thenReturn(new iOSVariant());
 
         final Response response = this.endpoint.resetSecret(GOOD_APP_ID,"123");
-        assertEquals(response.getStatus(), 400);
+        assertEquals(response.getStatus(), 404);
     }
 
     @Test

--- a/jaxrs/src/test/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/AndroidVariantEndpointTest.java
+++ b/jaxrs/src/test/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/AndroidVariantEndpointTest.java
@@ -149,7 +149,7 @@ public class AndroidVariantEndpointTest {
 
         final Response response = this.endpoint.updateAndroidVariant("push-app-id", "variant-id", updatedVariant);
 
-        assertEquals(response.getStatus(), 200);
+        assertEquals(200,response.getStatus());
         assertTrue(response.getEntity() == originalVariant);        // identity check
         assertEquals(originalVariant.getGoogleKey(), "Updated Google Key");
 

--- a/jaxrs/src/test/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/AndroidVariantEndpointTest.java
+++ b/jaxrs/src/test/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/AndroidVariantEndpointTest.java
@@ -6,6 +6,7 @@ import org.jboss.aerogear.unifiedpush.api.AndroidVariant;
 import org.jboss.aerogear.unifiedpush.api.PushApplication;
 import org.jboss.aerogear.unifiedpush.api.Variant;
 import org.jboss.aerogear.unifiedpush.api.iOSVariant;
+import org.jboss.aerogear.unifiedpush.rest.util.error.UnifiedPushError;
 import org.jboss.aerogear.unifiedpush.service.GenericVariantService;
 import org.jboss.aerogear.unifiedpush.service.PushApplicationService;
 import org.jboss.aerogear.unifiedpush.service.PushSearchService;
@@ -181,6 +182,7 @@ public class AndroidVariantEndpointTest {
 
         final Response response = this.endpoint.deleteVariant("foo");
         assertEquals(response.getStatus(), 404);
+        assertEquals("Could not find requested Variant",((UnifiedPushError)response.getEntity()).getMessage());
     }
 
     @Test

--- a/jaxrs/src/test/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/WebPushVariantEndpointTest.java
+++ b/jaxrs/src/test/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/WebPushVariantEndpointTest.java
@@ -166,11 +166,11 @@ public class WebPushVariantEndpointTest {
     }
 
     @Test
-    public void shouldReturn400WhenFindVariantByIdFindsVariantOfAnotherPlatform() {
+    public void shouldReturn404WhenFindVariantByIdFindsVariantOfAnotherPlatform() {
         when(variantService.findByVariantID("123")).thenReturn(new iOSVariant());
 
         final Response response = this.endpoint.findVariantById(GOOD_APP_ID,"123");
-        assertEquals(response.getStatus(), 400);
+        assertEquals(response.getStatus(), 404);
     }
 
     @Test
@@ -192,11 +192,11 @@ public class WebPushVariantEndpointTest {
     }
 
     @Test
-    public void shouldReturn400WhenDeleteVariantFindsVariantOfAnotherPlatform() {
+    public void shouldReturn404WhenDeleteVariantFindsVariantOfAnotherPlatform() {
         when(variantService.findByVariantID("123")).thenReturn(new iOSVariant());
 
         final Response response = this.endpoint.deleteVariant(GOOD_APP_ID,"123");
-        assertEquals(response.getStatus(), 400);
+        assertEquals(response.getStatus(), 404);
     }
 
     @Test
@@ -219,11 +219,11 @@ public class WebPushVariantEndpointTest {
     }
 
     @Test
-    public void shouldReturn400WhenResetSecretFindsVariantOfAnotherPlatform() {
+    public void shouldReturn404WhenResetSecretFindsVariantOfAnotherPlatform() {
         when(variantService.findByVariantID("123")).thenReturn(new iOSVariant());
 
         final Response response = this.endpoint.resetSecret(GOOD_APP_ID,"123");
-        assertEquals(response.getStatus(), 400);
+        assertEquals(response.getStatus(), 404);
     }
 
     @Test

--- a/jaxrs/src/test/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/WebPushVariantEndpointTest.java
+++ b/jaxrs/src/test/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/WebPushVariantEndpointTest.java
@@ -35,6 +35,7 @@ import static org.mockito.Mockito.never;
 @RunWith(MockitoJUnitRunner.class)
 public class WebPushVariantEndpointTest {
 
+    private static final String GOOD_APP_ID = "good_app_id";
     WebPushVariantEndpoint endpoint;
 
 
@@ -61,7 +62,7 @@ public class WebPushVariantEndpointTest {
 
         this.endpoint.pushAppService = pushAppService;
         this.endpoint.variantService = variantService;
-
+        when(searchService.findByPushApplicationIDForDeveloper(GOOD_APP_ID)).thenReturn(new PushApplication());
         when(searchManager.getSearchService()).thenReturn(searchService);
     }
 
@@ -160,7 +161,7 @@ public class WebPushVariantEndpointTest {
     public void shouldReturn404WhenFindVariantByIdCannotFindAnyVariants() {
         when(variantService.findByVariantID("foo")).thenReturn(null);
 
-        final Response response = this.endpoint.findVariantById("foo");
+        final Response response = this.endpoint.findVariantById("","foo");
         assertEquals(response.getStatus(), 404);
     }
 
@@ -168,7 +169,7 @@ public class WebPushVariantEndpointTest {
     public void shouldReturn400WhenFindVariantByIdFindsVariantOfAnotherPlatform() {
         when(variantService.findByVariantID("123")).thenReturn(new iOSVariant());
 
-        final Response response = this.endpoint.findVariantById("123");
+        final Response response = this.endpoint.findVariantById(GOOD_APP_ID,"123");
         assertEquals(response.getStatus(), 400);
     }
 
@@ -177,7 +178,7 @@ public class WebPushVariantEndpointTest {
         final WebPushVariant variant = new WebPushVariant();
         when(variantService.findByVariantID("123")).thenReturn(variant);
 
-        final Response response = this.endpoint.findVariantById("123");
+        final Response response = this.endpoint.findVariantById(GOOD_APP_ID,"123");
         assertEquals(response.getStatus(), 200);
         assertTrue(variant == response.getEntity());    // identity check
     }
@@ -186,7 +187,7 @@ public class WebPushVariantEndpointTest {
     public void shouldReturn404WhenDeleteVariantCannotFindAnyVariants() {
         when(variantService.findByVariantID("foo")).thenReturn(null);
 
-        final Response response = this.endpoint.deleteVariant("foo");
+        final Response response = this.endpoint.deleteVariant(GOOD_APP_ID,"foo");
         assertEquals(response.getStatus(), 404);
     }
 
@@ -194,7 +195,7 @@ public class WebPushVariantEndpointTest {
     public void shouldReturn400WhenDeleteVariantFindsVariantOfAnotherPlatform() {
         when(variantService.findByVariantID("123")).thenReturn(new iOSVariant());
 
-        final Response response = this.endpoint.deleteVariant("123");
+        final Response response = this.endpoint.deleteVariant(GOOD_APP_ID,"123");
         assertEquals(response.getStatus(), 400);
     }
 
@@ -203,7 +204,7 @@ public class WebPushVariantEndpointTest {
         final WebPushVariant variant = new WebPushVariant();
         when(variantService.findByVariantID("123")).thenReturn(variant);
 
-        final Response response = this.endpoint.deleteVariant("123");
+        final Response response = this.endpoint.deleteVariant(GOOD_APP_ID,"123");
         assertEquals(response.getStatus(), 204);
 
         verify(variantService).removeVariant(variant);
@@ -213,7 +214,7 @@ public class WebPushVariantEndpointTest {
     public void shouldReturn404WhenResetSecretCannotFindAnyVariants() {
         when(variantService.findByVariantID("foo")).thenReturn(null);
 
-        final Response response = this.endpoint.resetSecret("foo");
+        final Response response = this.endpoint.resetSecret(GOOD_APP_ID,"foo");
         assertEquals(response.getStatus(), 404);
     }
 
@@ -221,7 +222,7 @@ public class WebPushVariantEndpointTest {
     public void shouldReturn400WhenResetSecretFindsVariantOfAnotherPlatform() {
         when(variantService.findByVariantID("123")).thenReturn(new iOSVariant());
 
-        final Response response = this.endpoint.resetSecret("123");
+        final Response response = this.endpoint.resetSecret(GOOD_APP_ID,"123");
         assertEquals(response.getStatus(), 400);
     }
 
@@ -232,7 +233,7 @@ public class WebPushVariantEndpointTest {
 
         when(variantService.findByVariantID("123")).thenReturn(variant);
 
-        final Response response = this.endpoint.resetSecret("123");
+        final Response response = this.endpoint.resetSecret(GOOD_APP_ID,"123");
         assertEquals(response.getStatus(), 200);
 
         verify(variantService).updateVariant(variant);

--- a/jaxrs/src/test/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/WebPushVariantEndpointTest.java
+++ b/jaxrs/src/test/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/WebPushVariantEndpointTest.java
@@ -138,10 +138,12 @@ public class WebPushVariantEndpointTest {
     public void shouldUpdateWebPushVariantSuccessfully() {
         final WebPushVariant originalVariant = new WebPushVariant();
         final WebPushVariant updatedVariant = new WebPushVariant();
+        final PushApplication pushApp = new PushApplication();
 
         originalVariant.setPublicKey("test public Key");
         updatedVariant.setPublicKey("update public Key");
 
+        when(searchService.findByPushApplicationIDForDeveloper("push-app-id")).thenReturn(pushApp);
         when(variantService.findByVariantID("variant-id")).thenReturn(originalVariant);
         when(validator.validate(updatedVariant)).thenReturn(Collections.EMPTY_SET);
 

--- a/jaxrs/src/test/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/iOSTokenVariantEndpointTest.java
+++ b/jaxrs/src/test/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/iOSTokenVariantEndpointTest.java
@@ -93,12 +93,13 @@ public class iOSTokenVariantEndpointTest {
     @Test
     public void shouldUpdateiOSTokenVariantSuccessfully_withMultiPartData() {
         final iOSTokenVariant original = new iOSTokenVariant();
-
         final iOSTokenVariant update = new iOSTokenVariant();
+        final PushApplication pushApp = new PushApplication();
         update.setName("variant name");
         update.setPrivateKey("privateKey");
         update.setProduction(false);
 
+        when(searchService.findByPushApplicationIDForDeveloper("push-app-id")).thenReturn(pushApp);
         when(variantService.findByVariantID("variant-id")).thenReturn(original);
         when(validator.validate(update)).thenReturn(Collections.EMPTY_SET);
         when(validator.validate(original)).thenReturn(Collections.EMPTY_SET);
@@ -115,8 +116,9 @@ public class iOSTokenVariantEndpointTest {
     @Test
     public void shouldUpdateiOSTokenVariantSuccessfully_noMultiPartData() {
         final iOSTokenVariant original = new iOSTokenVariant();
-
         final iOSTokenVariant update = new iOSTokenVariant();
+        final PushApplication pushApp = new PushApplication();
+
         update.setName("variant name");
         update.setPrivateKey("certificate");
         update.setTeamId("team id");
@@ -126,6 +128,8 @@ public class iOSTokenVariantEndpointTest {
 
         update.setProduction(false);
 
+
+        when(searchService.findByPushApplicationIDForDeveloper("push-app-id")).thenReturn(pushApp);
         when(variantService.findByVariantID("variant-id")).thenReturn(original);
 
         final Response response = this.endpoint.updateiOSVariant("push-app-id", "variant-id", update);

--- a/jaxrs/src/test/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/iOSTokenVariantEndpointTest.java
+++ b/jaxrs/src/test/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/iOSTokenVariantEndpointTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class iOSTokenVariantEndpointTest {
+    private static final String GOOD_APP_ID = "good_app_id";
     iOSTokenVariantEndpoint endpoint;
 
     @Mock
@@ -55,6 +56,7 @@ public class iOSTokenVariantEndpointTest {
         this.endpoint.producer = producer;
 
         when(searchManager.getSearchService()).thenReturn(searchService);
+        when(searchService.findByPushApplicationIDForDeveloper(GOOD_APP_ID)).thenReturn(new PushApplication());
     }
 
     @Test
@@ -153,7 +155,7 @@ public class iOSTokenVariantEndpointTest {
         final iOSTokenVariant variant = new iOSTokenVariant();
         when(variantService.findByVariantID("123")).thenReturn(variant);
 
-        final Response response = this.endpoint.findVariantById("123");
+        final Response response = this.endpoint.findVariantById(GOOD_APP_ID,"123");
         assertEquals(response.getStatus(), 200);
         assertTrue(variant == response.getEntity());    // identity check
     }
@@ -166,7 +168,7 @@ public class iOSTokenVariantEndpointTest {
         final iOSTokenVariant variant = new iOSTokenVariant();
         when(variantService.findByVariantID("123")).thenReturn(variant);
 
-        final Response response = this.endpoint.deleteVariant("123");
+        final Response response = this.endpoint.deleteVariant(GOOD_APP_ID,"123");
         assertEquals(response.getStatus(), 204);
 
         verify(variantService).removeVariant(variant);
@@ -182,7 +184,7 @@ public class iOSTokenVariantEndpointTest {
 
         when(variantService.findByVariantID("123")).thenReturn(variant);
 
-        final Response response = this.endpoint.resetSecret("123");
+        final Response response = this.endpoint.resetSecret(GOOD_APP_ID,"123");
         assertEquals(response.getStatus(), 200);
 
         verify(variantService).updateVariant(variant);

--- a/jaxrs/src/test/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/iOSVariantEndpointTest.java
+++ b/jaxrs/src/test/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/iOSVariantEndpointTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class iOSVariantEndpointTest {
+    private static final String GOOD_APP_ID = "good_app_id";
     iOSVariantEndpoint endpoint;
 
     @Mock
@@ -52,7 +53,7 @@ public class iOSVariantEndpointTest {
         this.endpoint.pushAppService = pushAppService;
         this.endpoint.variantService = variantService;
         this.endpoint.producer = producer;
-
+        when(searchService.findByPushApplicationIDForDeveloper(GOOD_APP_ID)).thenReturn(new PushApplication());
         when(searchManager.getSearchService()).thenReturn(searchService);
     }
 
@@ -134,7 +135,7 @@ public class iOSVariantEndpointTest {
         final iOSVariant variant = new iOSVariant();
         when(variantService.findByVariantID("123")).thenReturn(variant);
 
-        final Response response = this.endpoint.findVariantById("123");
+        final Response response = this.endpoint.findVariantById(GOOD_APP_ID,"123");
         assertEquals(response.getStatus(), 200);
         assertTrue(variant == response.getEntity());    // identity check
     }
@@ -147,7 +148,7 @@ public class iOSVariantEndpointTest {
         final iOSVariant variant = new iOSVariant();
         when(variantService.findByVariantID("123")).thenReturn(variant);
 
-        final Response response = this.endpoint.deleteVariant("123");
+        final Response response = this.endpoint.deleteVariant(GOOD_APP_ID,"123");
         assertEquals(response.getStatus(), 204);
 
         verify(variantService).removeVariant(variant);
@@ -163,7 +164,7 @@ public class iOSVariantEndpointTest {
 
         when(variantService.findByVariantID("123")).thenReturn(variant);
 
-        final Response response = this.endpoint.resetSecret("123");
+        final Response response = this.endpoint.resetSecret(GOOD_APP_ID,"123");
         assertEquals(response.getStatus(), 200);
 
         verify(variantService).updateVariant(variant);

--- a/jaxrs/src/test/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/iOSVariantEndpointTest.java
+++ b/jaxrs/src/test/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/iOSVariantEndpointTest.java
@@ -83,11 +83,11 @@ public class iOSVariantEndpointTest {
     @Test
     public void shouldUpdateiOSVariantSuccessfully_withMultiPartData() {
         final iOSVariant original = new iOSVariant();
+        original.setCertificate("Certificate".getBytes());
         final iOSApplicationUploadForm update = new iOSApplicationUploadForm();
         final PushApplication pushApp = new PushApplication();
 
         update.setName("variant name");
-        update.setCertificate("certificate".getBytes());
         update.setProduction(false);
 
         when(searchService.findByPushApplicationIDForDeveloper("push-app-id")).thenReturn(pushApp);
@@ -99,7 +99,7 @@ public class iOSVariantEndpointTest {
 
         assertEquals(response.getStatus(), 200);
         assertEquals(original.getName(), "variant name");
-
+        assertNotNull(original.getCertificate());
         verify(variantService).updateVariant(original);
         verify(producer).changeAPNClient(original);
     }
@@ -109,9 +109,9 @@ public class iOSVariantEndpointTest {
         final iOSVariant original = new iOSVariant();
         final PushApplication pushApp = new PushApplication();
         final iOSVariant update = new iOSVariant();
+        original.setCertificate("Certificate".getBytes());
 
         update.setName("variant name");
-        update.setCertificate("certificate".getBytes());
         update.setProduction(false);
 
         when(searchService.findByPushApplicationIDForDeveloper("push-app-id")).thenReturn(pushApp);
@@ -121,6 +121,7 @@ public class iOSVariantEndpointTest {
 
         assertEquals(response.getStatus(), 204);
         assertEquals(original.getName(), "variant name");
+        assertNotNull(original.getCertificate());
 
         verify(variantService).updateVariant(original);
     }

--- a/jaxrs/src/test/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/iOSVariantEndpointTest.java
+++ b/jaxrs/src/test/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/iOSVariantEndpointTest.java
@@ -83,12 +83,14 @@ public class iOSVariantEndpointTest {
     @Test
     public void shouldUpdateiOSVariantSuccessfully_withMultiPartData() {
         final iOSVariant original = new iOSVariant();
-
         final iOSApplicationUploadForm update = new iOSApplicationUploadForm();
+        final PushApplication pushApp = new PushApplication();
+
         update.setName("variant name");
         update.setCertificate("certificate".getBytes());
         update.setProduction(false);
 
+        when(searchService.findByPushApplicationIDForDeveloper("push-app-id")).thenReturn(pushApp);
         when(variantService.findByVariantID("variant-id")).thenReturn(original);
         when(validator.validate(update)).thenReturn(Collections.EMPTY_SET);
         when(validator.validate(original)).thenReturn(Collections.EMPTY_SET);
@@ -105,12 +107,14 @@ public class iOSVariantEndpointTest {
     @Test
     public void shouldUpdateiOSVariantSuccessfully_noMultiPartData() {
         final iOSVariant original = new iOSVariant();
-
+        final PushApplication pushApp = new PushApplication();
         final iOSVariant update = new iOSVariant();
+
         update.setName("variant name");
         update.setCertificate("certificate".getBytes());
         update.setProduction(false);
 
+        when(searchService.findByPushApplicationIDForDeveloper("push-app-id")).thenReturn(pushApp);
         when(variantService.findByVariantID("variant-id")).thenReturn(original);
 
         final Response response = this.endpoint.updateiOSVariant("push-app-id", "variant-id", update);

--- a/model/api/pom.xml
+++ b/model/api/pom.xml
@@ -17,6 +17,18 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>11</source>
+                    <target>11</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
     <parent>
         <groupId>org.jboss.aerogear.unifiedpush</groupId>
         <artifactId>unifiedpush-model-parent</artifactId>
@@ -57,6 +69,12 @@
             <groupId>com.turo</groupId>
             <artifactId>pushy</artifactId>
             <version>0.13.9</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.javax.persistence</groupId>
+            <artifactId>hibernate-jpa-2.0-api</artifactId>
+            <version>1.0.1.Final</version>
             <scope>compile</scope>
         </dependency>
 

--- a/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/APNSVariant.java
+++ b/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/APNSVariant.java
@@ -1,5 +1,8 @@
 package org.jboss.aerogear.unifiedpush.api;
 
+import javax.persistence.Access;
+import javax.persistence.AccessType;
+
 /**
  * There are two APNS Variants, iOSVariant and iOSTokenVariant.  However, they also have some metadata that is shared
  * as well as needing to have their updates observed by SimpleApnsClientCache.  This is a interface that defines the
@@ -7,19 +10,32 @@ package org.jboss.aerogear.unifiedpush.api;
  */
 public abstract class APNSVariant extends Variant {
 
-    private boolean production = false;
+    @Access(AccessType.PROPERTY)
+    private Boolean production;
 
     /**
      * If <code>true</code> a connection to Apple's Production APNs server
      * will be established for this iOS variant.
-     *
+     * <p>
      * If the method returns <code>false</code> a connection to
      * Apple's Sandbox/Development APNs server will be established
      * for this iOS variant.
      *
-     * @return production state
+     * @return production state defaults to false
      */
     public boolean isProduction() {
+        return production != null ? production : false;
+    }
+
+    /**
+     * This returns the instance of production. This method is used to test if
+     * a production value was set. You probably want to use isProduction unless
+     * you have a reason to check for the existence of production instead of
+     * its value.
+     *
+     * @return the production Boolean object, may be null.
+     */
+    public Boolean production() {
         return production;
     }
 

--- a/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/AndroidVariant.java
+++ b/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/AndroidVariant.java
@@ -1,13 +1,13 @@
 /**
  * JBoss, Home of Professional Open Source
  * Copyright Red Hat, Inc., and individual contributors.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- * 	http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -50,7 +50,7 @@ public class AndroidVariant extends Variant {
     /**
      * The Server Key from the Firebase Console of a project which has been enabled for FCM.
      *
-      @return the Server key
+     @return the Server key
      */
     public String getGoogleKey() {
         return this.googleKey;
@@ -63,5 +63,22 @@ public class AndroidVariant extends Variant {
     @Override
     public VariantType getType() {
         return VariantType.ANDROID;
+    }
+
+    public void merge(AndroidVariant androidVariant) {
+        // apply updated data:
+        if (getGoogleKey() != null && !getGoogleKey().isBlank()) {
+            androidVariant.setGoogleKey(getGoogleKey());
+        }
+
+        if (getProjectNumber() != null && !getProjectNumber().isBlank()) {
+            androidVariant.setProjectNumber(getProjectNumber());
+        }
+        if (getName() != null && !getName().isBlank()) {
+            androidVariant.setName(getName());
+        }
+        if (getDescription() != null && !getDescription().isBlank()) {
+            androidVariant.setDescription(getDescription());
+        }
     }
 }

--- a/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/WebPushVariant.java
+++ b/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/WebPushVariant.java
@@ -1,13 +1,13 @@
 /**
  * JBoss, Home of Professional Open Source
  * Copyright Red Hat, Inc., and individual contributors.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- * 	http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -53,6 +53,7 @@ public class WebPushVariant extends Variant {
     /**
      * This is a VAPID public key.  It must match the private key.
      * See https://tools.ietf.org/html/draft-ietf-webpush-vapid-01
+     *
      * @return
      */
     public String getPublicKey() {
@@ -66,6 +67,7 @@ public class WebPushVariant extends Variant {
     /**
      * This is a VAPID private key.  It must match the public key.
      * See https://tools.ietf.org/html/draft-ietf-webpush-vapid-01
+     *
      * @return
      */
     public String getPrivateKey() {
@@ -115,7 +117,7 @@ public class WebPushVariant extends Variant {
                 return false;
             }
             if (alias.toLowerCase().startsWith("mailto:")) {
-                return  alias.contains("@");
+                return alias.contains("@");
             }
             new java.net.URL(alias);
             return true;
@@ -127,4 +129,26 @@ public class WebPushVariant extends Variant {
         }
     }
 
+    /**
+     * Applies the non null values of this class to the webPushVariant param
+     * @param webPushVariant value to have non null values of this instance applied
+     */
+    public void merge(WebPushVariant webPushVariant) {
+        if (getPublicKey() != null && !getPublicKey().isBlank()) {
+            webPushVariant.setPublicKey(getPublicKey());
+        }
+        if (getPrivateKey() != null && !getPrivateKey().isBlank()) {
+            webPushVariant.setPrivateKey(getPrivateKey());
+        }
+        if (getName() != null && !getName().isBlank()) {
+            webPushVariant.setName(getName());
+        }
+        if (getDescription() != null && !getDescription().isBlank()) {
+            webPushVariant.setDescription(getDescription());
+        }
+
+        if (getAlias() != null && !getAlias().isBlank()) {
+            webPushVariant.setAlias(getAlias());
+        }
+    }
 }

--- a/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/iOSTokenVariant.java
+++ b/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/iOSTokenVariant.java
@@ -154,5 +154,6 @@ public class iOSTokenVariant extends APNSVariant {
         if (this.getPrivateKey() != null && !this.getPrivateKey().isBlank()) {
             iOSTokenVariant.setPrivateKey(this.getPrivateKey());
         }
+
     }
 }

--- a/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/iOSTokenVariant.java
+++ b/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/iOSTokenVariant.java
@@ -33,7 +33,6 @@ public class iOSTokenVariant extends APNSVariant {
     private static final long serialVersionUID = -889367404039436329L;
 
 
-
     @NotNull
     @Size(max = 10, min = 10, message = "Team ID must be 10 characters long")
     private String teamId;
@@ -117,6 +116,7 @@ public class iOSTokenVariant extends APNSVariant {
 
     /**
      * Bundle ID is the unique identified for your app in APNS.
+     *
      * @return bundle id
      */
     public String getBundleId() {
@@ -125,5 +125,34 @@ public class iOSTokenVariant extends APNSVariant {
 
     public void setBundleId(String bundleId) {
         this.bundleId = bundleId;
+    }
+
+    /**
+     * Applies non null values to the provided iOSTokenVariant
+     * @param iOSTokenVariant a value that will be updated using non null fields of this variant instance
+     */
+    public void merge(iOSTokenVariant iOSTokenVariant) {
+        if (this.getName() != null && !this.getName().isBlank()) {
+            iOSTokenVariant.setName(this.getName());
+        }
+
+        if (this.getDescription() != null && !this.getDescription().isBlank()) {
+            iOSTokenVariant.setDescription(this.getDescription());
+        }
+        if (this.production() != null) {
+            iOSTokenVariant.setProduction(this.isProduction());
+        }
+        if (this.getKeyId() != null && !this.getKeyId().isBlank()) {
+            iOSTokenVariant.setKeyId(this.getKeyId());
+        }
+        if (this.getBundleId() != null && !this.getBundleId().isBlank()) {
+            iOSTokenVariant.setBundleId(this.getBundleId());
+        }
+        if (this.getTeamId() != null && !this.getTeamId().isBlank()) {
+            iOSTokenVariant.setTeamId(this.getTeamId());
+        }
+        if (this.getPrivateKey() != null && !this.getPrivateKey().isBlank()) {
+            iOSTokenVariant.setPrivateKey(this.getPrivateKey());
+        }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -221,8 +221,8 @@
         Options to override the compiler arguments directly on the compiler arument line to separate between what
         the IDE understands as the source level and what the Maven compiler actually use.
     -->
-    <maven.compiler.target>1.8</maven.compiler.target>
-    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
     <wildfly-maven-plugin.version>1.2.0.Final</wildfly-maven-plugin.version>
 
     <aerogear.bom.version>1.1.15</aerogear.bom.version>


### PR DESCRIPTION
@ziccardi I've started by replacing all of the errors that just returned a string. Would you like to take some time to discuss how to beef up the `UnifiedPushError` object?