### PR TITLE
feat(webpush): generate automatically vapid keys server side

### DIFF
--- a/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/WebPushVariantEndpoint.java
+++ b/jaxrs/src/main/java/org/jboss/aerogear/unifiedpush/rest/registry/applications/WebPushVariantEndpoint.java
@@ -16,11 +16,17 @@
  */
 package org.jboss.aerogear.unifiedpush.rest.registry.applications;
 
+import nl.martijndwars.webpush.Base64Encoder;
+import nl.martijndwars.webpush.Utils;
+import org.bouncycastle.jce.interfaces.ECPrivateKey;
+import org.bouncycastle.jce.interfaces.ECPublicKey;
 import org.jboss.aerogear.unifiedpush.api.PushApplication;
+import org.jboss.aerogear.unifiedpush.api.Variant;
 import org.jboss.aerogear.unifiedpush.api.WebPushVariant;
 import org.jboss.aerogear.unifiedpush.rest.annotations.DisabledByEnvironment;
 import org.jboss.aerogear.unifiedpush.rest.util.error.ErrorBuilder;
 import org.jboss.aerogear.unifiedpush.service.impl.SearchManager;
+import org.jboss.aerogear.unifiedpush.utils.KeyUtils;
 
 import javax.validation.ConstraintViolationException;
 import javax.validation.Validator;
@@ -29,6 +35,11 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.KeyPair;
+import java.security.NoSuchAlgorithmException;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 
 @Path("/applications/{pushAppID}/{ignore:webpush|web_push}")
 @DisabledByEnvironment({"webpush","web_push"})
@@ -68,6 +79,18 @@ public class WebPushVariantEndpoint extends AbstractVariantEndpoint<WebPushVaria
 
         if (pushApp == null) {
             return Response.status(Response.Status.NOT_FOUND).entity(ErrorBuilder.forPushApplications().notFound().build()).build();
+        }
+
+        if (webPushVariant.getPrivateKey() == null && webPushVariant.getPublicKey() == null) {
+            // User didn't provide a keypair. Generating a new one
+            try {
+                KeyPair kp = KeyUtils.generateKeyPair();
+                webPushVariant.setPrivateKey(Base64Encoder.encodeUrl(Utils.encode((ECPrivateKey) kp.getPrivate())));
+                webPushVariant.setPublicKey(Base64Encoder.encodeUrl(Utils.encode((ECPublicKey) kp.getPublic())));
+            } catch (InvalidAlgorithmParameterException | NoSuchAlgorithmException exc) {
+                logger.error("Unable to create WebPush variant: error creating vapid keys", exc);
+                return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(ErrorBuilder.forVariants().withDetail("vapid-keys", "Unable to generate vapid keys").build()).build();
+            }
         }
 
         // some validation
@@ -149,5 +172,53 @@ public class WebPushVariantEndpoint extends AbstractVariantEndpoint<WebPushVaria
         }
 
         return Response.status(Response.Status.NOT_FOUND).entity(ErrorBuilder.forVariants().notFound().build()).build();
+    }
+
+    /**
+     * Secret Reset
+     *
+     * @param variantId id of {@link Variant}
+     * @return {@link Variant} with new secret
+     * @statuscode 200 The secret of Variant reset successfully
+     * @statuscode 404 The requested Variant resource exists but it is not of the given type
+     * @statuscode 404 The requested Variant resource does not exist
+     */
+    @PUT
+    @Path("/{variantId}/renew")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response renewKeys(@PathParam("pushAppID") String pushApplicationID,
+                                @PathParam("variantId") String variantId) {
+        // find the root push app
+        PushApplication pushApp = getSearch().findByPushApplicationIDForDeveloper(pushApplicationID);
+
+        if (pushApp == null) {
+            return Response.status(Response.Status.NOT_FOUND).entity(ErrorBuilder.forPushApplications().notFound().build()).build();
+        }
+        var res = new AtomicReference<Response>();
+
+        pushApp.getVariants().stream()
+                .filter(variant -> variant.getVariantID().equals(variantId) && variant instanceof WebPushVariant).findFirst()
+                .ifPresentOrElse(
+                variant -> {
+                    logger.trace("Renewing keys for: {}", variant.getName());
+
+                    // Generating a new Vapid Key Pair
+                    try {
+                        WebPushVariant wpv = (WebPushVariant) variant;
+                        KeyPair kp = KeyUtils.generateKeyPair();
+                        wpv.setPrivateKey(Base64Encoder.encodeUrl(Utils.encode((ECPrivateKey) kp.getPrivate())));
+                        wpv.setPublicKey(Base64Encoder.encodeUrl(Utils.encode((ECPublicKey) kp.getPublic())));
+                        variantService.updateVariant(variant);
+                        res.set(Response.ok(variant).build());
+                    } catch (InvalidAlgorithmParameterException | NoSuchAlgorithmException exc) {
+                        logger.error("Unable to renew WebPush variant keys", exc);
+                        res.set(Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(ErrorBuilder.forVariants().withDetail("vapid-keys", "Unable to generate vapid keys").build()).build());
+                    }
+                },
+                () -> { res.set(Response.status(Response.Status.NOT_FOUND).entity(ErrorBuilder.forVariants().notFound().build()).build()); }
+        );
+
+        return res.get();
     }
 }

--- a/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/WebPushVariant.java
+++ b/model/api/src/main/java/org/jboss/aerogear/unifiedpush/api/WebPushVariant.java
@@ -18,6 +18,7 @@
 package org.jboss.aerogear.unifiedpush.api;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import nl.martijndwars.webpush.Utils;
 import org.jboss.aerogear.unifiedpush.utils.KeyUtils;
 
@@ -43,6 +44,7 @@ public class WebPushVariant extends Variant {
      * TODO: Find a way to store this securely
      */
     @NotNull
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     @Size(max = 255, message = "Private Key must be max. 255 chars long")
     private String privateKey;
 

--- a/model/api/src/main/java/org/jboss/aerogear/unifiedpush/utils/KeyUtils.java
+++ b/model/api/src/main/java/org/jboss/aerogear/unifiedpush/utils/KeyUtils.java
@@ -13,11 +13,7 @@ import org.bouncycastle.util.BigIntegers;
 import org.jboss.aerogear.unifiedpush.api.WebPushRegistration;
 
 import java.math.BigInteger;
-import java.security.KeyFactory;
-import java.security.NoSuchAlgorithmException;
-import java.security.PrivateKey;
-import java.security.Provider;
-import java.security.PublicKey;
+import java.security.*;
 import java.security.spec.InvalidKeySpecException;
 
 
@@ -59,7 +55,7 @@ public class KeyUtils {
 
     /**
      * Returns the base64 encoded public key as a PublicKey object
-     * 
+     *
      * @param registration the registration to get the key from
      * @return the key for registration
      * @throws NoSuchAlgorithmException if the key algorithm does not exist
@@ -75,5 +71,19 @@ public class KeyUtils {
         return kf.generatePublic(pubSpec);
     }
 
+    /**
+     * Generate an EC keypair on the prime256v1 curve.
+     *
+     * @return the newly generated keypair
+     * @throws InvalidAlgorithmParameterException the algorithm parameters are wrong
+     * @throws NoSuchAlgorithmException algorithm does not exists
+     */
+    public static KeyPair generateKeyPair() throws InvalidAlgorithmParameterException, NoSuchAlgorithmException {
+        ECNamedCurveParameterSpec parameterSpec = ECNamedCurveTable.getParameterSpec(CURVE);
 
+        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance(ALGORITHM, PROVIDER);
+        keyPairGenerator.initialize(parameterSpec);
+
+        return keyPairGenerator.generateKeyPair();
+    }
 }


### PR DESCRIPTION
## Motivation
ISSUE: https://issues.jboss.org/browse/AEROGEAR-10165

LINKED TO: https://github.com/aerogear/unifiedpush-admin-ui/pull/115

## What
Previous version was requiring to send the vapid keys when creating a
new WebPush variant, thus exposing the private key. Now the keys are
created inside UPS

A new `/renew` endpoint has been added to regenerate the keys

## Verification Steps
Try creating a WebPush variant by passing only the variant name and alias
Try making a `put` to the new `/renew` endpoint and check that the keys are changed (only the public key is visible in the webui)
