### PR TITLE
fix: 🐛 webpush messages were not UTF-8 encoded

### DIFF
--- a/push-sender/src/main/java/org/jboss/aerogear/unifiedpush/message/webpush/WebPushSender.java
+++ b/push-sender/src/main/java/org/jboss/aerogear/unifiedpush/message/webpush/WebPushSender.java
@@ -100,7 +100,7 @@ public class WebPushSender implements PushNotificationSender {
 
                 try {
                     final Notification notification = new Notification(registration.getEndpoint(), getUserPublicKey(registration),
-                            registration.getAuthAsBytes(), gson.toJson(pushMessage.getMessage()).getBytes());
+                            registration.getAuthAsBytes(), gson.toJson(pushMessage.getMessage()).getBytes("UTF-8"));
 
                     final HttpResponse response = webPushService.send(notification);
                     final int responseCode = response.getStatusLine().getStatusCode();


### PR DESCRIPTION
## Motivation
Webpush messages was encoded using the default encoding, thus generating
errors when sending UTF-8 texts

ISSUE [AEROGEAR-10376](https://issues.redhat.com/browse/AEROGEAR-10376)

## What
Changed encoding for webpush messages to UTF-8

## Verification Steps
 
1. Use the ups admin console to create a webpush variant for an application. Alternatively the UPS-CLI can be used (see [here](https://www.npmjs.com/package/@aerogear/unifiedpush-cli))
2. Configure your application to be notified using the created variant (the [cookbook](https://github.com/aerogear/unifiedpush-cookbook/tree/master/webpush/hello-world-webpush) app could be used too)
3. Send a message containing UTF-8 character to the application using the UPS admin ui. (for example "ğüşç")
4. Check that the message is correctly displayed (with the previous version this was resulting to a series of question marks)

**NOTE** The cookbook variant contains a bug in the registration. If instead of seeing the message in the web application you see a popup with the message object, reload the page and register again
